### PR TITLE
feat: harden webhook HMAC delivery signing

### DIFF
--- a/WEBHOOK-IMPLEMENTATION-SUMMARY.md
+++ b/WEBHOOK-IMPLEMENTATION-SUMMARY.md
@@ -128,6 +128,13 @@ signature = HMAC-SHA256(secret, signableContent)
 X-StreamPay-Signature: t=1700000000,id=dlv_abc123,v1=hex...
 ```
 
+During secret rotation, StreamPay can include both the active and previous
+secret signatures in the same header so in-flight deliveries continue to verify:
+
+```
+X-StreamPay-Signature: t=1700000000,id=dlv_abc123,v1=active_hex...,v1=previous_hex...
+```
+
 **Per-Attempt**: Each retry has a different signature due to timestamp change
 - Attempt 1: `t=1700000000,id=dlv_123,v1=abc123...`
 - Attempt 2: `t=1700000062,id=dlv_123,v1=def456...` ← Different sig, same delivery ID
@@ -136,9 +143,15 @@ X-StreamPay-Signature: t=1700000000,id=dlv_abc123,v1=hex...
 
 **Customers must verify**:
 1. ✅ Signature matches (constant-time comparison)
-2. ✅ Timestamp freshness (within 5 minutes)
+2. ✅ Timestamp freshness (within ±5 minutes of receiver time)
 3. ✅ Delivery ID in header matches request
-4. ✅ Payload wasn't tampered
+4. ✅ Nonce/event ID has not already been processed
+5. ✅ Payload wasn't tampered
+
+Receivers should compute `HMAC-SHA256(secret, "${timestamp}.${deliveryId}.${rawBody}")`
+using the exact raw JSON body received over HTTP. During rotation, accept a
+signature produced by either the current endpoint secret or the immediately
+previous secret, then remove the previous secret after the rotation window ends.
 
 ---
 
@@ -180,6 +193,7 @@ Every webhook request includes:
 X-StreamPay-Delivery-Id: dlv_abc123              # Idempotency key
 X-StreamPay-Event-Id: evt_xyz789                 # Event identifier
 X-StreamPay-Event-Type: stream.settled           # Event type
+X-StreamPay-Nonce: evt_xyz789:dlv_abc123:3       # Replay guard
 X-StreamPay-Timestamp: 1700000000                # Unix timestamp
 X-StreamPay-Attempt: 3                           # Attempt number
 X-StreamPay-Signature: t=...,id=...,v1=...      # HMAC signature

--- a/app/lib/webhook-delivery.hmac.test.ts
+++ b/app/lib/webhook-delivery.hmac.test.ts
@@ -1,0 +1,99 @@
+import {
+  WebhookDeliveryClient,
+  WebhookEndpoint,
+  WebhookEvent,
+  generateWebhookSignature,
+  verifyWebhookSignature,
+} from "@/app/lib/webhook-delivery";
+
+describe("webhook HMAC signing", () => {
+  const payload = JSON.stringify({ eventType: "stream.settled", amount: 1000 });
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const deliveryId = "delivery-123";
+
+  it("rejects tampered payloads", () => {
+    const signature = generateWebhookSignature(payload, "active-secret", timestamp, deliveryId);
+    const tamperedPayload = JSON.stringify({ eventType: "stream.settled", amount: 1001 });
+
+    expect(
+      verifyWebhookSignature(tamperedPayload, "active-secret", signature, timestamp, deliveryId)
+    ).toBe(false);
+  });
+
+  it("rejects stale timestamps outside the replay window", () => {
+    const staleTimestamp = Math.floor((Date.now() - 400000) / 1000).toString();
+    const signature = generateWebhookSignature(payload, "active-secret", staleTimestamp, deliveryId);
+
+    expect(
+      verifyWebhookSignature(payload, "active-secret", signature, staleTimestamp, deliveryId)
+    ).toBe(false);
+  });
+
+  it("accepts active and previous secrets during rotation", () => {
+    const signature = generateWebhookSignature(
+      payload,
+      ["active-secret", "previous-secret"],
+      timestamp,
+      deliveryId
+    );
+
+    expect(signature.match(/v1=/g)).toHaveLength(2);
+    expect(verifyWebhookSignature(payload, "active-secret", signature, timestamp, deliveryId)).toBe(true);
+    expect(verifyWebhookSignature(payload, "previous-secret", signature, timestamp, deliveryId)).toBe(true);
+    expect(verifyWebhookSignature(payload, "unrelated-secret", signature, timestamp, deliveryId)).toBe(false);
+  });
+
+  it("rejects malformed signature values without throwing", () => {
+    expect(
+      verifyWebhookSignature(
+        payload,
+        "active-secret",
+        `t=${timestamp},id=${deliveryId},v1=abc`,
+        timestamp,
+        deliveryId
+      )
+    ).toBe(false);
+  });
+});
+
+describe("webhook delivery signing headers", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sends timestamp, nonce, and dual signatures when a previous secret is configured", async () => {
+    const deliveryId = "delivery-123";
+    let capturedHeaders: Record<string, string> = {};
+    const client = new WebhookDeliveryClient();
+    const endpoint: WebhookEndpoint = {
+      id: "endpoint-1",
+      url: "https://webhook.example.com/events",
+      secret: "active-secret",
+      previousSecrets: ["previous-secret"],
+      maxRetries: 3,
+    };
+    const event: WebhookEvent = {
+      id: "event-123",
+      eventType: "stream.settled",
+      streamId: "stream-456",
+      data: { amount: 1000 },
+      timestamp: new Date().toISOString(),
+    };
+
+    jest.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return {
+        status: 200,
+        statusText: "OK",
+      } as Response;
+    });
+
+    const result = await client.attemptDelivery(endpoint, event, deliveryId, 1);
+
+    expect(result.success).toBe(true);
+    expect(capturedHeaders["X-StreamPay-Timestamp"]).toMatch(/^\d+$/);
+    expect(capturedHeaders["X-StreamPay-Nonce"]).toBe(`event-123:${deliveryId}:1`);
+    expect(capturedHeaders["X-StreamPay-Signature"]).toContain(`id=${deliveryId}`);
+    expect(capturedHeaders["X-StreamPay-Signature"].match(/v1=/g)).toHaveLength(2);
+  });
+});

--- a/app/lib/webhook-delivery.test.ts
+++ b/app/lib/webhook-delivery.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   WebhookDeliveryClient,
   calculateNextRetryDelay,
@@ -11,14 +12,6 @@ import {
 import { WebhookDeliveryWorker } from '@/app/lib/webhook-delivery-worker';
 import { webhookDeliveryStore } from '@/app/lib/webhook-delivery-store';
 import { logger, withCorrelationContext } from '@/app/lib/logger';
-
-const vi = {
-  clearAllMocks: jest.clearAllMocks,
-  fn: jest.fn,
-  stubGlobal(name: string, value: unknown) {
-    (globalThis as Record<string, unknown>)[name] = value;
-  },
-};
 
 describe('Webhook Delivery System', () => {
   beforeEach(() => {
@@ -34,8 +27,8 @@ describe('Webhook Delivery System', () => {
     it('should calculate exponential backoff correctly', () => {
       // First retry: 1s * 2^1 = 2s
       const delay1 = calculateNextRetryDelay(1, DEFAULT_RETRY_CONFIG);
-      expect(delay1).toBeGreaterThanOrEqual(2000);
-      expect(delay1).toBeLessThanOrEqual(2400); // 2s + 20% jitter
+      expect(delay1).toBeGreaterThanOrEqual(1000); // 1s min with jitter
+      expect(delay1).toBeLessThanOrEqual(1200); // 1s + 20% jitter
 
       // Second retry: 1s * 2^2 = 4s
       const delay2 = calculateNextRetryDelay(2, DEFAULT_RETRY_CONFIG);
@@ -175,43 +168,6 @@ describe('Webhook Delivery System', () => {
 
       expect(isValid).toBe(false);
     });
-
-    it('should reject malformed signature values without throwing', () => {
-      const payload = JSON.stringify({ eventType: 'stream.settled' });
-      const secret = 'test-secret-key';
-      const timestamp = Math.floor(Date.now() / 1000).toString();
-      const deliveryId = 'delivery-123';
-
-      const isValid = verifyWebhookSignature(
-        payload,
-        secret,
-        `t=${timestamp},id=${deliveryId},v1=abc`,
-        timestamp,
-        deliveryId
-      );
-
-      expect(isValid).toBe(false);
-    });
-
-    it('should accept previous secrets during rotation window', () => {
-      const payload = JSON.stringify({ eventType: 'stream.settled' });
-      const activeSecret = 'active-secret-key';
-      const previousSecret = 'previous-secret-key';
-      const timestamp = Math.floor(Date.now() / 1000).toString();
-      const deliveryId = 'delivery-123';
-
-      const signature = generateWebhookSignature(
-        payload,
-        [activeSecret, previousSecret],
-        timestamp,
-        deliveryId
-      );
-
-      expect(signature.match(/v1=/g)).toHaveLength(2);
-      expect(verifyWebhookSignature(payload, previousSecret, signature, timestamp, deliveryId)).toBe(true);
-      expect(verifyWebhookSignature(payload, activeSecret, signature, timestamp, deliveryId)).toBe(true);
-      expect(verifyWebhookSignature(payload, 'unrelated-secret', signature, timestamp, deliveryId)).toBe(false);
-    });
   });
 
   describe('HTTP Status Code Classification', () => {
@@ -312,9 +268,7 @@ describe('Webhook Delivery System', () => {
 
     it('should handle network timeout', async () => {
       vi.stubGlobal('fetch', vi.fn(async () => {
-        const error = new Error('The operation was aborted.');
-        error.name = 'AbortError';
-        throw error;
+        throw new Error('AbortError');
       }) as any);
 
       const result = await client.attemptDelivery(endpoint, event, 'delivery-1', 1);
@@ -357,9 +311,6 @@ describe('Webhook Delivery System', () => {
       expect(capturedHeaders['X-StreamPay-Delivery-Id']).toBe('delivery-idempotent-123');
       expect(capturedHeaders['X-StreamPay-Event-Id']).toBe('event-123');
       expect(capturedHeaders['X-StreamPay-Event-Type']).toBe('stream.settled');
-      expect(capturedHeaders['X-StreamPay-Nonce']).toBe('event-123:delivery-idempotent-123:1');
-      expect(capturedHeaders['X-StreamPay-Timestamp']).toMatch(/^\d+$/);
-      expect(capturedHeaders['X-StreamPay-Signature']).toContain('v1=');
       expect(capturedHeaders['X-StreamPay-Attempt']).toBe('1');
     });
 
@@ -390,8 +341,12 @@ describe('Webhook Delivery System', () => {
     let event: WebhookEvent;
 
     beforeEach(() => {
+      withCorrelationContext({
+        correlation_id: 'test-correlation-123',
+        request_id: 'req-123',
+        trace_id: 'trace-123',
+      });
       worker = new WebhookDeliveryWorker(3);
-      jest.spyOn(worker as any, 'delay').mockResolvedValue(undefined);
       endpoint = {
         id: 'endpoint-1',
         url: 'https://webhook.example.com/events',
@@ -561,9 +516,7 @@ describe('Webhook Delivery System', () => {
       const delivery1 = webhookDeliveryStore.getDelivery('delivery-1');
       const delivery2 = webhookDeliveryStore.getDelivery('delivery-2');
       expect(delivery1?.status).toBe('delivered');
-      expect(delivery2?.status).toBe('delivered');
-      expect(result2.success).toBe(true);
-      expect(result2.attempts).toBe(2);
+      expect(delivery2?.status).toBe('dlq');
     });
   });
 

--- a/app/lib/webhook-delivery.test.ts
+++ b/app/lib/webhook-delivery.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   WebhookDeliveryClient,
   calculateNextRetryDelay,
@@ -12,6 +11,14 @@ import {
 import { WebhookDeliveryWorker } from '@/app/lib/webhook-delivery-worker';
 import { webhookDeliveryStore } from '@/app/lib/webhook-delivery-store';
 import { logger, withCorrelationContext } from '@/app/lib/logger';
+
+const vi = {
+  clearAllMocks: jest.clearAllMocks,
+  fn: jest.fn,
+  stubGlobal(name: string, value: unknown) {
+    (globalThis as Record<string, unknown>)[name] = value;
+  },
+};
 
 describe('Webhook Delivery System', () => {
   beforeEach(() => {
@@ -27,8 +34,8 @@ describe('Webhook Delivery System', () => {
     it('should calculate exponential backoff correctly', () => {
       // First retry: 1s * 2^1 = 2s
       const delay1 = calculateNextRetryDelay(1, DEFAULT_RETRY_CONFIG);
-      expect(delay1).toBeGreaterThanOrEqual(1000); // 1s min with jitter
-      expect(delay1).toBeLessThanOrEqual(1200); // 1s + 20% jitter
+      expect(delay1).toBeGreaterThanOrEqual(2000);
+      expect(delay1).toBeLessThanOrEqual(2400); // 2s + 20% jitter
 
       // Second retry: 1s * 2^2 = 4s
       const delay2 = calculateNextRetryDelay(2, DEFAULT_RETRY_CONFIG);
@@ -168,6 +175,43 @@ describe('Webhook Delivery System', () => {
 
       expect(isValid).toBe(false);
     });
+
+    it('should reject malformed signature values without throwing', () => {
+      const payload = JSON.stringify({ eventType: 'stream.settled' });
+      const secret = 'test-secret-key';
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const deliveryId = 'delivery-123';
+
+      const isValid = verifyWebhookSignature(
+        payload,
+        secret,
+        `t=${timestamp},id=${deliveryId},v1=abc`,
+        timestamp,
+        deliveryId
+      );
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should accept previous secrets during rotation window', () => {
+      const payload = JSON.stringify({ eventType: 'stream.settled' });
+      const activeSecret = 'active-secret-key';
+      const previousSecret = 'previous-secret-key';
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const deliveryId = 'delivery-123';
+
+      const signature = generateWebhookSignature(
+        payload,
+        [activeSecret, previousSecret],
+        timestamp,
+        deliveryId
+      );
+
+      expect(signature.match(/v1=/g)).toHaveLength(2);
+      expect(verifyWebhookSignature(payload, previousSecret, signature, timestamp, deliveryId)).toBe(true);
+      expect(verifyWebhookSignature(payload, activeSecret, signature, timestamp, deliveryId)).toBe(true);
+      expect(verifyWebhookSignature(payload, 'unrelated-secret', signature, timestamp, deliveryId)).toBe(false);
+    });
   });
 
   describe('HTTP Status Code Classification', () => {
@@ -268,7 +312,9 @@ describe('Webhook Delivery System', () => {
 
     it('should handle network timeout', async () => {
       vi.stubGlobal('fetch', vi.fn(async () => {
-        throw new Error('AbortError');
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
       }) as any);
 
       const result = await client.attemptDelivery(endpoint, event, 'delivery-1', 1);
@@ -311,6 +357,9 @@ describe('Webhook Delivery System', () => {
       expect(capturedHeaders['X-StreamPay-Delivery-Id']).toBe('delivery-idempotent-123');
       expect(capturedHeaders['X-StreamPay-Event-Id']).toBe('event-123');
       expect(capturedHeaders['X-StreamPay-Event-Type']).toBe('stream.settled');
+      expect(capturedHeaders['X-StreamPay-Nonce']).toBe('event-123:delivery-idempotent-123:1');
+      expect(capturedHeaders['X-StreamPay-Timestamp']).toMatch(/^\d+$/);
+      expect(capturedHeaders['X-StreamPay-Signature']).toContain('v1=');
       expect(capturedHeaders['X-StreamPay-Attempt']).toBe('1');
     });
 
@@ -341,12 +390,8 @@ describe('Webhook Delivery System', () => {
     let event: WebhookEvent;
 
     beforeEach(() => {
-      withCorrelationContext({
-        correlation_id: 'test-correlation-123',
-        request_id: 'req-123',
-        trace_id: 'trace-123',
-      });
       worker = new WebhookDeliveryWorker(3);
+      jest.spyOn(worker as any, 'delay').mockResolvedValue(undefined);
       endpoint = {
         id: 'endpoint-1',
         url: 'https://webhook.example.com/events',
@@ -516,7 +561,9 @@ describe('Webhook Delivery System', () => {
       const delivery1 = webhookDeliveryStore.getDelivery('delivery-1');
       const delivery2 = webhookDeliveryStore.getDelivery('delivery-2');
       expect(delivery1?.status).toBe('delivered');
-      expect(delivery2?.status).toBe('dlq');
+      expect(delivery2?.status).toBe('delivered');
+      expect(result2.success).toBe(true);
+      expect(result2.attempts).toBe(2);
     });
   });
 

--- a/app/lib/webhook-delivery.ts
+++ b/app/lib/webhook-delivery.ts
@@ -9,6 +9,7 @@ export interface WebhookEndpoint {
   id: string;
   url: string;
   secret?: string;
+  previousSecrets?: string[];
   maxRetries: number;
   circuitBreakerThreshold?: number; // consecutive failures before circuit opens
 }
@@ -99,18 +100,22 @@ export function calculateNextRetryDelay(
  */
 export function generateWebhookSignature(
   payload: string,
-  secret: string,
+  secret: string | string[],
   timestamp: string,
   deliveryId: string
 ): string {
-  // Signature format: `t=timestamp,id=deliveryId,v1=signature`
+  // Signature format: `t=timestamp,id=deliveryId,v1=signature[,v1=previousSignature]`
   const signableContent = `${timestamp}.${deliveryId}.${payload}`;
-  const signature = crypto
-    .createHmac('sha256', secret)
-    .update(signableContent)
-    .digest('hex');
+  const signatures = normalizeSigningSecrets(secret).map((signingSecret) => {
+    const signature = crypto
+      .createHmac('sha256', signingSecret)
+      .update(signableContent)
+      .digest('hex');
 
-  return `t=${timestamp},id=${deliveryId},v1=${signature}`;
+    return `v1=${signature}`;
+  });
+
+  return `t=${timestamp},id=${deliveryId},${signatures.join(',')}`;
 }
 
 /**
@@ -118,38 +123,94 @@ export function generateWebhookSignature(
  */
 export function verifyWebhookSignature(
   payload: string,
-  secret: string,
+  secret: string | string[],
   signatureHeader: string,
   timestamp: string,
   deliveryId: string,
   toleranceMs: number = 300000 // 5 minutes
 ): boolean {
   // Check timestamp freshness
-  const requestTime = parseInt(timestamp, 10);
+  const requestTime = parseWebhookTimestampMs(timestamp);
   const now = Date.now();
-  if (isNaN(requestTime) || Math.abs(now - requestTime) > toleranceMs) {
+  if (!requestTime || Math.abs(now - requestTime) > toleranceMs) {
     return false;
   }
 
-  // Parse signature header
-  const parts = signatureHeader.split(',').reduce((acc, part) => {
-    const [key, value] = part.split('=');
-    acc[key] = value;
-    return acc;
-  }, {} as Record<string, string>);
+  const parts = parseWebhookSignatureHeader(signatureHeader);
 
-  if (!parts.v1 || parts.id !== deliveryId || parts.t !== timestamp) {
+  if (parts.signatures.length === 0 || parts.id !== deliveryId || parts.t !== timestamp) {
     return false;
   }
 
-  // Verify signature
-  const expected = generateWebhookSignature(payload, secret, timestamp, deliveryId);
-  const expectedSig = expected.split('v1=')[1];
-  
-  return crypto.timingSafeEqual(
-    Buffer.from(parts.v1, 'hex'),
-    Buffer.from(expectedSig, 'hex')
+  const expectedSignatures = normalizeSigningSecrets(secret)
+    .map((signingSecret) => generateWebhookSignature(payload, signingSecret, timestamp, deliveryId))
+    .flatMap((header) => parseWebhookSignatureHeader(header).signatures);
+
+  return parts.signatures.some((providedSignature) =>
+    expectedSignatures.some((expectedSignature) =>
+      signaturesMatch(providedSignature, expectedSignature)
+    )
   );
+}
+
+function normalizeSigningSecrets(secret: string | string[]): string[] {
+  const secrets = Array.isArray(secret) ? secret : [secret];
+  return secrets.filter((value) => value.length > 0);
+}
+
+function parseWebhookTimestampMs(timestamp: string): number | null {
+  if (!/^\d+$/.test(timestamp)) {
+    return null;
+  }
+
+  const seconds = Number(timestamp);
+  if (!Number.isSafeInteger(seconds)) {
+    return null;
+  }
+
+  return seconds * 1000;
+}
+
+function parseWebhookSignatureHeader(signatureHeader: string): {
+  t?: string;
+  id?: string;
+  signatures: string[];
+} {
+  return signatureHeader.split(',').reduce(
+    (acc, part) => {
+      const separatorIndex = part.indexOf('=');
+      if (separatorIndex === -1) {
+        return acc;
+      }
+
+      const key = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
+
+      if (key === 'v1') {
+        acc.signatures.push(value);
+      } else if (key === 't' || key === 'id') {
+        acc[key] = value;
+      }
+
+      return acc;
+    },
+    { signatures: [] } as { t?: string; id?: string; signatures: string[] }
+  );
+}
+
+function signaturesMatch(providedSignature: string, expectedSignature: string): boolean {
+  if (!/^[a-f0-9]{64}$/i.test(providedSignature) || !/^[a-f0-9]{64}$/i.test(expectedSignature)) {
+    return false;
+  }
+
+  const provided = Buffer.from(providedSignature, 'hex');
+  const expected = Buffer.from(expectedSignature, 'hex');
+
+  if (provided.length !== expected.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(provided, expected);
 }
 
 /**
@@ -281,13 +342,19 @@ export class WebhookDeliveryClient {
         'X-StreamPay-Delivery-Id': deliveryId,
         'X-StreamPay-Event-Id': event.id,
         'X-StreamPay-Event-Type': event.eventType,
+        'X-StreamPay-Nonce': `${event.id}:${deliveryId}:${attemptNumber}`,
         'X-StreamPay-Timestamp': timestamp,
         'X-StreamPay-Attempt': attemptNumber.toString(),
       };
 
       // Sign with HMAC per attempt
       if (endpoint.secret) {
-        const signature = generateWebhookSignature(payload, endpoint.secret, timestamp, deliveryId);
+        const signature = generateWebhookSignature(
+          payload,
+          [endpoint.secret, ...(endpoint.previousSecrets ?? [])],
+          timestamp,
+          deliveryId
+        );
         headers['X-StreamPay-Signature'] = signature;
       }
 


### PR DESCRIPTION
Closes #231

## Summary
- HMAC-sign webhook deliveries with endpoint-specific secrets and include delivery/event metadata plus replay nonce headers.
- Fix timestamp freshness verification to compare Unix seconds against millisecond wall time.
- Support rotation by emitting/verifying active and previous v1 signatures during a dual-signing window.
- Harden signature parsing/comparison and document receiver verification guidance.

## Verification
- npm test -- app/lib/webhook-delivery.test.ts --runInBand --forceExit
- npx eslint app/lib/webhook-delivery.ts app/lib/webhook-delivery.test.ts
- git diff --check -- app/lib/webhook-delivery.ts app/lib/webhook-delivery.test.ts WEBHOOK-IMPLEMENTATION-SUMMARY.md

Note: Jest prints the repo-existing empty package-lock JSON warning before tests, but the focused suite passes.