### PR TITLE
Add reduced-motion-safe toggle states

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -501,7 +501,13 @@ a:hover {
 }
 
 .toggle-button--active { background-color: var(--accent); }
-.toggle-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
+.toggle-button:not(:disabled):hover { background-color: #3f3f46; }
+.toggle-button:not(:disabled):active { transform: scale(0.96); }
+.toggle-button--active:not(:disabled):hover { background-color: var(--accent-hover); }
+.toggle-button:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 4px;
+}
 .toggle-button:disabled { cursor: not-allowed; opacity: 0.5; }
 
 .toggle-thumb {
@@ -516,6 +522,17 @@ a:hover {
 }
 
 .toggle-button--active .toggle-thumb { transform: translateX(20px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .toggle-button,
+  .toggle-thumb {
+    transition: none;
+  }
+
+  .toggle-button:not(:disabled):active {
+    transform: none;
+  }
+}
 
 .alert {
   border-radius: 0.75rem;


### PR DESCRIPTION
Closes #214.

## Summary
- add visible hover and active states for enabled settings toggles
- strengthen the keyboard focus ring contrast using the existing accent-strong token
- disable toggle transitions and active scaling under `prefers-reduced-motion: reduce`
- keep the thumb-position state indicator intact so on/off is not color-only

## Validation
- `git diff --check`

## Notes
- `npm run lint` and `npm run build` both fail on the existing unrelated parse error in `app/api/activity/route.ts:65`, which is also blocking the current main branch checks outside this CSS change.