### PR TITLE
fix(schedules): centralize interval math, UTC storage, and month-end …

### DIFF
--- a/app/lib/schedules.test.ts
+++ b/app/lib/schedules.test.ts
@@ -1,0 +1,123 @@
+import { getNextPayoutAt, calculateAccrual, type StreamSchedule } from './schedules';
+
+describe('Schedule Engine', () => {
+  describe('getNextPayoutAt', () => {
+    it('calculates next second correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'second',
+        rate: 1,
+      };
+      const now = new Date('2026-01-01T00:00:00.500Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-01T00:00:01.500Z');
+    });
+
+    it('calculates next day correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T12:00:00Z'),
+        interval: 'day',
+        rate: 10,
+      };
+      const now = new Date('2026-01-01T13:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-02T12:00:00.000Z');
+    });
+
+    it('handles month-end correctly (Jan 31 to Feb)', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-31T10:00:00Z'),
+        interval: 'month',
+        rate: 100,
+      };
+      const now = new Date('2026-01-31T11:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      // Feb only has 28 days in 2026
+      expect(next?.toISOString()).toBe('2026-02-28T10:00:00.000Z');
+    });
+
+    it('handles leap year correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2024-01-29T10:00:00Z'),
+        interval: 'month',
+        rate: 100,
+      };
+      const now = new Date('2024-01-29T11:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      // 2024 is leap year, has Feb 29
+      expect(next?.toISOString()).toBe('2024-02-29T10:00:00.000Z');
+    });
+
+    it('respects endDate', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        endDate: new Date('2026-01-01T12:00:00Z'),
+        interval: 'day',
+        rate: 10,
+      };
+      const now = new Date('2026-01-01T06:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+    });
+  });
+
+  describe('calculateAccrual', () => {
+    it('calculates second-based accrual', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'second',
+        rate: 1,
+      };
+      const now = new Date('2026-01-01T00:00:05.500Z');
+      const accrual = calculateAccrual(schedule, now);
+      expect(accrual).toBe(5.5);
+    });
+
+    it('truncates to precision (default 7)', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'hour',
+        rate: 10,
+      };
+      // 1.5 hours + a tiny bit
+      const now = new Date('2026-01-01T01:30:00.0000001Z');
+      const accrual = calculateAccrual(schedule, now);
+      // (1.5 * 10) = 15
+      expect(accrual).toBe(15);
+    });
+
+    it('handles very small rates and high precision', () => {
+       const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'day',
+        rate: 0.0000001, // 1 stroop per day
+        precision: 7
+      };
+      const now = new Date('2026-01-01T12:00:00Z'); // half day
+      const accrual = calculateAccrual(schedule, now);
+      expect(accrual).toBe(0); // 0.00000005 truncated to 7 decimals is 0
+    });
+  });
+
+  describe('formatNextPayout', () => {
+    it('formats near-future payout correctly', () => {
+      const now = new Date();
+      const next = new Date(now.getTime() + 5 * 60 * 1000 + 1000); // 5 mins and 1 sec
+      const { formatNextPayout } = require('./schedules');
+      expect(formatNextPayout(next)).toContain('5 minutes');
+    });
+
+    it('formats distant future payout correctly', () => {
+      const next = new Date('2099-01-01T10:00:00Z');
+      const { formatNextPayout } = require('./schedules');
+      const result = formatNextPayout(next);
+      expect(result).toMatch(/Jan/i);
+      expect(result).toMatch(/1/);
+    });
+
+    it('handles ended streams', () => {
+      const { formatNextPayout } = require('./schedules');
+      expect(formatNextPayout(null)).toBe('Stream ended');
+    });
+  });
+});

--- a/app/lib/schedules.ts
+++ b/app/lib/schedules.ts
@@ -1,0 +1,146 @@
+/**
+ * Schedule Engine for StreamPay
+ * Handles per-second, hourly, and monthly payout calculations.
+ * Aligned with UTC storage and local display requirements.
+ */
+
+export type PayoutInterval = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export interface StreamSchedule {
+  startDate: Date; // UTC
+  endDate?: Date; // UTC
+  interval: PayoutInterval;
+  rate: number; // Amount per interval
+  precision?: number; // Decimal places for rounding (default 7 for XLM)
+}
+
+/**
+ * Calculates the next payout time based on the current time and stream schedule.
+ * All calculations are done in UTC.
+ */
+export function getNextPayoutAt(schedule: StreamSchedule, now: Date = new Date()): Date | null {
+  const { startDate, endDate, interval } = schedule;
+  
+  if (now < startDate) {
+    return new Date(startDate);
+  }
+  
+  if (endDate && now >= endDate) {
+    return null;
+  }
+
+  const next = new Date(startDate);
+  
+  switch (interval) {
+    case 'second':
+      next.setTime(now.getTime() + 1000);
+      break;
+    case 'minute':
+      next.setTime(now.getTime() - (now.getTime() % 60000) + 60000);
+      break;
+    case 'hour':
+      next.setTime(now.getTime() - (now.getTime() % 3600000) + 3600000);
+      break;
+    case 'day':
+      next.setUTCDate(next.getUTCDate() + Math.floor((now.getTime() - startDate.getTime()) / 86400000) + 1);
+      break;
+    case 'week':
+      const daysSinceStart = Math.floor((now.getTime() - startDate.getTime()) / 86400000);
+      next.setUTCDate(next.getUTCDate() + (Math.floor(daysSinceStart / 7) + 1) * 7);
+      break;
+    case 'month':
+      let months = (now.getUTCFullYear() - startDate.getUTCFullYear()) * 12 + (now.getUTCMonth() - startDate.getUTCMonth());
+      if (now.getUTCDate() >= startDate.getUTCDate()) {
+        months += 1;
+      }
+      next.setUTCMonth(startDate.getUTCMonth() + months);
+      // Handle month-end overflow (e.g. Jan 31 -> Feb 28)
+      if (next.getUTCDate() !== startDate.getUTCDate()) {
+        next.setUTCDate(0);
+      }
+      break;
+    case 'year':
+      let years = now.getUTCFullYear() - startDate.getUTCFullYear();
+      if (now.getUTCMonth() > startDate.getUTCMonth() || (now.getUTCMonth() === startDate.getUTCMonth() && now.getUTCDate() >= startDate.getUTCDate())) {
+        years += 1;
+      }
+      next.setUTCFullYear(startDate.getUTCFullYear() + years);
+      break;
+  }
+
+  if (endDate && next > endDate) {
+    return new Date(endDate);
+  }
+
+  return next;
+}
+
+/**
+ * Calculates accrued amount based on time elapsed and rate.
+ * Uses banker's rounding (round half to even) or truncation based on project standards.
+ * For StreamPay, we use truncation for safety in financial calculations, or fixed precision.
+ */
+export function calculateAccrual(schedule: StreamSchedule, now: Date = new Date()): number {
+  const { startDate, endDate, interval, rate, precision = 7 } = schedule;
+  
+  if (now <= startDate) return 0;
+  
+  const effectiveEnd = endDate && now > endDate ? endDate : now;
+  const elapsedMs = effectiveEnd.getTime() - startDate.getTime();
+  
+  let intervalMs: number;
+  switch (interval) {
+    case 'second': intervalMs = 1000; break;
+    case 'minute': intervalMs = 60000; break;
+    case 'hour': intervalMs = 3600000; break;
+    case 'day': intervalMs = 86400000; break;
+    case 'week': intervalMs = 604800000; break;
+    case 'month':
+      // For accrual, we use average month length or specific interval math
+      // The requirement asks for per-second/hourly math
+      intervalMs = 30.44 * 24 * 60 * 60 * 1000; // Approx month
+      break;
+    case 'year':
+      intervalMs = 365.25 * 24 * 60 * 60 * 1000; // Approx year
+      break;
+    default:
+      intervalMs = 86400000;
+  }
+
+  const amount = (elapsedMs / intervalMs) * rate;
+  const factor = Math.pow(10, precision);
+  return Math.floor(amount * factor) / factor; // Truncate to precision
+}
+
+/**
+ * Formats a summary of the schedule for display.
+ */
+export function formatScheduleSummary(schedule: StreamSchedule): string {
+  const { interval, rate } = schedule;
+  const period = interval === 'day' ? 'daily' : interval === 'week' ? 'weekly' : interval === 'month' ? 'monthly' : `every ${interval}`;
+  return `${rate} XLM ${period}`;
+}
+
+/**
+ * Formats the "next payout" time for the UI.
+ * Handles UTC to Local display implicitly by using browser locale if needed,
+ * but here we follow the project's requirement to store UTC and display clearly.
+ */
+export function formatNextPayout(nextPayout: Date | null): string {
+  if (!nextPayout) return 'Stream ended';
+  
+  const now = new Date();
+  const diffMs = nextPayout.getTime() - now.getTime();
+  
+  if (diffMs < 0) return 'Processing...';
+  if (diffMs < 60000) return 'In less than a minute';
+  if (diffMs < 3600000) return `In ${Math.floor(diffMs / 60000)} minutes`;
+  if (diffMs < 86400000) return `In ${Math.floor(diffMs / 3600000)} hours`;
+  
+  return nextPayout.toLocaleDateString(undefined, { 
+    month: 'short', 
+    day: 'numeric', 
+    hour: '2-digit', 
+    minute: '2-digit' 
+  });
+}

--- a/docs/payout-math.md
+++ b/docs/payout-math.md
@@ -1,0 +1,42 @@
+# Payout Schedule Math
+
+This document describes the mathematical logic used for calculating payout schedules, accruals, and next execution times in StreamPay.
+
+## Core Principles
+
+1. **UTC Storage**: All dates are stored and processed in UTC. Timezone conversion is strictly a display-layer concern.
+2. **Deterministic Calculation**: Payout times are calculated relative to the `startDate` of the stream, ensuring consistent intervals even if executions are delayed.
+3. **Precision**: StreamPay uses 7 decimal places for XLM (aligning with stroops) and other assets unless specified otherwise.
+
+## Calculation Logic
+
+### Next Payout Time (`getNextPayoutAt`)
+
+Calculates the absolute next time a payment should occur based on the current time and the stream's recurrence interval.
+
+- **Per-second**: Current time + 1 second.
+- **Hourly/Daily/Weekly**: Aligned to the `startDate`'s time of day/week.
+- **Monthly**: Aligned to the `startDate`'s day of the month.
+  - **Edge Case (Short Months)**: If a stream starts on the 31st, and the next month has only 28/30 days, the payout is capped at the last day of that month.
+
+### Accrual & Proration (`calculateAccrual`)
+
+Calculates the amount earned but not yet paid out.
+
+- **Formula**: `(elapsedTime / intervalDuration) * rate`
+- **Rounding**: All accrual calculations use **truncation** to the specified precision (default 7). This ensures we never over-promise funds that haven't fully vested.
+
+## Rounding Strategy
+
+We use **Truncation** (rounding towards zero) for all financial math in the frontend.
+
+| Method | Value | Result (Precision 2) | Rationale |
+| :--- | :--- | :--- | :--- |
+| Truncate | 1.239 | 1.23 | Conservative; avoids over-allocation. |
+| Banker's | 1.235 | 1.24 | Standard for banking; avoids bias. |
+
+*Note: StreamPay defaults to Truncation for payout math to ensure ledger consistency.*
+
+## Stellar Ledger Alignment
+
+While Stellar ledgers close every ~5 seconds, our engine calculates time with millisecond precision. Execution engines should trigger as soon as possible after the `next_payout_at` timestamp is passed by a closed ledger.


### PR DESCRIPTION
## feat(schedules): centralize payout math and UTC handling

Closes #94

### Summary
- Added `app/lib/schedules.ts` for `next_payout_at`, accrual, and proration
- Switched to UTC-based calculations (timezone only affects display)
- Implemented truncation (7 decimal places) for deterministic rounding
- Handled edge cases: month-end, leap years, short months

### Tests
- Added `app/lib/schedules.test.ts`
- Covers intervals, rounding, and edge cases  
 All tests passing locally

### Notes
- Added `docs/payout-math.md` (rounding + examples)
- Ready for integration with `schedule_summary` and `next_execution_at`