### PR TITLE
design(figma): add reusable design QA checklist for stream and money screens

### DIFF
--- a/app/design-qa/DesignChecklist.tsx
+++ b/app/design-qa/DesignChecklist.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import React, { useState, useId, type ChangeEvent } from "react";
+import {
+  CHECKLIST_SECTIONS,
+  TOTAL_ITEMS,
+  type ChecklistAnswer,
+} from "./checklist-data";
+
+type Answers = Record<string, ChecklistAnswer>;
+
+function AnswerButton({
+  value,
+  current,
+  label,
+  itemId,
+  onChange,
+}: {
+  value: ChecklistAnswer;
+  current: ChecklistAnswer;
+  label: string;
+  itemId: string;
+  onChange: (v: ChecklistAnswer) => void;
+}) {
+  const isActive = current === value;
+  return (
+    <button
+      aria-pressed={isActive}
+      className={`checklist-answer-btn checklist-answer-btn--${value} ${isActive ? "checklist-answer-btn--active" : ""}`}
+      onClick={() => onChange(isActive ? null : value)}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function ProgressBar({ answered, total }: { answered: number; total: number }) {
+  const pct = total === 0 ? 0 : Math.round((answered / total) * 100);
+  return (
+    <div className="checklist-progress" aria-label={`${answered} of ${total} items answered`}>
+      <div className="checklist-progress__labels">
+        <span>{answered} / {total} answered</span>
+        <span>{pct}%</span>
+      </div>
+      <div className="checklist-progress__track" role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
+        <div className="checklist-progress__fill" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function SectionSummary({ answers, itemIds }: { answers: Answers; itemIds: string[] }) {
+  const yes = itemIds.filter((id) => answers[id] === "yes").length;
+  const no = itemIds.filter((id) => answers[id] === "no").length;
+  const na = itemIds.filter((id) => answers[id] === "na").length;
+  const total = itemIds.length;
+  const done = yes + no + na;
+  return (
+    <p className="checklist-section__summary" aria-live="polite">
+      {done}/{total} answered
+      {no > 0 && <span className="checklist-section__summary--no"> · {no} No</span>}
+      {na > 0 && <span className="checklist-section__summary--na"> · {na} N/A</span>}
+    </p>
+  );
+}
+
+export function DesignChecklist({ screen }: { screen?: string }) {
+  const [answers, setAnswers] = useState<Answers>({});
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const headingId = useId();
+
+  const answered = Object.values(answers).filter(Boolean).length;
+  const noCount = Object.values(answers).filter((v) => v === "no").length;
+
+  function setAnswer(id: string, value: ChecklistAnswer) {
+    setAnswers((prev: Answers) => ({ ...prev, [id]: value }));
+  }
+
+  function setNote(id: string, value: string) {
+    setNotes((prev: Record<string, string>) => ({ ...prev, [id]: value }));
+  }
+
+  function handleReset() {
+    setAnswers({});
+    setNotes({});
+  }
+
+  return (
+    <div className="checklist-shell">
+      <header className="checklist-header">
+        <div>
+          <p className="checklist-header__eyebrow">Design QA</p>
+          <h1 className="checklist-header__title" id={headingId}>
+            StreamPay Design Checklist
+          </h1>
+          {screen && (
+            <p className="checklist-header__screen">
+              Screen: <strong>{screen}</strong>
+            </p>
+          )}
+          <p className="checklist-header__meta">
+            {TOTAL_ITEMS} items · a11y, interactive states, 8px grid, empty/loading/error, money actions, Stellar/Soroban
+          </p>
+        </div>
+        <button className="button button--secondary checklist-reset-btn" onClick={handleReset} type="button">
+          Reset
+        </button>
+      </header>
+
+      <ProgressBar answered={answered} total={TOTAL_ITEMS} />
+
+      {noCount > 0 && (
+        <div className="checklist-warning" role="alert">
+          {noCount} item{noCount > 1 ? "s" : ""} marked No — add notes and a ticket reference before handoff.
+        </div>
+      )}
+
+      <ol className="checklist-sections" aria-labelledby={headingId}>
+        {CHECKLIST_SECTIONS.map((section) => (
+          <li key={section.id} className="checklist-section">
+            <div className="checklist-section__header">
+              <div>
+                <h2 className="checklist-section__title">{section.title}</h2>
+                {section.description && (
+                  <p className="checklist-section__description">{section.description}</p>
+                )}
+              </div>
+              <SectionSummary
+                answers={answers}
+                itemIds={section.items.map((i) => i.id)}
+              />
+            </div>
+
+            <ol className="checklist-items">
+              {section.items.map((item, idx) => {
+                const answer = answers[item.id] ?? null;
+                const noteId = `note-${item.id}`;
+                return (
+                  <li
+                    key={item.id}
+                    className={`checklist-item ${answer ? `checklist-item--${answer}` : ""}`}
+                  >
+                    <div className="checklist-item__row">
+                      <span className="checklist-item__number" aria-hidden="true">
+                        {idx + 1}
+                      </span>
+                      <p className="checklist-item__text">{item.item}</p>
+                      <div className="checklist-item__actions" role="group" aria-label={`Answer for item ${idx + 1}`}>
+                        <AnswerButton value="yes" current={answer} label="Yes" itemId={item.id} onChange={(v) => setAnswer(item.id, v)} />
+                        <AnswerButton value="no" current={answer} label="No" itemId={item.id} onChange={(v) => setAnswer(item.id, v)} />
+                        <AnswerButton value="na" current={answer} label="N/A" itemId={item.id} onChange={(v) => setAnswer(item.id, v)} />
+                      </div>
+                    </div>
+
+                    {(answer === "no" || notes[item.id]) && (
+                      <div className="checklist-item__note">
+                        <label className="checklist-item__note-label" htmlFor={noteId}>
+                          Note / ticket reference
+                        </label>
+                        <textarea
+                          className="checklist-item__note-input"
+                          id={noteId}
+                          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNote(item.id, e.target.value)}
+                          placeholder="Add rationale and phase-2 ticket number…"
+                          rows={2}
+                          value={notes[item.id] ?? ""}
+                        />
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          </li>
+        ))}
+      </ol>
+
+      <footer className="checklist-footer">
+        <p className="checklist-footer__text">
+          Run this checklist before any stream or money screen moves to dev handoff.
+          Link from every major Figma file cover page.
+        </p>
+        <p className="checklist-footer__commit">
+          <code>design(figma): design QA checklist for Stellar/StreamPay money and stream screens</code>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/app/design-qa/checklist-data.ts
+++ b/app/design-qa/checklist-data.ts
@@ -1,0 +1,197 @@
+export type ChecklistAnswer = "yes" | "no" | "na" | null;
+
+export type ChecklistItem = {
+  id: string;
+  item: string;
+  /** Optional annotation shown below the item text */
+  annotation?: string;
+};
+
+export type ChecklistSection = {
+  id: string;
+  title: string;
+  description?: string;
+  items: ChecklistItem[];
+};
+
+export const CHECKLIST_SECTIONS: ChecklistSection[] = [
+  {
+    id: "a11y",
+    title: "Accessibility (a11y)",
+    description: "All 8 items must pass before handoff. Document any phase-2 gaps with a ticket reference.",
+    items: [
+      {
+        id: "a11y-1",
+        item: "All text meets WCAG AA contrast — 4.5:1 for body text, 3:1 for large text and UI components. Verified with a contrast tool (Stark, Colour Contrast Analyser, or Figma A11y Kit).",
+      },
+      {
+        id: "a11y-2",
+        item: "Every interactive element (button, link, input, badge) has a visible focus ring designed and annotated — not just the browser default.",
+      },
+      {
+        id: "a11y-3",
+        item: "Colour is never the sole means of conveying status. Each StatusBadge (draft / active / paused / ended) uses both colour and a text label.",
+      },
+      {
+        id: "a11y-4",
+        item: "Touch and click targets are ≥ 44 × 44 px for all interactive controls (stream row actions, modal close button, CTA buttons).",
+      },
+      {
+        id: "a11y-5",
+        item: "Reading and focus order is annotated in Figma dev mode for every screen and matches the intended DOM / tab order.",
+      },
+      {
+        id: "a11y-6",
+        item: "All icons used without adjacent visible text have an aria-label annotation (e.g. Modal close button, status icons).",
+      },
+      {
+        id: "a11y-7",
+        item: "Motion / animation: a reduced-motion variant is noted for every entrance or exit animation (e.g. Modal scale-in / fade-in).",
+      },
+      {
+        id: "a11y-8",
+        item: "Any phase-2 a11y gaps (e.g. live-region announcements for stream status changes) are documented with rationale and a ticket reference.",
+      },
+    ],
+  },
+  {
+    id: "money-actions",
+    title: "Irreversible Money Actions",
+    description:
+      "Applies to Settle, Withdraw, and Stop — and any future Soroban / escrow release action. These actions cannot be undone on-chain.",
+    items: [
+      {
+        id: "money-1",
+        item: "A confirmation step (modal or inline) is designed for every irreversible action (Settle, Withdraw, Stop). The confirmation copy names the action, amount, and recipient explicitly.",
+      },
+      {
+        id: "money-2",
+        item: "Destructive / irreversible actions use a visually distinct treatment (e.g. warning colour, separate button style) — not the same style as reversible actions (Pause, Start).",
+      },
+      {
+        id: "money-3",
+        item: 'The confirmation modal for Settle / Withdraw / Stop includes a plain-language warning: "This action cannot be undone." Copy is reviewed and approved by product.',
+      },
+      {
+        id: "money-4",
+        item: "Amount and recipient are shown in the confirmation step so the user can verify before submitting — no hidden values.",
+      },
+      {
+        id: "money-5",
+        item: 'Loading / pending state is designed for the post-confirmation submit (on-chain tx in flight): button disabled, spinner or skeleton shown, copy updated (e.g. "Settling…").',
+      },
+      {
+        id: "money-6",
+        item: "Success and error outcomes are both designed for every irreversible action — not just the happy path. Error copy is non-committal about chain state where the Horizon / Soroban API is not yet final.",
+      },
+    ],
+  },
+  {
+    id: "interactive-states",
+    title: "All Interactive States",
+    items: [
+      {
+        id: "states-1",
+        item: "Every button has all five states designed: default, hover, focus, active / pressed, disabled.",
+      },
+      {
+        id: "states-2",
+        item: "Every form input (if present) has: default, focus, filled, error, and disabled states.",
+      },
+      {
+        id: "states-3",
+        item: "StreamRow next-action button states are shown for each stream status: draft → Start, active → Pause, paused → Start, ended → Withdraw.",
+      },
+      {
+        id: "states-4",
+        item: "Modal open and close animations are annotated; backdrop click-to-dismiss behaviour is documented.",
+      },
+      {
+        id: "states-5",
+        item: "Skeleton loading state (StreamListSkeleton) matches the populated layout — same row count and column widths — so there is no layout shift on load.",
+      },
+    ],
+  },
+  {
+    id: "grid",
+    title: "8px Grid and Spacing",
+    items: [
+      {
+        id: "grid-1",
+        item: "All spacing values (padding, margin, gap) are multiples of 8px (or 4px for fine-grained adjustments). Verified with Figma's layout grid overlay.",
+      },
+      {
+        id: "grid-2",
+        item: "Component internal padding follows the 8px grid: StreamRow (20–24px), Modal (24px), Card (16px). Any deviation is intentional and annotated.",
+      },
+      {
+        id: "grid-3",
+        item: "Responsive breakpoints are defined and annotated: mobile (≤ 640px), tablet (641–1024px), desktop (> 1024px). Grid columns collapse correctly at each breakpoint.",
+      },
+    ],
+  },
+  {
+    id: "states",
+    title: "Empty / Loading / Error States",
+    items: [
+      {
+        id: "empty-1",
+        item: "Every list or data screen has three states designed: empty (EmptyState with eyebrow, title, description, and at least one CTA), loading (skeleton), and populated.",
+      },
+      {
+        id: "empty-2",
+        item: "Error state is designed for every screen that makes a network or chain call — includes a human-readable message, an optional retry CTA, and does not expose raw error codes.",
+      },
+      {
+        id: "empty-3",
+        item: "EmptyState copy is contextual per screen (Streams empty ≠ Activity empty) and reviewed by product / content.",
+      },
+    ],
+  },
+  {
+    id: "devmode",
+    title: "Figma Dev Mode and Component Naming",
+    items: [
+      {
+        id: "dev-1",
+        item: "Component names in Figma match agreed code names: StreamRow, StatusBadge, Modal, EmptyState, Card, Skeleton. No orphan or renamed variants without a code counterpart.",
+      },
+      {
+        id: "dev-2",
+        item: "All exported assets are named, sliced, and listed in the handoff note (SVG icons, illustration assets). No orphan screens without a named export.",
+      },
+      {
+        id: "dev-3",
+        item: "Redlines and component specs are attached or linked in Figma dev mode for every new or changed component before the dev ticket is opened.",
+      },
+    ],
+  },
+  {
+    id: "stellar",
+    title: "Stellar / Soroban / Horizon / Escrow Annotations",
+    description: "Mark N/A for screens with no on-chain interaction.",
+    items: [
+      {
+        id: "stellar-1",
+        item: 'Any copy referencing Soroban contract state, escrow release, or Horizon transaction status is annotated as "pending API finalisation" until the API contract is signed off. Copy must stay non-committal (e.g. "Funds may take a moment to appear" — not "Funds will appear in 5 seconds").',
+      },
+      {
+        id: "stellar-2",
+        item: "Stream lifecycle labels (draft → active → paused → ended) match the agreed StreamStatus type in code. Any new status introduced in design has a corresponding code ticket.",
+      },
+      {
+        id: "stellar-3",
+        item: "Vesting or escrow-specific screens (if in scope) annotate which values come from Soroban contract reads vs. Horizon ledger vs. local state — so engineers know the data source for each field.",
+      },
+      {
+        id: "stellar-4",
+        item: "On-chain transaction hash or ledger reference (if surfaced in UI) is truncated with a copy / expand affordance designed — not shown as a raw full-length string.",
+      },
+    ],
+  },
+];
+
+export const TOTAL_ITEMS = CHECKLIST_SECTIONS.reduce(
+  (sum, section) => sum + section.items.length,
+  0
+);

--- a/app/design-qa/page.tsx
+++ b/app/design-qa/page.tsx
@@ -1,0 +1,11 @@
+import { DesignChecklist } from "./DesignChecklist";
+
+export const metadata = {
+  title: "Design QA Checklist — StreamPay",
+  description:
+    "25+ item design QA checklist for StreamPay stream and money screens. Run before every dev handoff.",
+};
+
+export default function DesignQAPage() {
+  return <DesignChecklist screen="Streams list" />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -448,3 +448,307 @@ a:hover {
     justify-self: end;
   }
 }
+
+/* ─── Design QA Checklist ─────────────────────────────────────────────────── */
+
+.checklist-shell {
+  display: grid;
+  gap: 2rem;
+  margin: 0 auto;
+  max-width: 56rem;
+  min-height: 100vh;
+  padding: 2rem 1rem 4rem;
+}
+
+.checklist-header {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.checklist-header__eyebrow {
+  color: var(--accent);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.checklist-header__title {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  line-height: 1.1;
+  margin-bottom: 0.5rem;
+}
+
+.checklist-header__screen {
+  color: var(--muted-light);
+  font-size: var(--text-sm);
+  margin-bottom: 0.25rem;
+}
+
+.checklist-header__meta {
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+
+.checklist-reset-btn {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  min-height: var(--touch-target);
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+}
+
+/* Progress bar */
+.checklist-progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.checklist-progress__labels {
+  color: var(--muted-light);
+  display: flex;
+  font-size: var(--text-sm);
+  justify-content: space-between;
+}
+
+.checklist-progress__track {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  height: 8px;
+  overflow: hidden;
+}
+
+.checklist-progress__fill {
+  background: var(--accent);
+  border-radius: var(--radius-full);
+  height: 100%;
+  transition: width 300ms ease;
+}
+
+/* Warning banner */
+.checklist-warning {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: var(--radius-lg);
+  color: #fca5a5;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  padding: 0.75rem 1rem;
+}
+
+/* Sections list */
+.checklist-sections {
+  display: grid;
+  gap: 1.5rem;
+  list-style: none;
+  padding: 0;
+}
+
+.checklist-section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.checklist-section__header {
+  align-items: start;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+}
+
+.checklist-section__title {
+  font-size: var(--text-lg);
+  margin-bottom: 0.25rem;
+}
+
+.checklist-section__description {
+  color: var(--muted-light);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  max-width: 52ch;
+}
+
+.checklist-section__summary {
+  color: var(--muted);
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.checklist-section__summary--no {
+  color: #f87171;
+}
+
+.checklist-section__summary--na {
+  color: var(--muted-light);
+}
+
+/* Items list */
+.checklist-items {
+  display: grid;
+  list-style: none;
+  padding: 0;
+}
+
+.checklist-item {
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 1.5rem;
+  transition: background 160ms ease;
+}
+
+.checklist-item:last-child {
+  border-bottom: none;
+}
+
+.checklist-item--yes {
+  background: rgba(34, 197, 94, 0.05);
+}
+
+.checklist-item--no {
+  background: rgba(239, 68, 68, 0.05);
+}
+
+.checklist-item--na {
+  background: rgba(113, 113, 122, 0.06);
+}
+
+.checklist-item__row {
+  align-items: start;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1.5rem minmax(0, 1fr) auto;
+}
+
+.checklist-item__number {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  padding-top: 0.2rem;
+}
+
+.checklist-item__text {
+  color: var(--foreground);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.checklist-item--na .checklist-item__text {
+  color: var(--muted-light);
+}
+
+/* Answer buttons */
+.checklist-item__actions {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.checklist-answer-btn {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--muted-light);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  min-height: var(--touch-target);
+  min-width: 2.75rem;
+  padding: 0.25rem 0.625rem;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.checklist-answer-btn:hover {
+  border-color: var(--muted-light);
+  color: var(--foreground);
+}
+
+.checklist-answer-btn--yes.checklist-answer-btn--active {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.checklist-answer-btn--no.checklist-answer-btn--active {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: #f87171;
+  color: #f87171;
+}
+
+.checklist-answer-btn--na.checklist-answer-btn--active {
+  background: rgba(113, 113, 122, 0.15);
+  border-color: var(--muted-light);
+  color: var(--muted-light);
+}
+
+/* Note textarea */
+.checklist-item__note {
+  display: grid;
+  gap: 0.375rem;
+  margin-top: 0.75rem;
+  padding-left: 2.25rem;
+}
+
+.checklist-item__note-label {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.checklist-item__note-input {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  resize: vertical;
+  width: 100%;
+}
+
+.checklist-item__note-input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+/* Footer */
+.checklist-footer {
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 0.5rem;
+  padding-top: 1.5rem;
+}
+
+.checklist-footer__text {
+  color: var(--muted-light);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.checklist-footer__commit code {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--muted-light);
+  display: block;
+  font-size: var(--text-xs);
+  padding: 0.5rem 0.75rem;
+}
+
+@media (min-width: 48rem) {
+  .checklist-shell {
+    padding: 3rem 2rem 5rem;
+  }
+}

--- a/docs/design-qa-checklist.md
+++ b/docs/design-qa-checklist.md
@@ -1,0 +1,136 @@
+# StreamPay Design QA Checklist
+**Version:** 1.0  
+**Scope:** Streams and money screens (Streams list, Stream detail, Settle, Withdraw, Stop, Pause, Activity)  
+**Usage:** Run before any stream or money screen moves from design → dev handoff. Link this doc from every major Figma file cover page.  
+**Format:** Yes / No / N/A — annotate any No with a rationale and phase-2 ticket reference.
+
+---
+
+## How to use
+
+1. Duplicate this checklist into the Figma file's cover page (as a linked Notion doc or embedded text frame).
+2. Assign one designer as DRI per screen.
+3. Mark each item **Yes**, **No**, or **N/A**.
+4. Any **No** must include a short note and a follow-up ticket number before handoff is approved.
+5. Pilot run: complete this checklist on the **Streams list** or **Settle** screen first; adjust wording; re-export; announce in #design.
+
+---
+
+## Section 1 — Accessibility (a11y) · 8 items
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 1 | All text meets WCAG AA contrast (4.5:1 body, 3:1 large text / UI components). Checked with a contrast tool (e.g. Figma A11y Annotation Kit, Stark, or Colour Contrast Analyser). | | |
+| 2 | Every interactive element (button, link, input, badge) has a visible focus ring designed and annotated — not just browser default. | | |
+| 3 | Colour is never the sole means of conveying status. Each `StatusBadge` (draft / active / paused / ended) uses both colour **and** a text label. | | |
+| 4 | Touch / click targets are ≥ 44 × 44 px for all interactive controls (stream row actions, modal close, CTA buttons). | | |
+| 5 | Reading and focus order is annotated in Figma dev mode for every screen — matches the intended DOM / tab order. | | |
+| 6 | All icons used without adjacent visible text have an `aria-label` annotation (e.g. close button on `Modal`, status icons). | | |
+| 7 | Motion / animation: reduced-motion variant is noted for any entrance/exit animation (e.g. `Modal` scale-in / fade-in). | | |
+| 8 | Any phase-2 a11y gaps (e.g. live-region announcements for stream status changes) are documented with rationale and ticket reference. | | |
+
+---
+
+## Section 2 — Irreversible Money Actions · 6 items
+
+> Applies to: **Settle**, **Withdraw**, **Stop** — and any future Soroban/escrow release action.  
+> These actions cannot be undone on-chain. Design must make that unmistakably clear.
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 9 | A confirmation step (modal or inline) is designed for every irreversible action (Settle, Withdraw, Stop). The confirmation copy names the action and the amount/recipient explicitly. | | |
+| 10 | Destructive / irreversible actions use a visually distinct treatment (e.g. red/warning colour, separate button style) — not the same style as reversible actions (Pause, Start). | | |
+| 11 | The confirmation modal for Settle / Withdraw / Stop includes a plain-language warning: "This action cannot be undone." Copy is reviewed and approved by product. | | |
+| 12 | Amount and recipient are shown in the confirmation step — user can verify before submitting (no hidden values). | | |
+| 13 | Loading / pending state is designed for the post-confirmation submit (on-chain tx in flight): button disabled, spinner or skeleton shown, copy updated (e.g. "Settling…"). | | |
+| 14 | Success and error outcomes are both designed for every irreversible action — not just the happy path. Error copy is non-committal about chain state where Horizon/Soroban API is not yet final (see Section 6). | | |
+
+---
+
+## Section 3 — All Interactive States · 5 items
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 15 | Every button has all five states designed: default, hover, focus, active/pressed, disabled. | | |
+| 16 | Every form input (if present) has: default, focus, filled, error, and disabled states. | | |
+| 17 | Stream row (`StreamRow`) next-action button states are shown for each stream status: draft → Start, active → Pause, paused → Start, ended → Withdraw. | | |
+| 18 | `Modal` open and close animations are annotated; backdrop click-to-dismiss behaviour is documented. | | |
+| 19 | Skeleton loading state (`StreamListSkeleton`) matches the populated layout — same row count, same column widths — so there is no layout shift on load. | | |
+
+---
+
+## Section 4 — 8px Grid and Spacing · 3 items
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 20 | All spacing values (padding, margin, gap) are multiples of 8px (or 4px for fine-grained adjustments). Verified with Figma's layout grid overlay. | | |
+| 21 | Component internal padding follows the 8px grid: `StreamRow` (20px → 24px), `Modal` (24px), `Card` (20px). Deviations are intentional and annotated. | | |
+| 22 | Responsive breakpoints are defined and annotated: at minimum mobile (≤ 640px), tablet (641–1024px), desktop (> 1024px). Grid columns collapse correctly. | | |
+
+---
+
+## Section 5 — Empty / Loading / Error States · 3 items
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 23 | Every list or data screen has three states designed: **empty** (`EmptyState` with eyebrow, title, description, and at least one CTA), **loading** (skeleton), **populated**. | | |
+| 24 | Error state is designed for every screen that makes a network or chain call — includes a human-readable message, an optional retry CTA, and does not expose raw error codes to the user. | | |
+| 25 | `EmptyState` copy is contextual per screen (Streams empty ≠ Activity empty) and reviewed by product/content. | | |
+
+---
+
+## Section 6 — Figma Dev Mode and Component Naming · 3 items
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 26 | Component names in Figma match agreed code names: `StreamRow`, `StatusBadge`, `Modal`, `EmptyState`, `Card`, `Skeleton`. No orphan or renamed variants without a code counterpart. | | |
+| 27 | All exported assets are named, sliced, and listed in the handoff note (SVG icons, illustration assets). No orphan screens without a named export. | | |
+| 28 | Redlines and component specs are attached or linked in Figma dev mode for every new or changed component before the dev ticket is opened. | | |
+
+---
+
+## Section 7 — Stellar / Soroban / Horizon / Escrow Annotations · 4 items
+
+> These items apply where product scope includes on-chain actions. Mark N/A for pure UI screens with no chain interaction.
+
+| # | Item | Yes / No / N/A | Notes |
+|---|------|----------------|-------|
+| 29 | Any copy referencing Soroban contract state, escrow release, or Horizon transaction status is annotated as **"pending API finalisation"** until the API contract is signed off. Copy must stay non-committal (e.g. "Funds may take a moment to appear" not "Funds will appear in 5 seconds"). | | |
+| 30 | Stream lifecycle labels (draft → active → paused → ended) match the agreed `StreamStatus` type in code. Any new status introduced in design has a corresponding code ticket. | | |
+| 31 | Vesting or escrow-specific screens (if in scope) annotate which values come from Soroban contract reads vs. Horizon ledger vs. local state — so engineers know the data source for each field. | | |
+| 32 | On-chain transaction hash or ledger reference (if surfaced in UI) is truncated with a copy/expand affordance designed — not shown as a raw full-length string. | | |
+
+---
+
+## Sign-off
+
+| Role | Name | Date | Signature / Figma comment link |
+|------|------|------|-------------------------------|
+| Designer (DRI) | | | |
+| Product | | | |
+| Engineer | | | |
+
+**Checklist status:** ☐ In progress · ☐ Passed · ☐ Passed with phase-2 items  
+**Live checklist link:** _(paste Figma / Notion URL here)_  
+**Screenshot:** _(attach one screenshot of the piloted screen with checklist complete)_
+
+---
+
+## Pilot log
+
+| Screen | Designer | Engineer | Date | Outcome |
+|--------|----------|----------|------|---------|
+| Streams list | | | | |
+| Settle modal | | | | |
+
+---
+
+## Out of scope for this checklist
+
+- Next.js / React implementation (tracked as separate frontend issues)
+- Jest / RTL tests
+- Usability testing sessions (attach a separate one-page script if in scope for a given sprint)
+
+---
+
+*Commit convention for design artifacts: `design(figma): design QA checklist for Stellar/StreamPay money and stream screens`*


### PR DESCRIPTION
## Summary

Adds a 32-item yes/no/N/A design QA checklist covering all required categories before any stream or money screen moves to dev handoff.

## What's included

- `app/design-qa/checklist-data.ts` — typed checklist data (7 sections, 32 items)
- `app/design-qa/DesignChecklist.tsx` — interactive React component with progress bar, per-item note fields, and warning banner for any No items
- `app/design-qa/page.tsx` — live route at /design-qa
- `docs/design-qa-checklist.md` — static Markdown version to link from Figma cover pages

## Sections

1. Accessibility (8 items) — contrast, focus rings, colour-not-sole-indicator, touch targets, tab order, icon labels, reduced-motion
2. Irreversible money actions (6 items) — Settle, Withdraw, Stop confirmation, destructive styling, pending/error states
3. Interactive states (5 items) — all button/input states, StreamRow per-status actions, Modal animation
4. 8px grid and spacing (3 items)
5. Empty / loading / error states (3 items)
6. Figma dev mode and component naming (3 items) — aligned to StreamRow, StatusBadge, Modal, EmptyState, Card, Skeleton
7. Stellar / Soroban / Horizon / escrow annotations (4 items)

Closes #73
