### PR TITLE
Test identity Bearer token rejection paths

### DIFF
--- a/app/api/identity/me/route.test.ts
+++ b/app/api/identity/me/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+import jwt from "jsonwebtoken";
+import { GET } from "./route";
+
+const TEST_JWT_SECRET = "test-secret-at-least-32-characters-long";
+const DEV_JWT_SECRET = "streampay-dev-secret-do-not-use-in-prod";
+
+function requestWithAuth(authorization?: string) {
+  return new Request("http://localhost/api/identity/me", {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+function signToken(payload: Record<string, unknown>, secret = TEST_JWT_SECRET, options: jwt.SignOptions = {}) {
+  return jwt.sign(payload, secret, {
+    algorithm: "HS256",
+    expiresIn: "15m",
+    ...options,
+  });
+}
+
+function algNoneToken(payload: Record<string, unknown>) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.`;
+}
+
+describe("GET /api/identity/me auth", () => {
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  });
+
+  it("rejects requests with no authorization header", async () => {
+    const response = await GET(requestWithAuth());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects non-Bearer authorization headers", async () => {
+    const response = await GET(requestWithAuth("Basic dXNlcjpwYXNz"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects expired Bearer tokens", async () => {
+    const token = signToken({ sub: "GEXPIRED", actorId: "actor-expired" }, TEST_JWT_SECRET, {
+      expiresIn: "-1s",
+    });
+
+    const response = await GET(requestWithAuth(`Bearer ${token}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects Bearer tokens with a tampered signature", async () => {
+    const token = signToken({ sub: "GTAMPERED", actorId: "actor-tampered" });
+    const tamperedToken = `${token.slice(0, -1)}x`;
+
+    const response = await GET(requestWithAuth(`Bearer ${tamperedToken}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects alg=none Bearer tokens", async () => {
+    const token = algNoneToken({ sub: "GNONE", actorId: "actor-none" });
+
+    const response = await GET(requestWithAuth(`Bearer ${token}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects tokens signed with the insecure dev secret", async () => {
+    const token = signToken({ sub: "GDEVSECRET", actorId: "actor-dev" }, DEV_JWT_SECRET);
+
+    const response = await GET(requestWithAuth(`Bearer ${token}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects valid-looking tokens when JWT_SECRET is missing", async () => {
+    const token = signToken({ sub: "GMISSINGSECRET", actorId: "actor-missing" });
+    delete process.env.JWT_SECRET;
+
+    const response = await GET(requestWithAuth(`Bearer ${token}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns wallet identity for a valid Bearer token", async () => {
+    const token = signToken({ sub: "GVALIDWALLET", actorId: "actor-valid" });
+
+    const response = await GET(requestWithAuth(`Bearer ${token}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.wallet_address).toBe("GVALIDWALLET");
+    expect(body.data.display_name).toBe("GVALIDWALLET");
+    expect(body.links.self).toBe("/api/identity/me");
+  });
+});

--- a/app/api/identity/me/route.ts
+++ b/app/api/identity/me/route.ts
@@ -3,7 +3,7 @@ import { getClientIdentity, checkRateLimit, rateLimitResponse } from "@/app/lib/
 import { recordThrottle, recordRequest } from "@/app/lib/rate-limit-metrics";
 import { getLimitForRoute } from "@/app/lib/rate-limit-config";
 import { getCorrelationContext } from "@/app/lib/logger";
-import { tryAuthenticateRequest } from "@/app/lib/auth";
+import { hasConfiguredJwtSecret, tryAuthenticateRequest } from "@/app/lib/auth";
 
 function createErrorResponse(code: string, message: string, status: number) {
   const context = getCorrelationContext();
@@ -21,6 +21,10 @@ export async function GET(request: Request) {
     return rateLimitResponse(result.retryAfter!);
   }
   recordRequest(url.pathname);
+
+  if (!hasConfiguredJwtSecret()) {
+    return createErrorResponse("UNAUTHORIZED", "Missing or invalid authorization header", 401);
+  }
 
   const actor = tryAuthenticateRequest(request);
   if (!actor) {

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import type { AuditActorRole } from "@/app/types/audit";
 
 export const JWT_SECRET = process.env.JWT_SECRET || "streampay-dev-secret-do-not-use-in-prod";
+const DEV_JWT_SECRET = "streampay-dev-secret-do-not-use-in-prod";
 
 const VALID_ROLES = new Set<AuditActorRole>([
   "user",
@@ -47,6 +48,13 @@ function normalizeRole(role: string | undefined): AuditActorRole {
   return "user";
 }
 
+export function hasConfiguredJwtSecret(): boolean {
+  if (!process.env.JWT_SECRET || process.env.JWT_SECRET === DEV_JWT_SECRET) {
+    return false;
+  }
+  return true;
+}
+
 export function tryAuthenticateRequest(request: Request): AuthenticatedActor | null {
   const authHeader = request.headers?.get?.("authorization") ?? null;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -55,7 +63,9 @@ export function tryAuthenticateRequest(request: Request): AuthenticatedActor | n
 
   const token = authHeader.slice(7);
   try {
-    const verified = jwt.verify(token, JWT_SECRET) as TokenClaims;
+    const verified = jwt.verify(token, process.env.JWT_SECRET || DEV_JWT_SECRET, {
+      algorithms: ["HS256"],
+    }) as TokenClaims;
     if (!verified.sub) {
       return null;
     }


### PR DESCRIPTION
## Summary
- add focused `GET /api/identity/me` tests for missing, non-Bearer, expired, tampered, `alg=none`, insecure dev-secret, and missing-secret token paths
- assert valid tokens still return the wallet identity fields
- require `/api/identity/me` to fail closed when `JWT_SECRET` is missing or left at the insecure dev fallback
- restrict JWT verification to HS256

Closes #248.

## Validation
- `npm test -- app/api/identity/me/route.test.ts --runInBand --forceExit`
- `git diff --check`

## Notes
- `npm run build` currently fails before this change is reached because `app/api/activity/route.ts` has an existing syntax error at line 65.
- Existing wallet route tests also fail locally on Node 24 with `TypeError: Invalid digest: ed25519`; the new identity route test itself passes.