### PR TITLE
Test/property invariants balance

### DIFF
--- a/app/lib/assets.test.ts
+++ b/app/lib/assets.test.ts
@@ -1,0 +1,82 @@
+import { parseAssetString, verifyTrustline, NATIVE_ASSET } from './assets';
+
+describe('Asset Engine', () => {
+  describe('parseAssetString', () => {
+    it('parses XLM correctly', () => {
+      expect(parseAssetString('XLM')).toEqual(NATIVE_ASSET);
+      expect(parseAssetString('native')).toEqual(NATIVE_ASSET);
+    });
+
+    it('parses custom assets correctly', () => {
+      const assetStr = 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335XOP3IA2M3QC2ED2AAA7Z5TJH';
+      const parsed = parseAssetString(assetStr);
+      expect(parsed.code).toBe('USDC');
+      expect(parsed.issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335XOP3IA2M3QC2ED2AAA7Z5TJH');
+      expect(parsed.isNative).toBe(false);
+    });
+
+    it('throws on invalid formats', () => {
+      expect(() => parseAssetString('USDC')).toThrow();
+      expect(() => parseAssetString('USDC:short')).toThrow();
+    });
+  });
+
+  describe('verifyTrustline', () => {
+    const mockPublicKey = 'GBZZ..';
+    const customAsset = { 
+      code: 'USDC', 
+      issuer: 'GA5Z..', 
+      isNative: false 
+    };
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    it('returns true for native asset without network call', async () => {
+      const result = await verifyTrustline(mockPublicKey, NATIVE_ASSET);
+      expect(result.exists).toBe(true);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns true if trustline exists', async () => {
+      (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          balances: [
+            { asset_code: 'USDC', asset_issuer: 'GA5Z..' }
+          ]
+        })
+      });
+
+      const result = await verifyTrustline(mockPublicKey, customAsset);
+      expect(result.exists).toBe(true);
+    });
+
+    it('returns false and error if trustline missing', async () => {
+       (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          balances: [
+            { asset_type: 'native' }
+          ]
+        })
+      });
+
+      const result = await verifyTrustline(mockPublicKey, customAsset);
+      expect(result.exists).toBe(false);
+      expect(result.error).toContain('Missing trustline');
+    });
+
+    it('handles 404 account not found', async () => {
+      (fetch as jest.Mock).mockResolvedValue({
+        status: 404,
+        ok: false
+      });
+
+      const result = await verifyTrustline(mockPublicKey, customAsset);
+      expect(result.exists).toBe(false);
+      expect(result.error).toContain('does not exist');
+    });
+  });
+});

--- a/app/lib/assets.ts
+++ b/app/lib/assets.ts
@@ -1,0 +1,82 @@
+/**
+ * Asset Engine for StreamPay
+ * Handles XLM and Stellar custom assets (Trustlines).
+ */
+
+export interface StellarAsset {
+  code: string;
+  issuer?: string;
+  isNative: boolean;
+}
+
+export const NATIVE_ASSET: StellarAsset = {
+  code: 'XLM',
+  isNative: true,
+};
+
+/**
+ * Parses an asset string (e.g. "USDC:GABC...") or returns native.
+ */
+export function parseAssetString(assetStr: string): StellarAsset {
+  if (!assetStr || assetStr.toUpperCase() === 'XLM' || assetStr.toLowerCase() === 'native') {
+    return NATIVE_ASSET;
+  }
+
+  if (assetStr.includes(':')) {
+    const [code, issuer] = assetStr.split(':');
+    if (code && issuer && issuer.length === 56 && issuer.startsWith('G')) {
+      return { code: code.toUpperCase(), issuer, isNative: false };
+    }
+  }
+
+  throw new Error(`Invalid asset format: ${assetStr}. Expected XLM or CODE:ISSUER`);
+}
+
+/**
+ * Fetches account balances from Horizon and checks for a specific trustline.
+ */
+export async function verifyTrustline(
+  publicKey: string,
+  asset: StellarAsset,
+  horizonUrl: string = 'https://horizon.stellar.org'
+): Promise<{ exists: boolean; error?: string }> {
+  if (asset.isNative) return { exists: true };
+
+  try {
+    const response = await fetch(`${horizonUrl}/accounts/${publicKey}`);
+    
+    if (response.status === 404) {
+      return { exists: false, error: 'Recipient account does not exist on-chain.' };
+    }
+
+    if (!response.ok) {
+      return { exists: false, error: `Horizon error: ${response.status}` };
+    }
+
+    const data = await response.json();
+    const hasTrustline = data.balances.some(
+      (b: any) => b.asset_code === asset.code && b.asset_issuer === asset.issuer
+    );
+
+    if (!hasTrustline) {
+      return { exists: false, error: `Missing trustline for ${asset.code}.` };
+    }
+
+    return { exists: true };
+  } catch (err: any) {
+    return { exists: false, error: `Network error: ${err.message}` };
+  }
+}
+
+/**
+ * Validates if an asset can be used for a stream.
+ */
+export function validateAssetPair(sourceAsset: StellarAsset, destAsset: StellarAsset): boolean {
+  // v1 limitation: source and destination must match unless a path payment is used
+  // For now, we enforce same asset
+  return (
+    sourceAsset.isNative === destAsset.isNative &&
+    sourceAsset.code === destAsset.code &&
+    sourceAsset.issuer === destAsset.issuer
+  );
+}

--- a/app/lib/schedules.test.ts
+++ b/app/lib/schedules.test.ts
@@ -1,0 +1,123 @@
+import { getNextPayoutAt, calculateAccrual, type StreamSchedule } from './schedules';
+
+describe('Schedule Engine', () => {
+  describe('getNextPayoutAt', () => {
+    it('calculates next second correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'second',
+        rate: 1,
+      };
+      const now = new Date('2026-01-01T00:00:00.500Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-01T00:00:01.500Z');
+    });
+
+    it('calculates next day correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T12:00:00Z'),
+        interval: 'day',
+        rate: 10,
+      };
+      const now = new Date('2026-01-01T13:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-02T12:00:00.000Z');
+    });
+
+    it('handles month-end correctly (Jan 31 to Feb)', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-31T10:00:00Z'),
+        interval: 'month',
+        rate: 100,
+      };
+      const now = new Date('2026-01-31T11:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      // Feb only has 28 days in 2026
+      expect(next?.toISOString()).toBe('2026-02-28T10:00:00.000Z');
+    });
+
+    it('handles leap year correctly', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2024-01-29T10:00:00Z'),
+        interval: 'month',
+        rate: 100,
+      };
+      const now = new Date('2024-01-29T11:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      // 2024 is leap year, has Feb 29
+      expect(next?.toISOString()).toBe('2024-02-29T10:00:00.000Z');
+    });
+
+    it('respects endDate', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        endDate: new Date('2026-01-01T12:00:00Z'),
+        interval: 'day',
+        rate: 10,
+      };
+      const now = new Date('2026-01-01T06:00:00Z');
+      const next = getNextPayoutAt(schedule, now);
+      expect(next?.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+    });
+  });
+
+  describe('calculateAccrual', () => {
+    it('calculates second-based accrual', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'second',
+        rate: 1,
+      };
+      const now = new Date('2026-01-01T00:00:05.500Z');
+      const accrual = calculateAccrual(schedule, now);
+      expect(accrual).toBe(5.5);
+    });
+
+    it('truncates to precision (default 7)', () => {
+      const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'hour',
+        rate: 10,
+      };
+      // 1.5 hours + a tiny bit
+      const now = new Date('2026-01-01T01:30:00.0000001Z');
+      const accrual = calculateAccrual(schedule, now);
+      // (1.5 * 10) = 15
+      expect(accrual).toBe(15);
+    });
+
+    it('handles very small rates and high precision', () => {
+       const schedule: StreamSchedule = {
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        interval: 'day',
+        rate: 0.0000001, // 1 stroop per day
+        precision: 7
+      };
+      const now = new Date('2026-01-01T12:00:00Z'); // half day
+      const accrual = calculateAccrual(schedule, now);
+      expect(accrual).toBe(0); // 0.00000005 truncated to 7 decimals is 0
+    });
+  });
+
+  describe('formatNextPayout', () => {
+    it('formats near-future payout correctly', () => {
+      const now = new Date();
+      const next = new Date(now.getTime() + 5 * 60 * 1000 + 1000); // 5 mins and 1 sec
+      const { formatNextPayout } = require('./schedules');
+      expect(formatNextPayout(next)).toContain('5 minutes');
+    });
+
+    it('formats distant future payout correctly', () => {
+      const next = new Date('2099-01-01T10:00:00Z');
+      const { formatNextPayout } = require('./schedules');
+      const result = formatNextPayout(next);
+      expect(result).toMatch(/Jan/i);
+      expect(result).toMatch(/1/);
+    });
+
+    it('handles ended streams', () => {
+      const { formatNextPayout } = require('./schedules');
+      expect(formatNextPayout(null)).toBe('Stream ended');
+    });
+  });
+});

--- a/app/lib/schedules.ts
+++ b/app/lib/schedules.ts
@@ -1,0 +1,146 @@
+/**
+ * Schedule Engine for StreamPay
+ * Handles per-second, hourly, and monthly payout calculations.
+ * Aligned with UTC storage and local display requirements.
+ */
+
+export type PayoutInterval = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export interface StreamSchedule {
+  startDate: Date; // UTC
+  endDate?: Date; // UTC
+  interval: PayoutInterval;
+  rate: number; // Amount per interval
+  precision?: number; // Decimal places for rounding (default 7 for XLM)
+}
+
+/**
+ * Calculates the next payout time based on the current time and stream schedule.
+ * All calculations are done in UTC.
+ */
+export function getNextPayoutAt(schedule: StreamSchedule, now: Date = new Date()): Date | null {
+  const { startDate, endDate, interval } = schedule;
+  
+  if (now < startDate) {
+    return new Date(startDate);
+  }
+  
+  if (endDate && now >= endDate) {
+    return null;
+  }
+
+  const next = new Date(startDate);
+  
+  switch (interval) {
+    case 'second':
+      next.setTime(now.getTime() + 1000);
+      break;
+    case 'minute':
+      next.setTime(now.getTime() - (now.getTime() % 60000) + 60000);
+      break;
+    case 'hour':
+      next.setTime(now.getTime() - (now.getTime() % 3600000) + 3600000);
+      break;
+    case 'day':
+      next.setUTCDate(next.getUTCDate() + Math.floor((now.getTime() - startDate.getTime()) / 86400000) + 1);
+      break;
+    case 'week':
+      const daysSinceStart = Math.floor((now.getTime() - startDate.getTime()) / 86400000);
+      next.setUTCDate(next.getUTCDate() + (Math.floor(daysSinceStart / 7) + 1) * 7);
+      break;
+    case 'month':
+      let months = (now.getUTCFullYear() - startDate.getUTCFullYear()) * 12 + (now.getUTCMonth() - startDate.getUTCMonth());
+      if (now.getUTCDate() >= startDate.getUTCDate()) {
+        months += 1;
+      }
+      next.setUTCMonth(startDate.getUTCMonth() + months);
+      // Handle month-end overflow (e.g. Jan 31 -> Feb 28)
+      if (next.getUTCDate() !== startDate.getUTCDate()) {
+        next.setUTCDate(0);
+      }
+      break;
+    case 'year':
+      let years = now.getUTCFullYear() - startDate.getUTCFullYear();
+      if (now.getUTCMonth() > startDate.getUTCMonth() || (now.getUTCMonth() === startDate.getUTCMonth() && now.getUTCDate() >= startDate.getUTCDate())) {
+        years += 1;
+      }
+      next.setUTCFullYear(startDate.getUTCFullYear() + years);
+      break;
+  }
+
+  if (endDate && next > endDate) {
+    return new Date(endDate);
+  }
+
+  return next;
+}
+
+/**
+ * Calculates accrued amount based on time elapsed and rate.
+ * Uses banker's rounding (round half to even) or truncation based on project standards.
+ * For StreamPay, we use truncation for safety in financial calculations, or fixed precision.
+ */
+export function calculateAccrual(schedule: StreamSchedule, now: Date = new Date()): number {
+  const { startDate, endDate, interval, rate, precision = 7 } = schedule;
+  
+  if (now <= startDate) return 0;
+  
+  const effectiveEnd = endDate && now > endDate ? endDate : now;
+  const elapsedMs = effectiveEnd.getTime() - startDate.getTime();
+  
+  let intervalMs: number;
+  switch (interval) {
+    case 'second': intervalMs = 1000; break;
+    case 'minute': intervalMs = 60000; break;
+    case 'hour': intervalMs = 3600000; break;
+    case 'day': intervalMs = 86400000; break;
+    case 'week': intervalMs = 604800000; break;
+    case 'month':
+      // For accrual, we use average month length or specific interval math
+      // The requirement asks for per-second/hourly math
+      intervalMs = 30.44 * 24 * 60 * 60 * 1000; // Approx month
+      break;
+    case 'year':
+      intervalMs = 365.25 * 24 * 60 * 60 * 1000; // Approx year
+      break;
+    default:
+      intervalMs = 86400000;
+  }
+
+  const amount = (elapsedMs / intervalMs) * rate;
+  const factor = Math.pow(10, precision);
+  return Math.floor(amount * factor) / factor; // Truncate to precision
+}
+
+/**
+ * Formats a summary of the schedule for display.
+ */
+export function formatScheduleSummary(schedule: StreamSchedule): string {
+  const { interval, rate } = schedule;
+  const period = interval === 'day' ? 'daily' : interval === 'week' ? 'weekly' : interval === 'month' ? 'monthly' : `every ${interval}`;
+  return `${rate} XLM ${period}`;
+}
+
+/**
+ * Formats the "next payout" time for the UI.
+ * Handles UTC to Local display implicitly by using browser locale if needed,
+ * but here we follow the project's requirement to store UTC and display clearly.
+ */
+export function formatNextPayout(nextPayout: Date | null): string {
+  if (!nextPayout) return 'Stream ended';
+  
+  const now = new Date();
+  const diffMs = nextPayout.getTime() - now.getTime();
+  
+  if (diffMs < 0) return 'Processing...';
+  if (diffMs < 60000) return 'In less than a minute';
+  if (diffMs < 3600000) return `In ${Math.floor(diffMs / 60000)} minutes`;
+  if (diffMs < 86400000) return `In ${Math.floor(diffMs / 3600000)} hours`;
+  
+  return nextPayout.toLocaleDateString(undefined, { 
+    month: 'short', 
+    day: 'numeric', 
+    hour: '2-digit', 
+    minute: '2-digit' 
+  });
+}

--- a/app/lib/stream-invariants.test.ts
+++ b/app/lib/stream-invariants.test.ts
@@ -7,7 +7,10 @@ import {
 } from './stream-invariants';
 
 describe('Stream Invariants (Property-based)', () => {
-  it('should maintain conservation of value regardless of event sequence', () => {
+  const isHeavyMode = process.env.TEST_MODE === 'heavy';
+  const numRuns = isHeavyMode ? 10000 : 1000;
+
+  it(`should maintain conservation of value (${numRuns} runs)`, () => {
     fc.assert(
       fc.property(
         fc.array(
@@ -36,7 +39,7 @@ describe('Stream Invariants (Property-based)', () => {
           return true;
         }
       ),
-      { numRuns: 1000 }
+      { numRuns, seed: 42 } // Seed for deterministic CI stability
     );
   });
 

--- a/app/lib/stream-invariants.test.ts
+++ b/app/lib/stream-invariants.test.ts
@@ -1,0 +1,52 @@
+import * as fc from 'fast-check';
+import { 
+  checkConservationOfValue, 
+  checkNonNegativeBalances, 
+  applyStreamEvent, 
+  StreamState 
+} from './stream-invariants';
+
+describe('Stream Invariants (Property-based)', () => {
+  it('should maintain conservation of value regardless of event sequence', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            type: fc.constantFrom('deposit', 'withdraw', 'refund'),
+            amount: fc.float({ min: 0, max: 10000, noNaN: true })
+          }),
+          { maxLength: 50 }
+        ),
+        (events) => {
+          let state: StreamState = { deposited: 0, withdrawn: 0, escrow: 0 };
+          
+          for (const event of events) {
+            // Guard against negative escrow in this model to simulate "valid" attempts,
+            // or just apply and check the invariant if we want to find failing paths.
+            // Requirement says "randomize a sequence of valid mutating events".
+            if (event.type === 'withdraw' && event.amount > state.escrow) continue;
+            if (event.type === 'refund' && event.amount > state.escrow) continue;
+            
+            state = applyStreamEvent(state, event);
+            
+            // Assert invariants
+            if (!checkConservationOfValue(state)) return false;
+            if (!checkNonNegativeBalances(state)) return false;
+          }
+          return true;
+        }
+      ),
+      { numRuns: 1000 }
+    );
+  });
+
+  it('regression: should not allow negative escrow via excessive withdrawal', () => {
+    // This is a static test derived from what a property test might find
+    const state: StreamState = { deposited: 100, withdrawn: 0, escrow: 100 };
+    const invalidEvent = { type: 'withdraw' as const, amount: 150 };
+    const newState = applyStreamEvent(state, invalidEvent);
+    
+    expect(checkNonNegativeBalances(newState)).toBe(false);
+    expect(newState.escrow).toBe(-50);
+  });
+});

--- a/app/lib/stream-invariants.ts
+++ b/app/lib/stream-invariants.ts
@@ -1,0 +1,65 @@
+/**
+ * Stream Invariants Module
+ * Pure functions to validate stream state consistency.
+ * These can be used in both frontend validation and tests.
+ */
+
+export interface StreamState {
+  deposited: number;
+  withdrawn: number;
+  escrow: number;
+}
+
+/**
+ * Invariant: Sum of legs matches deposited amount.
+ * Conservation of value: deposited = withdrawn + escrow
+ */
+export function checkConservationOfValue(state: StreamState): boolean {
+  // Using a small epsilon for floating point math if needed,
+  // but for Stellar/Soroban we usually use bigints or fixed precision.
+  // Here we assume basic numbers with truncation handling elsewhere.
+  return Math.abs(state.deposited - (state.withdrawn + state.escrow)) < 0.0000001;
+}
+
+/**
+ * Invariant: Balances must never be negative.
+ */
+export function checkNonNegativeBalances(state: StreamState): boolean {
+  return state.deposited >= 0 && state.withdrawn >= 0 && state.escrow >= 0;
+}
+
+/**
+ * Invariant: Cannot release more than what is in escrow.
+ */
+export function checkSettleLimit(state: StreamState, amountToRelease: number): boolean {
+  return amountToRelease <= state.escrow;
+}
+
+/**
+ * Reducer-like function to model stream mutations safely.
+ */
+export function applyStreamEvent(
+  state: StreamState,
+  event: { type: 'deposit' | 'withdraw' | 'refund'; amount: number }
+): StreamState {
+  const newState = { ...state };
+  
+  switch (event.type) {
+    case 'deposit':
+      newState.deposited += event.amount;
+      newState.escrow += event.amount;
+      break;
+    case 'withdraw':
+      // In a real scenario, this would be guarded by logic.
+      // For property tests, we apply it and check invariants.
+      newState.withdrawn += event.amount;
+      newState.escrow -= event.amount;
+      break;
+    case 'refund':
+      newState.deposited -= event.amount;
+      newState.escrow -= event.amount;
+      break;
+  }
+  
+  return newState;
+}

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,0 +1,26 @@
+# Stream Invariants & Property Testing
+
+To ensure the reliability of StreamPay's accounting, we use property-based testing to verify that stream states remain consistent under any sequence of valid events.
+
+## Core Invariants
+
+1. **Conservation of Value**: `deposited_amount == withdrawn_amount + escrow_balance`. Funds must always be accounted for.
+2. **Non-Negativity**: `deposited`, `withdrawn`, and `escrow` must never be less than zero.
+3. **Escrow Bound**: A withdrawal or refund can never exceed the current `escrow` balance.
+
+## Property Testing Setup
+
+We use `fast-check` to generate randomized sequences of `deposit`, `withdraw`, and `refund` events.
+
+- **Runs**: Default 1000 iterations per test.
+- **Shrinking**: If a failure is found, `fast-check` automatically simplifies the event sequence to the minimal reproduction case.
+- **CI Stability**: Tests use deterministic seeds to ensure failures are reproducible in CI pipelines.
+
+## Security Note
+
+These invariants are modeled in the frontend/middleware to guide users and catch logic errors early. However, they are **not** a substitute for on-chain Soroban contract security. Final enforcement always happens via Soroban smart contracts.
+
+## Future Work
+
+- Integration with [StreamPay-Contracts](https://github.com/Streampay-Org/StreamPay-Contracts) formal verification models.
+- Nightly "heavy" runs with 10,000+ iterations.

--- a/docs/payout-math.md
+++ b/docs/payout-math.md
@@ -1,0 +1,42 @@
+# Payout Schedule Math
+
+This document describes the mathematical logic used for calculating payout schedules, accruals, and next execution times in StreamPay.
+
+## Core Principles
+
+1. **UTC Storage**: All dates are stored and processed in UTC. Timezone conversion is strictly a display-layer concern.
+2. **Deterministic Calculation**: Payout times are calculated relative to the `startDate` of the stream, ensuring consistent intervals even if executions are delayed.
+3. **Precision**: StreamPay uses 7 decimal places for XLM (aligning with stroops) and other assets unless specified otherwise.
+
+## Calculation Logic
+
+### Next Payout Time (`getNextPayoutAt`)
+
+Calculates the absolute next time a payment should occur based on the current time and the stream's recurrence interval.
+
+- **Per-second**: Current time + 1 second.
+- **Hourly/Daily/Weekly**: Aligned to the `startDate`'s time of day/week.
+- **Monthly**: Aligned to the `startDate`'s day of the month.
+  - **Edge Case (Short Months)**: If a stream starts on the 31st, and the next month has only 28/30 days, the payout is capped at the last day of that month.
+
+### Accrual & Proration (`calculateAccrual`)
+
+Calculates the amount earned but not yet paid out.
+
+- **Formula**: `(elapsedTime / intervalDuration) * rate`
+- **Rounding**: All accrual calculations use **truncation** to the specified precision (default 7). This ensures we never over-promise funds that haven't fully vested.
+
+## Rounding Strategy
+
+We use **Truncation** (rounding towards zero) for all financial math in the frontend.
+
+| Method | Value | Result (Precision 2) | Rationale |
+| :--- | :--- | :--- | :--- |
+| Truncate | 1.239 | 1.23 | Conservative; avoids over-allocation. |
+| Banker's | 1.235 | 1.24 | Standard for banking; avoids bias. |
+
+*Note: StreamPay defaults to Truncation for payout math to ensure ledger consistency.*
+
+## Stellar Ledger Alignment
+
+While Stellar ledgers close every ~5 seconds, our engine calculates time with millisecond precision. Execution engines should trigger as soon as possible after the `next_payout_at` timestamp is passed by a closed ledger.

--- a/docs/supported-assets.md
+++ b/docs/supported-assets.md
@@ -1,0 +1,28 @@
+# Supported Assets (v1)
+
+StreamPay supports Stellar Native (XLM) and any valid Stellar Classic assets (Alpha-numeric 4 or 12). 
+
+## Asset Types
+
+### 1. Stellar Native (XLM)
+- **Code**: `XLM`
+- **Trustline**: Required by default for all Stellar accounts. No pre-flight needed.
+- **Precision**: 7 decimal places (Stroops).
+
+### 2. Stellar Classic Assets (Custom)
+- **Format**: `CODE:ISSUER_ADDRESS`
+- **Trustline**: The recipient **must** establish a trustline for the specific asset before a stream can be successfully funded or paid out.
+- **Pre-flight Check**: StreamPay-Frontend performs an automated check against Horizon to verify trustline existence.
+
+## Validation Matrix
+
+| Case | Result | Actionable Error |
+| :--- | :--- | :--- |
+| Valid XLM | Success | N/A |
+| Valid USDC:G... | Success (if trustline exists) | N/A |
+| Missing Trustline | Reject | "Missing trustline for [CODE]." |
+| Account Not Found | Reject | "Recipient account does not exist on-chain." |
+| Invalid Format | Reject | "Invalid asset format. Expected CODE:ISSUER" |
+
+## Minimum Reserves
+Users must maintain the Stellar base reserve + increments for each trustline. StreamPay does not currently sponsor reserves for trustlines in v1.


### PR DESCRIPTION
## test(streams): property-based invariants for balance and escrow

Closes #124

### Summary
- Added property-based tests using fast-check
- Implemented invariants: non-negative balances and escrow conservation
- Introduced lightweight in-memory model for stream state transitions

### Tests
- Added `app/lib/stream-invariants.test.ts`
- Runs seeded randomized event sequences for deterministic CI
- Includes regression test for negative escrow case  
 All tests passing locally

### Notes
- Added `docs/invariants.md` (invariants + assumptions)
- Designed to complement on-chain guarantees, not replace them