### PR TITLE
feat: add dependency-aware readiness checks

### DIFF
--- a/app/api/healthz/route.test.ts
+++ b/app/api/healthz/route.test.ts
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+
+import { GET } from "./route";
+
+describe("GET /api/healthz", () => {
+  it("returns process liveness without dependency checks", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(new Date(body.checked_at).toString()).not.toBe("Invalid Date");
+  });
+});

--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    checked_at: new Date().toISOString(),
+  });
+}

--- a/app/api/readyz/route.test.ts
+++ b/app/api/readyz/route.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+
+import { GET } from "./route";
+import { getReadinessReport } from "../../lib/health";
+
+jest.mock("../../lib/health", () => ({
+  getReadinessReport: jest.fn(),
+}));
+
+const mockedGetReadinessReport = getReadinessReport as jest.MockedFunction<typeof getReadinessReport>;
+
+describe("GET /api/readyz", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns 200 when all readiness checks pass", async () => {
+    mockedGetReadinessReport.mockResolvedValue({
+      status: "ok",
+      checks: {
+        config: { status: "ok", checked_at: "2026-05-27T00:00:00.000Z" },
+        stellar: { status: "ok", checked_at: "2026-05-27T00:00:00.000Z" },
+        kms: { status: "ok", checked_at: "2026-05-27T00:00:00.000Z" },
+      },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it("returns 503 with per-dependency detail when a dependency is degraded", async () => {
+    mockedGetReadinessReport.mockResolvedValue({
+      status: "degraded",
+      checks: {
+        config: { status: "ok", checked_at: "2026-05-27T00:00:00.000Z" },
+        stellar: {
+          status: "degraded",
+          message: "Horizon timeout",
+          checked_at: "2026-05-27T00:00:00.000Z",
+        },
+        kms: { status: "ok", checked_at: "2026-05-27T00:00:00.000Z" },
+      },
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      status: "degraded",
+      checks: {
+        stellar: { status: "degraded", message: "Horizon timeout" },
+      },
+    });
+  });
+});

--- a/app/api/readyz/route.ts
+++ b/app/api/readyz/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { getReadinessReport } from "@/app/lib/health";
 
 export async function GET() {
-  return NextResponse.json({ status: "ok" });
+  const report = await getReadinessReport();
+  return NextResponse.json(report, { status: report.status === "ok" ? 200 : 503 });
 }

--- a/app/lib/health.test.ts
+++ b/app/lib/health.test.ts
@@ -1,0 +1,116 @@
+/** @jest-environment node */
+
+import { getReadinessReport } from "./health";
+
+const fixedNow = () => new Date("2026-05-27T00:00:00.000Z");
+
+function createOkStellarClient() {
+  return {
+    readAccount: jest.fn().mockResolvedValue({ horizon: "ok" }),
+    readBalances: jest.fn(),
+    writeJson: jest.fn(),
+    getCircuitMetrics: jest.fn(),
+    getCircuitState: jest.fn().mockReturnValue("closed"),
+  };
+}
+
+function createConfig() {
+  return {
+    network: {
+      name: "testnet" as const,
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      passphrase: "Test SDF Network ; September 2015",
+      hasFriendbot: true,
+      friendbotUrl: "https://friendbot.stellar.org",
+      explorerUrl: "https://stellar.expert/testnet",
+      assetLabel: "TESTNET",
+      isProduction: false,
+    },
+    jwtSecret: "test-secret-at-least-32-characters-long",
+    serviceName: "streampay-test",
+    environment: "test",
+    allowedOrigins: ["http://localhost:3000"],
+    anomalyThresholds: {
+      creationBurstLimit: 50,
+      settleRateLimit: 20,
+    },
+  };
+}
+
+describe("readiness health checks", () => {
+  it("reports ok when config, Stellar, and KMS checks pass", async () => {
+    const stellarClient = createOkStellarClient();
+
+    const report = await getReadinessReport({
+      now: fixedNow,
+      validateConfig: jest.fn().mockReturnValue(createConfig()),
+      getSigner: jest.fn().mockReturnValue({ getPublicKey: jest.fn().mockResolvedValue("GABC") }),
+      createStellarClient: jest.fn().mockReturnValue(stellarClient),
+    });
+
+    expect(report.status).toBe("ok");
+    expect(report.checks.config.status).toBe("ok");
+    expect(report.checks.stellar.status).toBe("ok");
+    expect(report.checks.kms.status).toBe("ok");
+    expect(stellarClient.readAccount).toHaveBeenCalledWith({
+      url: "https://horizon-testnet.stellar.org",
+      address: "testnet",
+      critical: true,
+    });
+  });
+
+  it("reports degraded when configuration validation fails", async () => {
+    const report = await getReadinessReport({
+      now: fixedNow,
+      validateConfig: jest.fn(() => {
+        throw new Error("JWT_SECRET environment variable is required");
+      }),
+      getSigner: jest.fn().mockReturnValue({ getPublicKey: jest.fn().mockResolvedValue("GABC") }),
+      createStellarClient: jest.fn().mockReturnValue(createOkStellarClient()),
+    });
+
+    expect(report.status).toBe("degraded");
+    expect(report.checks.config).toMatchObject({
+      status: "degraded",
+      message: "JWT_SECRET environment variable is required",
+    });
+    expect(report.checks.stellar.status).toBe("degraded");
+  });
+
+  it("reports degraded when Stellar is unreachable", async () => {
+    const stellarClient = {
+      ...createOkStellarClient(),
+      readAccount: jest.fn().mockRejectedValue(new Error("Horizon timeout")),
+    };
+
+    const report = await getReadinessReport({
+      now: fixedNow,
+      validateConfig: jest.fn().mockReturnValue(createConfig()),
+      getSigner: jest.fn().mockReturnValue({ getPublicKey: jest.fn().mockResolvedValue("GABC") }),
+      createStellarClient: jest.fn().mockReturnValue(stellarClient),
+    });
+
+    expect(report.status).toBe("degraded");
+    expect(report.checks.stellar).toMatchObject({
+      status: "degraded",
+      message: "Horizon timeout",
+    });
+  });
+
+  it("reports degraded when the signer is unavailable", async () => {
+    const report = await getReadinessReport({
+      now: fixedNow,
+      validateConfig: jest.fn().mockReturnValue(createConfig()),
+      getSigner: jest.fn().mockReturnValue({
+        getPublicKey: jest.fn().mockRejectedValue(new Error("KMS unavailable")),
+      }),
+      createStellarClient: jest.fn().mockReturnValue(createOkStellarClient()),
+    });
+
+    expect(report.status).toBe("degraded");
+    expect(report.checks.kms).toMatchObject({
+      status: "degraded",
+      message: "KMS unavailable",
+    });
+  });
+});

--- a/app/lib/health.ts
+++ b/app/lib/health.ts
@@ -1,0 +1,92 @@
+import { validateConfig } from "@/app/lib/config";
+import { getSigner } from "@/app/lib/kms/factory";
+import { createResilientStellarClient } from "@/app/lib/stellarClient";
+
+export type HealthStatus = "ok" | "degraded";
+
+export type DependencyCheckResult = {
+  status: HealthStatus;
+  message?: string;
+  checked_at: string;
+};
+
+export type ReadinessReport = {
+  status: HealthStatus;
+  checks: Record<string, DependencyCheckResult>;
+};
+
+export type HealthCheckDependencies = {
+  now?: () => Date;
+  validateConfig?: typeof validateConfig;
+  getSigner?: typeof getSigner;
+  createStellarClient?: typeof createResilientStellarClient;
+};
+
+async function runCheck(
+  now: () => Date,
+  check: () => Promise<void> | void,
+): Promise<DependencyCheckResult> {
+  const checkedAt = now().toISOString();
+  try {
+    await check();
+    return { status: "ok", checked_at: checkedAt };
+  } catch (error) {
+    return {
+      status: "degraded",
+      message: error instanceof Error ? error.message : "Dependency check failed.",
+      checked_at: checkedAt,
+    };
+  }
+}
+
+export async function getReadinessReport(
+  dependencies: HealthCheckDependencies = {},
+): Promise<ReadinessReport> {
+  const now = dependencies.now ?? (() => new Date());
+  const validate = dependencies.validateConfig ?? validateConfig;
+  const signerFactory = dependencies.getSigner ?? getSigner;
+  const stellarClientFactory = dependencies.createStellarClient ?? createResilientStellarClient;
+
+  const configCheck = await runCheck(now, () => {
+    validate();
+  });
+
+  let horizonUrl = "";
+  const stellarCheck = await runCheck(now, async () => {
+    const config = validate();
+    horizonUrl = config.network.horizonUrl;
+    const client = stellarClientFactory({
+      tenant: "readiness",
+      network: config.network.name,
+      timeoutMs: 2000,
+      circuitBreaker: { failureThreshold: 1 },
+    });
+    await client.readAccount<unknown>({
+      url: config.network.horizonUrl,
+      address: config.network.name,
+      critical: true,
+    });
+  });
+
+  const kmsCheck = await runCheck(now, async () => {
+    const signer = signerFactory();
+    const publicKey = await signer.getPublicKey();
+    if (!publicKey) {
+      throw new Error("KMS signer did not return a public key.");
+    }
+  });
+
+  const checks: ReadinessReport["checks"] = {
+    config: configCheck,
+    stellar: {
+      ...stellarCheck,
+      ...(horizonUrl && stellarCheck.status === "ok" ? { message: `reachable: ${horizonUrl}` } : {}),
+    },
+    kms: kmsCheck,
+  };
+
+  return {
+    status: Object.values(checks).every((check) => check.status === "ok") ? "ok" : "degraded",
+    checks,
+  };
+}


### PR DESCRIPTION
Closes #227

## Summary
- Add a dependency-aware readiness report covering config validation, Stellar/Horizon access, and KMS signer access.
- Return 503 from /api/readyz when a dependency is degraded, with per-check details.
- Add a lightweight /api/healthz liveness endpoint.

## Verification
- npm test -- app/lib/health.test.ts app/api/readyz/route.test.ts app/api/healthz/route.test.ts --runInBand --forceExit
- npx eslint app/lib/health.ts app/lib/health.test.ts app/api/readyz/route.ts app/api/readyz/route.test.ts app/api/healthz/route.ts app/api/healthz/route.test.ts
- git diff --check

Note: Jest prints the repo-existing empty package-lock JSON warning before tests, but the focused suites pass.