### PR TITLE
feat: introduce pluggable persistent store for stream state

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ eventually consistent; balances and account state may lag the chain by the cache
 Auth and write operations are never cached. Cache keys must include the tenant and account address to
 prevent cross-tenant data leakage.
 
+## Persistence seam
+
+Backend stream, idempotency, export, and activity state now sits behind a
+pluggable repository interface.
+
+- Default adapter: in-memory (`app/lib/repositories/in-memory.ts`)
+- Durable seam: PostgreSQL-oriented adapter contract (`app/lib/repositories/postgres.ts`)
+- Design notes and rollout plan: [docs/persistent-store-interface.md](docs/persistent-store-interface.md)
+
+The default runtime behavior remains in-memory until the SQL migration track
+cuts the durable adapter in.
+
 ## Prerequisites
 
 - Node.js 18+

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { db, encodeCursor, decodeCursor } from "@/app/lib/db";
-import { getClientIdentity, checkRateLimit, rateLimitResponse } from "@/app/lib/rate-limit";
-import { recordThrottle, recordRequest } from "@/app/lib/rate-limit-metrics";
+import { decodeCursor, encodeCursor, getStore } from "@/app/lib/db";
+import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
 import { getLimitForRoute } from "@/app/lib/rate-limit-config";
-import { logger, withCorrelationContext, getCorrelationContext } from "@/app/lib/logger";
+import { recordRequest, recordThrottle } from "@/app/lib/rate-limit-metrics";
+import { getCorrelationContext, logger, withCorrelationContext } from "@/app/lib/logger";
 
 function createErrorResponse(code: string, message: string, status: number) {
   const context = getCorrelationContext();
@@ -11,6 +11,7 @@ function createErrorResponse(code: string, message: string, status: number) {
 }
 
 export async function GET(request: Request) {
+  const { streamRepository } = getStore();
   const url = new URL(request.url);
   const limitType = getLimitForRoute("GET", url.pathname);
   const identity = getClientIdentity(request);
@@ -26,7 +27,7 @@ export async function GET(request: Request) {
   const cursor = searchParams.get("cursor");
   const streamId = searchParams.get("streamId");
   const type = searchParams.get("type");
-  const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 100);
+  const limit = Math.min(Number.parseInt(searchParams.get("limit") || "20", 10), 100);
 
   const context = {
     correlation_id: request.headers.get("x-correlation-id") || `api-${crypto.randomUUID()}`,
@@ -34,26 +35,48 @@ export async function GET(request: Request) {
   };
 
   return withCorrelationContext(context, async () => {
-    let events = Array.from(db.activity.values()).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    let events = Array.from(streamRepository.activity.values()).sort((a, b) =>
+      b.timestamp.localeCompare(a.timestamp),
+    );
 
     if (streamId) {
-      events = events.filter((e) => e.streamId === streamId);
+      events = events.filter((event) => event.streamId === streamId);
     }
+
     if (type) {
-      events = events.filter((e) => e.type === type);
+      events = events.filter((event) => event.type === type);
     }
-  }
 
-  const paginatedEvents = events.slice(0, limit);
-  const hasNext = events.length > limit;
-  const nextCursor = hasNext && paginatedEvents.length > 0 ? encodeCursor(paginatedEvents[paginatedEvents.length - 1].id) : null;
+    if (cursor) {
+      let cursorId: string;
+      try {
+        cursorId = decodeCursor(cursor);
+      } catch {
+        return createErrorResponse("INVALID_CURSOR", "Malformed cursor", 422);
+      }
 
-    logger.info("Activity list completed", { count: paginatedEvents.length, total: db.activity.size });
+      const cursorIndex = events.findIndex((event) => event.id === cursorId);
+      if (cursorIndex >= 0) {
+        events = events.slice(cursorIndex + 1);
+      }
+    }
 
-  return NextResponse.json({
-    data: paginatedEvents,
-    meta: { hasNext, nextCursor, total: db.activity.size },
-    links: { self: `/api/v1/activity?limit=${limit}` },
+    const paginatedEvents = events.slice(0, limit);
+    const hasNext = events.length > limit;
+    const nextCursor =
+      hasNext && paginatedEvents.length > 0
+        ? encodeCursor(paginatedEvents[paginatedEvents.length - 1].id)
+        : null;
+
+    logger.info("Activity list completed", {
+      count: paginatedEvents.length,
+      total: streamRepository.activity.size,
+    });
+
+    return NextResponse.json({
+      data: paginatedEvents,
+      meta: { hasNext, nextCursor, total: streamRepository.activity.size },
+      links: { self: `/api/v1/activity?limit=${limit}` },
+    });
   });
 }
-

--- a/app/api/exports/[id]/route.ts
+++ b/app/api/exports/[id]/route.ts
@@ -1,14 +1,14 @@
 import { createHmac, timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 import { tryAuthenticateRequest, JWT_SECRET } from "@/app/lib/auth";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 
 function createErrorResponse(code: string, message: string, status: number) {
   return NextResponse.json({ error: { code, message, request_id: "mock-request-id" } }, { status });
 }
 
 function createAuditRecord(exportId: string, type: "export.requested" | "export.downloaded" | "export.expired", details?: Record<string, unknown>) {
-  db.exportAudit.push({
+  getStore().exportRepository.audit.push({
     id: crypto.randomUUID(),
     exportId,
     type,
@@ -32,13 +32,14 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { exportRepository } = getStore();
   const actor = tryAuthenticateRequest(request);
   if (!actor) {
     return createErrorResponse("UNAUTHORIZED", "Missing or invalid authorization header", 401);
   }
 
   const { id } = await params;
-  const job = db.exportJobs.get(id);
+  const job = exportRepository.jobs.get(id);
   if (!job) {
     return createErrorResponse("EXPORT_NOT_FOUND", `Export job '${id}' not found.`, 404);
   }
@@ -50,7 +51,7 @@ export async function GET(
 
   const now = new Date();
   if (now > new Date(job.expiresAt)) {
-    db.exportJobs.set(id, { ...job, status: "expired" });
+    exportRepository.jobs.set(id, { ...job, status: "expired" });
     createAuditRecord(id, "export.expired", { expiresAt: job.expiresAt });
     return createErrorResponse("EXPORT_EXPIRED", "This export has expired and is no longer available.", 410);
   }
@@ -72,7 +73,7 @@ export async function GET(
     }
 
     if (now > new Date(expiresParam)) {
-      db.exportJobs.set(id, { ...job, status: "expired" });
+      exportRepository.jobs.set(id, { ...job, status: "expired" });
       createAuditRecord(id, "export.expired", { signedUrlExpiresAt: expiresParam });
       return createErrorResponse("EXPORT_URL_EXPIRED", "Signed URL has expired.", 410);
     }

--- a/app/api/exports/route.ts
+++ b/app/api/exports/route.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "crypto";
 import { NextResponse } from "next/server";
 import { tryAuthenticateRequest, JWT_SECRET } from "@/app/lib/auth";
-import { db, ExportJob, ExportJobStatus } from "@/app/lib/db";
+import { ExportJob, getStore } from "@/app/lib/db";
 
 const EXPORT_RETENTION_DAYS = 7;
 const SIGNED_URL_TTL_SECONDS = 60 * 60; // 1 hour
@@ -12,7 +12,7 @@ function createErrorResponse(code: string, message: string, status: number) {
 }
 
 function createAuditRecord(exportId: string, type: "export.requested" | "export.downloaded" | "export.expired", details?: Record<string, unknown>) {
-  db.exportAudit.push({
+  getStore().exportRepository.audit.push({
     id: crypto.randomUUID(),
     exportId,
     type,
@@ -35,15 +35,16 @@ function createSignedUrl(jobId: string, expiresAt: string): string {
 }
 
 async function generateExportArtifact(jobId: string) {
-  const job = db.exportJobs.get(jobId);
+  const { exportRepository, streamRepository } = getStore();
+  const job = exportRepository.jobs.get(jobId);
   if (!job) return;
 
   // Scope streams and activity to the job owner
-  const streams = Array.from(db.streams.values())
+  const streams = Array.from(streamRepository.streams.values())
     .filter((s) => (s as { ownerId?: string }).ownerId === job.ownerId)
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 
-  const events = Array.from(db.activity.values())
+  const events = Array.from(streamRepository.activity.values())
     .filter((e) => (e as { ownerId?: string }).ownerId === job.ownerId)
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
@@ -68,7 +69,7 @@ async function generateExportArtifact(jobId: string) {
   const signedUrlExpiresAt = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
   const signedUrl = createSignedUrl(jobId, signedUrlExpiresAt);
 
-  db.exportJobs.set(jobId, {
+  exportRepository.jobs.set(jobId, {
     ...job,
     status: "ready",
     signedUrl,
@@ -80,26 +81,28 @@ async function generateExportArtifact(jobId: string) {
 }
 
 function scheduleExportJob(jobId: string) {
-  if (db.exportProcessing.has(jobId)) return;
+  const { exportRepository } = getStore();
+  if (exportRepository.processing.has(jobId)) return;
 
   const jobPromise = new Promise<void>((resolve) => {
     setTimeout(async () => {
       try {
         await generateExportArtifact(jobId);
       } catch {
-        const job = db.exportJobs.get(jobId);
-        if (job) db.exportJobs.set(jobId, { ...job, status: "failed" });
+        const failedJob = exportRepository.jobs.get(jobId);
+        if (failedJob) exportRepository.jobs.set(jobId, { ...failedJob, status: "failed" });
       } finally {
-        db.exportProcessing.delete(jobId);
+        exportRepository.processing.delete(jobId);
         resolve();
       }
     }, EXPORT_PROCESS_DELAY_MS);
   });
 
-  db.exportProcessing.set(jobId, jobPromise);
+  exportRepository.processing.set(jobId, jobPromise);
 }
 
 export async function POST(request: Request) {
+  const { exportRepository } = getStore();
   const actor = tryAuthenticateRequest(request);
   if (!actor) {
     return createErrorResponse("UNAUTHORIZED", "Missing or invalid authorization header", 401);
@@ -119,7 +122,7 @@ export async function POST(request: Request) {
     rows: 0,
   };
 
-  db.exportJobs.set(id, job);
+  exportRepository.jobs.set(id, job);
   createAuditRecord(id, "export.requested", { requestedAt, retentionDays: EXPORT_RETENTION_DAYS });
   scheduleExportJob(id);
 

--- a/app/api/internal/reconciliation/route.ts
+++ b/app/api/internal/reconciliation/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { requireInternalServiceAuth } from "@/app/lib/internal-service-auth";
 
 function createErrorResponse(code: string, message: string, status: number) {
@@ -16,6 +16,7 @@ function createErrorResponse(code: string, message: string, status: number) {
 }
 
 export async function POST(request: Request) {
+  const { streamRepository } = getStore();
   const identity = await requireInternalServiceAuth(request, {
     allowedServices: ["ops-automation", "reconciliation-worker"],
     concealFailure: true,
@@ -35,13 +36,13 @@ export async function POST(request: Request) {
     return createErrorResponse("INVALID_REQUEST", "Request body must be valid JSON.", 400);
   }
 
-  if (body.streamId && !db.streams.has(body.streamId)) {
+  if (body.streamId && !streamRepository.streams.has(body.streamId)) {
     return createErrorResponse("STREAM_NOT_FOUND", `Stream '${body.streamId}' not found.`, 404);
   }
 
   const streams = body.streamId
-    ? [db.streams.get(body.streamId)!]
-    : Array.from(db.streams.values());
+    ? [streamRepository.streams.get(body.streamId)!]
+    : Array.from(streamRepository.streams.values());
 
   const summary = streams.reduce(
     (accumulator, stream) => {

--- a/app/api/streams/[id]/pause/route.ts
+++ b/app/api/streams/[id]/pause/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db, idempotencyToken } from "@/app/lib/db";
+import { getStore, idempotencyToken } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkStreamOrgPolicy } from "@/app/lib/org-policy";
 
@@ -22,15 +22,16 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { idempotencyStore, streamRepository } = getStore();
   const { id } = await params;
   const idempotencyKey = getHeader(request, "Idempotency-Key");
   const token = idempotencyKey ? idempotencyToken(`streams.pause.${id}`, idempotencyKey) : null;
 
-  if (token && db.idempotency.has(token)) {
-    return NextResponse.json(db.idempotency.get(token));
+  if (token && idempotencyStore.has(token)) {
+    return NextResponse.json(idempotencyStore.get(token));
   }
 
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -60,11 +61,11 @@ export async function POST(
     status: "paused" as const,
     updatedAt: new Date().toISOString(),
   };
-  db.streams.set(id, updatedStream);
+  streamRepository.streams.set(id, updatedStream);
 
   const payload = { data: updatedStream };
   if (token) {
-    db.idempotency.set(token, payload);
+    idempotencyStore.set(token, payload);
   }
 
   return NextResponse.json(payload);

--- a/app/api/streams/[id]/route.ts
+++ b/app/api/streams/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
 import { getLimitForRoute } from "@/app/lib/rate-limit-config";
@@ -43,13 +43,14 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { streamRepository } = getStore();
   const { id } = await params;
   const rateLimited = await enforceRateLimit(request, "GET", `/api/streams/${id}`);
   if (rateLimited) {
     return rateLimited;
   }
 
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -58,13 +59,14 @@ export async function GET(
 }
 
 export async function DELETE(request: Request, { params }: Context) {
+  const { streamRepository } = getStore();
   const { id } = await params;
   const rateLimited = await enforceRateLimit(request, "DELETE", `/api/streams/${id}`);
   if (rateLimited) {
     return rateLimited;
   }
 
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -77,6 +79,6 @@ export async function DELETE(request: Request, { params }: Context) {
     );
   }
 
-  db.streams.delete(id);
+  streamRepository.streams.delete(id);
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/streams/[id]/settle/route.ts
+++ b/app/api/streams/[id]/settle/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { recordPrivilegedStreamAuditEvent } from "@/app/lib/audit-log";
-import { db, idempotencyToken, withLock } from "@/app/lib/db";
+import { getStore, idempotencyToken, withLock } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkStreamOrgPolicy } from "@/app/lib/org-policy";
 import { getStellarSettlementClient } from "@/app/lib/stellar";
@@ -24,20 +24,21 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { idempotencyStore, streamRepository } = getStore();
   const { id } = await params;
   const idempotencyKey = getHeader(request, "Idempotency-Key");
   const token = idempotencyKey ? idempotencyToken(`streams.settle.${id}`, idempotencyKey) : null;
 
-  if (token && db.idempotency.has(token)) {
-    return NextResponse.json(db.idempotency.get(token));
+  if (token && idempotencyStore.has(token)) {
+    return NextResponse.json(idempotencyStore.get(token));
   }
 
   return withLock(id, async () => {
-    if (token && db.idempotency.has(token)) {
-      return NextResponse.json(db.idempotency.get(token));
+    if (token && idempotencyStore.has(token)) {
+      return NextResponse.json(idempotencyStore.get(token));
     }
 
-    const stream = db.streams.get(id);
+    const stream = streamRepository.streams.get(id);
     if (!stream) {
       return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
     }
@@ -78,7 +79,7 @@ export async function POST(
         state: "pending" as const,
       },
     };
-    db.streams.set(id, updatedStream);
+    streamRepository.streams.set(id, updatedStream);
 
     try {
       const settlement = await getStellarSettlementClient().settleStream({ streamId: id });
@@ -96,7 +97,7 @@ export async function POST(
 
       const payload = { data: { ...updatedStream, settlement } };
       if (token) {
-        db.idempotency.set(token, payload);
+        idempotencyStore.set(token, payload);
       }
 
       return NextResponse.json(payload);

--- a/app/api/streams/[id]/start/route.ts
+++ b/app/api/streams/[id]/start/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkStreamOrgPolicy } from "@/app/lib/org-policy";
 import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
@@ -33,6 +33,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { streamRepository } = getStore();
   const { id } = await params;
   const url = getRequestUrl(request, `/api/streams/${id}/start`);
   const limitType = getLimitForRoute("POST", url.pathname);
@@ -45,7 +46,7 @@ export async function POST(
   }
   recordRequest(url.pathname);
 
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -71,6 +72,6 @@ export async function POST(
     status: "active" as const,
     updatedAt: new Date().toISOString(),
   };
-  db.streams.set(id, updatedStream);
+  streamRepository.streams.set(id, updatedStream);
   return NextResponse.json({ data: updatedStream });
 }

--- a/app/api/streams/[id]/stop/route.ts
+++ b/app/api/streams/[id]/stop/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { recordPrivilegedStreamAuditEvent } from "@/app/lib/audit-log";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkStreamOrgPolicy } from "@/app/lib/org-policy";
 import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
@@ -28,6 +28,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { streamRepository } = getStore();
   const { id } = await params;
   const url = getRequestUrl(request, `/api/streams/${id}/stop`);
   const limitType = getLimitForRoute("POST", url.pathname);
@@ -40,7 +41,7 @@ export async function POST(
   }
   recordRequest(url.pathname);
 
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return createErrorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -72,7 +73,7 @@ export async function POST(
     updatedAt: new Date().toISOString(),
   };
 
-  db.streams.set(id, updatedStream);
+  streamRepository.streams.set(id, updatedStream);
   recordPrivilegedStreamAuditEvent({
     action: "stream.stop.override",
     after: updatedStream as unknown as Record<string, unknown>,

--- a/app/api/streams/[id]/withdraw/route.ts
+++ b/app/api/streams/[id]/withdraw/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { recordPrivilegedStreamAuditEvent } from "@/app/lib/audit-log";
-import { db, idempotencyToken, withLock } from "@/app/lib/db";
+import { getStore, idempotencyToken, withLock } from "@/app/lib/db";
 import { getCorrelationContext } from "@/app/lib/logger";
 import { checkStreamOrgPolicy } from "@/app/lib/org-policy";
 import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
@@ -29,6 +29,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { idempotencyStore, streamRepository } = getStore();
   const { id } = await params;
   const url = getRequestUrl(request, `/api/streams/${id}/withdraw`);
   const limitType = getLimitForRoute("POST", url.pathname);
@@ -45,16 +46,16 @@ export async function POST(
   const idempotencyKey = getHeader(request, "Idempotency-Key");
   const token = idempotencyKey ? idempotencyToken(`streams.withdraw.${id}`, idempotencyKey) : null;
 
-  if (token && db.idempotency.has(token)) {
-    return NextResponse.json(db.idempotency.get(token));
+  if (token && idempotencyStore.has(token)) {
+    return NextResponse.json(idempotencyStore.get(token));
   }
 
   return withLock(id, async () => {
-    if (token && db.idempotency.has(token)) {
-      return NextResponse.json(db.idempotency.get(token));
+    if (token && idempotencyStore.has(token)) {
+      return NextResponse.json(idempotencyStore.get(token));
     }
 
-    const stream = db.streams.get(id);
+    const stream = streamRepository.streams.get(id);
     if (!stream) {
       return createErrorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
     }
@@ -77,7 +78,7 @@ export async function POST(
       if (stream.status === "withdrawn") {
         const payload = { data: stream, withdrawal: stream.withdrawal };
         if (token) {
-          db.idempotency.set(token, payload);
+          idempotencyStore.set(token, payload);
         }
         return NextResponse.json(payload);
       }
@@ -86,7 +87,7 @@ export async function POST(
 
     const before = structuredClone(stream);
     const { alert, stream: updated } = await evaluateWithdrawalState(stream, new Date(), fetch);
-    db.streams.set(id, updated);
+    streamRepository.streams.set(id, updated);
 
     const payload = {
       alert,
@@ -108,7 +109,7 @@ export async function POST(
     });
 
     if (token) {
-      db.idempotency.set(token, payload);
+      idempotencyStore.set(token, payload);
     }
 
     return NextResponse.json(payload);

--- a/app/api/streams/events/route.test.ts
+++ b/app/api/streams/events/route.test.ts
@@ -1,7 +1,4 @@
 import { GET } from "./route";
-import { NextRequest } from "next/request";
-import { db, resetDb } from "@/app/lib/auth"; // Wait, db is in app/lib/db
-import { eventBus } from "@/app/lib/event-bus";
 import jwt from "jsonwebtoken";
 
 // Mock dependencies

--- a/app/api/streams/events/route.ts
+++ b/app/api/streams/events/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { tryAuthenticateRequest } from "@/app/lib/auth";
 import { eventBus } from "@/app/lib/event-bus";
 import { logger } from "@/app/lib/logger";
@@ -18,6 +18,7 @@ import { logger } from "@/app/lib/logger";
  * - 403 returned on unauthorized access or ID guessing.
  */
 export async function GET(request: NextRequest) {
+  const { streamRepository } = getStore();
   // 1. Authenticate Request
   const actor = tryAuthenticateRequest(request);
   if (!actor) {
@@ -32,7 +33,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "streamId parameter is required" } }, { status: 422 });
   }
 
-  const stream = db.streams.get(streamId);
+  const stream = streamRepository.streams.get(streamId);
   if (!stream) {
     return NextResponse.json({ error: { code: "NOT_FOUND", message: "Stream not found" } }, { status: 404 });
   }
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest) {
   // In this mock, we check if the user's wallet address matches the stream's recipient 
   // or if the user's email (if we had it) matches.
   // For the purpose of this task, we'll fetch the user to check their email too.
-  const user = db.users.get(actor.walletAddress);
+  const user = streamRepository.users.get(actor.walletAddress);
   const isOwner = 
     stream.recipient === actor.walletAddress || 
     (user && stream.email === user.email) ||

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db, decodeCursor, encodeCursor, idempotencyToken } from "@/app/lib/db";
+import { decodeCursor, encodeCursor, getStore, idempotencyToken } from "@/app/lib/db";
 import { getCorrelationContext, logger } from "@/app/lib/logger";
 import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/rate-limit";
 import { getLimitForRoute } from "@/app/lib/rate-limit-config";
@@ -27,6 +27,7 @@ function getHeader(request: Request, name: string): string | null {
 }
 
 export async function GET(request: Request) {
+  const { streamRepository } = getStore();
   const url = getRequestUrl(request, "/api/streams");
   const limitType = getLimitForRoute("GET", url.pathname);
   const identity = getClientIdentity(request);
@@ -43,7 +44,7 @@ export async function GET(request: Request) {
   const status = searchParams.get("status");
   const limit = Math.min(Number.parseInt(searchParams.get("limit") ?? "20", 10), 100);
 
-  let streams = Array.from(db.streams.values()).sort((left, right) => {
+  let streams = Array.from(streamRepository.streams.values()).sort((left, right) => {
     const timeCompare = left.createdAt.localeCompare(right.createdAt);
     return timeCompare !== 0 ? timeCompare : left.id.localeCompare(right.id);
   });
@@ -72,7 +73,10 @@ export async function GET(request: Request) {
       ? encodeCursor(paginatedStreams[paginatedStreams.length - 1].id)
       : null;
 
-  logger.info("Streams listed successfully", { count: paginatedStreams.length, total: db.streams.size });
+  logger.info("Streams listed successfully", {
+    count: paginatedStreams.length,
+    total: streamRepository.streams.size,
+  });
 
   return NextResponse.json({
     data: paginatedStreams,
@@ -82,6 +86,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const { idempotencyStore, streamRepository } = getStore();
   const url = getRequestUrl(request, "/api/streams");
   const limitType = getLimitForRoute("POST", url.pathname);
   const identity = getClientIdentity(request);
@@ -96,8 +101,8 @@ export async function POST(request: Request) {
   const idempotencyKey = getHeader(request, "Idempotency-Key");
   const token = idempotencyKey ? idempotencyToken("streams.create", idempotencyKey) : null;
 
-  if (token && db.idempotency.has(token)) {
-    return NextResponse.json(db.idempotency.get(token), { status: 201 });
+  if (token && idempotencyStore.has(token)) {
+    return NextResponse.json(idempotencyStore.get(token), { status: 201 });
   }
 
   try {
@@ -128,11 +133,11 @@ export async function POST(request: Request) {
       updatedAt: now,
     };
 
-    db.streams.set(id, newStream);
+    streamRepository.streams.set(id, newStream);
     const payload = { data: newStream, links: { self: `/api/v1/streams/${id}` } };
 
     if (token) {
-      db.idempotency.set(token, payload);
+      idempotencyStore.set(token, payload);
     }
 
     return NextResponse.json(payload, { status: 201 });

--- a/app/api/v2/streams/[id]/route.ts
+++ b/app/api/v2/streams/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db } from "@/app/lib/db";
+import { getStore } from "@/app/lib/db";
 import { toV2Stream } from "@/app/lib/api-version";
 
 type Context = { params: Promise<{ id: string }> };
@@ -10,8 +10,9 @@ function errorResponse(code: string, message: string, status: number) {
 
 /** GET /api/v2/streams/:id — single stream in v2 shape. */
 export async function GET(_request: Request, { params }: Context) {
+  const { streamRepository } = getStore();
   const { id } = await params;
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -23,8 +24,9 @@ export async function GET(_request: Request, { params }: Context) {
 
 /** DELETE /api/v2/streams/:id */
 export async function DELETE(_request: Request, { params }: Context) {
+  const { streamRepository } = getStore();
   const { id } = await params;
-  const stream = db.streams.get(id);
+  const stream = streamRepository.streams.get(id);
   if (!stream) {
     return errorResponse("STREAM_NOT_FOUND", `Stream '${id}' not found`, 404);
   }
@@ -35,6 +37,6 @@ export async function DELETE(_request: Request, { params }: Context) {
       409,
     );
   }
-  db.streams.delete(id);
+  streamRepository.streams.delete(id);
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/v2/streams/route.ts
+++ b/app/api/v2/streams/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { db, encodeCursor, decodeCursor, idempotencyToken } from "@/app/lib/db";
+import { decodeCursor, encodeCursor, getStore, idempotencyToken } from "@/app/lib/db";
 import { toV2Stream } from "@/app/lib/api-version";
 
 function errorResponse(code: string, message: string, status: number) {
@@ -8,12 +8,13 @@ function errorResponse(code: string, message: string, status: number) {
 
 /** GET /api/v2/streams — paginated stream list in v2 shape. */
 export async function GET(request: Request) {
+  const { streamRepository } = getStore();
   const { searchParams } = new URL(request.url);
   const cursor = searchParams.get("cursor");
   const status = searchParams.get("status");
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 100);
 
-  let streams = Array.from(db.streams.values()).sort((a, b) => {
+  let streams = Array.from(streamRepository.streams.values()).sort((a, b) => {
     const timeCompare = a.createdAt.localeCompare(b.createdAt);
     return timeCompare !== 0 ? timeCompare : a.id.localeCompare(b.id);
   });
@@ -54,13 +55,14 @@ export async function GET(request: Request) {
  *   - `settlement` is always present (null when not yet settled).
  */
 export async function POST(request: Request) {
+  const { idempotencyStore, streamRepository } = getStore();
   const idempotencyKey = request.headers.get("Idempotency-Key");
   const token = idempotencyKey
     ? idempotencyToken("v2.streams.create", idempotencyKey)
     : null;
 
-  if (token && db.idempotency.has(token)) {
-    return NextResponse.json(db.idempotency.get(token), { status: 201 });
+  if (token && idempotencyStore.has(token)) {
+    return NextResponse.json(idempotencyStore.get(token), { status: 201 });
   }
 
   let body: Record<string, unknown>;
@@ -97,14 +99,14 @@ export async function POST(request: Request) {
     updatedAt: now,
   };
 
-  db.streams.set(id, newStream);
+  streamRepository.streams.set(id, newStream);
 
   const payload = {
     data: toV2Stream(newStream),
     links: { self: `/api/v2/streams/${id}` },
   };
 
-  if (token) db.idempotency.set(token, payload);
+  if (token) idempotencyStore.set(token, payload);
 
   return NextResponse.json(payload, { status: 201 });
 }

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,4 +1,10 @@
 import type { ActivityEvent, ExportJob, Stream, User } from "@/app/types/openapi";
+import { createInMemoryPersistenceStore } from "@/app/lib/repositories/in-memory";
+import {
+  createPostgresPersistenceStore,
+  POSTGRES_ROLLOUT_NOTES,
+  POSTGRES_SCHEMA_SKETCH,
+} from "@/app/lib/repositories/postgres";
 
 export type { ExportJob };
 export type ExportJobStatus = ExportJob["status"];
@@ -11,167 +17,108 @@ export interface ExportAuditRecord {
   details?: Record<string, unknown>;
 }
 
-const initialUsers: User[] = [
-  {
-    wallet_address: "GD7H...3J4K",
-    email: "ada@creativestudio.io",
-    display_name: "Ada Creative",
-    avatar_url: null,
-    created_at: "2026-01-01T00:00:00Z",
-  },
-];
-
-const initialStreams: Stream[] = [
-  {
-    id: "stream-ada",
-    recipient: "Ada Creative Studio",
-    rate: "120 XLM / month",
-    schedule: "Pays every 30 days",
-    status: "active",
-    nextAction: "pause",
-    createdAt: "2026-04-01T09:00:00Z",
-    updatedAt: "2026-04-28T10:30:00Z",
-    email: "ada@creativestudio.io",
-    label: "Design Retainer Q2",
-    partnerId: "PARTNER-123",
-  },
-  {
-    id: "stream-kemi",
-    recipient: "Kemi Onboarding Support",
-    rate: "32 XLM / week",
-    schedule: "Draft stream ready to launch",
-    status: "draft",
-    nextAction: "start",
-    createdAt: "2026-04-10T14:00:00Z",
-    updatedAt: "2026-04-28T11:00:00Z",
-    email: "kemi@onboarding.io",
-    memo: "April Support batch",
-  },
-  {
-    id: "stream-yusuf",
-    recipient: "Yusuf QA Partnership",
-    rate: "18 XLM / day",
-    schedule: "Ended yesterday with funds available",
-    status: "ended",
-    nextAction: "withdraw",
-    createdAt: "2026-04-15T08:00:00Z",
-    updatedAt: "2026-04-27T20:00:00Z",
-  },
-];
-
-const initialActivity: ActivityEvent[] = [
-  {
-    id: "a7383234-4224-49dc-b868-0cdf37649fda",
-    type: "wallet.connected",
-    timestamp: "2026-04-28T09:00:00Z",
-    description: "Wallet connected and authenticated.",
-  },
-  {
-    id: "2b9d1d0c-bef4-46bc-a783-3073b28353fc",
-    type: "stream.created",
-    streamId: "stream-ada",
-    timestamp: "2026-04-01T09:00:00Z",
-    description: "Stream 'Design Retainer' created and set to draft.",
-  },
-  {
-    id: "d1578871-4be9-4c6a-bef5-12b2b5836478",
-    type: "stream.started",
-    streamId: "stream-ada",
-    timestamp: "2026-04-01T09:05:00Z",
-    description: "Stream 'Design Retainer' activated.",
-  },
-  {
-    id: "288f315d-5520-46e9-8acf-96994c87b786",
-    type: "stream.created",
-    streamId: "stream-kemi",
-    timestamp: "2026-04-10T14:00:00Z",
-    description: "Stream 'Kemi Onboarding Support' created as draft.",
-  },
-  {
-    id: "3bea183d-c3b5-4e96-9fbe-804f3aee49e9",
-    type: "stream.created",
-    streamId: "stream-yusuf",
-    timestamp: "2026-04-15T08:00:00Z",
-    description: "Stream 'Yusuf QA Partnership' created.",
-  },
-  {
-    id: "5ffa85da-27a4-4f7c-bde0-e5c067a28015",
-    type: "stream.stopped",
-    streamId: "stream-yusuf",
-    timestamp: "2026-04-27T20:00:00Z",
-    description: "Stream 'Yusuf QA Partnership' stopped and settled automatically.",
-  },
-];
-
-function createUsersMap(): Map<string, User> {
-  return new Map(initialUsers.map((user) => [user.wallet_address, { ...user }]));
+export interface KeyValueStore<K, V> {
+  readonly size: number;
+  clear(): void;
+  delete(key: K): boolean;
+  entries(): IterableIterator<[K, V]>;
+  forEach(callbackfn: (value: V, key: K) => void): void;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): void;
+  values(): IterableIterator<V>;
 }
 
-function createStreamsMap(): Map<string, Stream> {
-  return new Map(initialStreams.map((s) => [s.id, { ...s }]));
+export interface AppendOnlyStore<T> extends Iterable<T> {
+  readonly length: number;
+  clear(): void;
+  push(value: T): number;
+  some(predicate: (value: T, index: number, array: T[]) => boolean): boolean;
+  toArray(): T[];
 }
 
-function createActivityMap(): Map<string, ActivityEvent> {
-  return new Map(initialActivity.map((e) => [e.id, { ...e }]));
+export interface StreamRepository {
+  readonly activity: KeyValueStore<string, ActivityEvent>;
+  readonly streams: KeyValueStore<string, Stream>;
+  readonly users: KeyValueStore<string, User>;
+  reset(): void;
+  withLock<T>(id: string, callback: () => Promise<T>): Promise<T>;
 }
 
-// ── In-memory database ─────────────────────────────────────────────────
+export interface IdempotencyStore extends KeyValueStore<string, unknown> {
+  reset(): void;
+}
+
+export interface ExportRepository {
+  readonly audit: AppendOnlyStore<ExportAuditRecord>;
+  readonly jobs: KeyValueStore<string, ExportJob>;
+  readonly processing: KeyValueStore<string, Promise<void>>;
+  reset(): void;
+}
+
+export interface PersistenceStore {
+  readonly exportRepository: ExportRepository;
+  readonly idempotencyStore: IdempotencyStore;
+  readonly kind: "memory" | "postgres";
+  readonly streamRepository: StreamRepository;
+}
+
+let activeStore: PersistenceStore = createInMemoryPersistenceStore();
+
+export function getStore(): PersistenceStore {
+  return activeStore;
+}
+
+export function setStore(store: PersistenceStore): void {
+  activeStore = store;
+}
+
+export function createDefaultStore(): PersistenceStore {
+  return createInMemoryPersistenceStore();
+}
 
 export const db = {
-  users: createUsersMap(),
-  streams: createStreamsMap(),
-  activity: createActivityMap(),
-  idempotency: new Map<string, unknown>(),
-  exportJobs: new Map<string, ExportJob>(),
-  exportAudit: new Array<ExportAuditRecord>(),
-  exportProcessing: new Map<string, Promise<void>>(),
+  get activity() {
+    return getStore().streamRepository.activity;
+  },
+  get exportAudit() {
+    return getStore().exportRepository.audit;
+  },
+  get exportJobs() {
+    return getStore().exportRepository.jobs;
+  },
+  get exportProcessing() {
+    return getStore().exportRepository.processing;
+  },
+  get idempotency() {
+    return getStore().idempotencyStore;
+  },
+  get streams() {
+    return getStore().streamRepository.streams;
+  },
+  get users() {
+    return getStore().streamRepository.users;
+  },
 };
 
-// ── Concurrency: per-stream lock ──────────────────────────────────────────
-
-const locks = new Map<string, Promise<void>>();
-
 export async function withLock<T>(id: string, callback: () => Promise<T>): Promise<T> {
-  const existingLock = locks.get(id) ?? Promise.resolve();
-  let releaseCurrent!: () => void;
-  const currentLock = new Promise<void>((resolve) => {
-    releaseCurrent = resolve;
-  });
-
-  locks.set(id, currentLock);
-
-  try {
-    await existingLock;
-    return await callback();
-  } finally {
-    if (locks.get(id) === currentLock) {
-      locks.delete(id);
-    }
-    releaseCurrent();
-  }
+  return getStore().streamRepository.withLock(id, callback);
 }
 
 export function idempotencyToken(scope: string, idempotencyKey: string): string {
   return `${scope}:${idempotencyKey}`;
 }
 
-/** Resets all in-memory state to seed data. Use in beforeEach in tests. */
+/** Resets all default-store state to seed data. Use in beforeEach in tests. */
 export function resetDb(): void {
-  db.users.clear();
-  for (const [id, user] of createUsersMap()) {
-    db.users.set(id, user);
+  if (getStore().kind === "memory") {
+    getStore().streamRepository.reset();
+    getStore().idempotencyStore.reset();
+    getStore().exportRepository.reset();
+    return;
   }
 
-  db.streams.clear();
-  for (const [id, stream] of createStreamsMap()) db.streams.set(id, stream);
-
-  db.activity.clear();
-  for (const [id, event] of createActivityMap()) db.activity.set(id, event);
-
-  db.idempotency.clear();
-  db.exportJobs.clear();
-  db.exportAudit.length = 0;
-  db.exportProcessing.clear();
+  activeStore = createDefaultStore();
 }
 
 export function encodeCursor(id: string): string {
@@ -188,7 +135,9 @@ export function decodeCursor(cursor: string): string {
   }
   try {
     return Buffer.from(cursor, "base64").toString("utf8");
-  } catch (e) {
+  } catch {
     throw new Error("Invalid cursor: malformed base64");
   }
 }
+
+export { createInMemoryPersistenceStore, createPostgresPersistenceStore, POSTGRES_SCHEMA_SKETCH, POSTGRES_ROLLOUT_NOTES };

--- a/app/lib/privacy.ts
+++ b/app/lib/privacy.ts
@@ -1,5 +1,5 @@
 import { Stream, User } from "@/app/types/openapi";
-import { db } from "./db";
+import { getStore } from "./db";
 
 /**
  * Retention period: 7 years in milliseconds.
@@ -46,20 +46,21 @@ export function isPastRetention(createdAt: string): boolean {
  * Legal/Audit requirement: Keep stream aggregates (IDs, amounts, status) for 7 years.
  */
 export async function processDeletionRequest(walletAddress: string): Promise<{ requestId: string; status: string }> {
+  const { streamRepository } = getStore();
   // 1. Scrub PII from all streams associated with this user
   // In a real DB, we'd query by user_id. Here we check recipient and email.
-  const user = db.users.get(walletAddress);
+  const user = streamRepository.users.get(walletAddress);
   const userEmail = user?.email;
   const userName = user?.display_name;
 
-  for (const [id, stream] of db.streams.entries()) {
+  for (const [id, stream] of streamRepository.streams.entries()) {
     const isAssociated = 
       stream.email === userEmail || 
       (userName && stream.recipient.includes(userName)) ||
       stream.recipient.includes(walletAddress);
 
     if (isAssociated) {
-      db.streams.set(id, {
+      streamRepository.streams.set(id, {
         ...stream,
         email: undefined,
         label: undefined,
@@ -71,7 +72,7 @@ export async function processDeletionRequest(walletAddress: string): Promise<{ r
   }
 
   // 2. Delete user record
-  db.users.delete(walletAddress);
+  streamRepository.users.delete(walletAddress);
 
   return {
     requestId: `dsr-${Math.random().toString(36).slice(2, 11)}`,

--- a/app/lib/repositories/in-memory.test.ts
+++ b/app/lib/repositories/in-memory.test.ts
@@ -1,0 +1,219 @@
+import {
+  createInMemoryPersistenceStore,
+  createPostgresPersistenceStore,
+  db,
+  decodeCursor,
+  createDefaultStore,
+  encodeCursor,
+  idempotencyToken,
+  POSTGRES_ROLLOUT_NOTES,
+  POSTGRES_SCHEMA_SKETCH,
+  setStore,
+  getStore,
+  resetDb,
+} from "@/app/lib/db";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return { promise, resolve };
+}
+
+describe("repository adapters", () => {
+  afterEach(() => {
+    setStore(createInMemoryPersistenceStore());
+  });
+
+  it("seeds the default in-memory store and resets transient state", () => {
+    const store = createInMemoryPersistenceStore();
+    setStore(store);
+
+    expect(store.streamRepository.users.size).toBe(1);
+    expect(store.streamRepository.streams.size).toBe(3);
+    expect(store.streamRepository.activity.size).toBe(6);
+
+    store.streamRepository.streams.set("stream-extra", {
+      id: "stream-extra",
+      recipient: "Extra Recipient",
+      rate: "5 XLM / month",
+      schedule: "Monthly",
+      status: "draft",
+      nextAction: "start",
+      createdAt: "2026-05-01T00:00:00Z",
+      updatedAt: "2026-05-01T00:00:00Z",
+    });
+    store.idempotencyStore.set("streams.create:abc", { ok: true });
+    store.exportRepository.jobs.set("job-1", {
+      id: "job-1",
+      ownerId: "owner-1",
+      status: "pending",
+      requestedAt: "2026-05-01T00:00:00Z",
+      expiresAt: "2026-05-08T00:00:00Z",
+      fileName: "job-1.csv",
+      rows: 0,
+    });
+    store.exportRepository.audit.push({
+      id: "audit-1",
+      exportId: "job-1",
+      type: "export.requested",
+      timestamp: "2026-05-01T00:00:00Z",
+    });
+
+    resetDb();
+
+    expect(getStore().streamRepository.streams.size).toBe(3);
+    expect(getStore().streamRepository.streams.has("stream-extra")).toBe(false);
+    expect(getStore().idempotencyStore.size).toBe(0);
+    expect(getStore().exportRepository.jobs.size).toBe(0);
+    expect(getStore().exportRepository.audit.length).toBe(0);
+  });
+
+  it("keeps the legacy db facade wired to the active repository store", () => {
+    const store = createInMemoryPersistenceStore();
+    setStore(store);
+
+    expect(db.users).toBe(store.streamRepository.users);
+    expect(db.streams).toBe(store.streamRepository.streams);
+    expect(db.activity).toBe(store.streamRepository.activity);
+    expect(db.idempotency).toBe(store.idempotencyStore);
+    expect(db.exportJobs).toBe(store.exportRepository.jobs);
+    expect(db.exportAudit).toBe(store.exportRepository.audit);
+    expect(db.exportProcessing).toBe(store.exportRepository.processing);
+  });
+
+  it("serializes concurrent work for the same lock key", async () => {
+    const store = createInMemoryPersistenceStore();
+    const gate = deferred();
+    const order: string[] = [];
+
+    const first = store.streamRepository.withLock("stream-ada", async () => {
+      order.push("first:start");
+      await gate.promise;
+      order.push("first:end");
+      return "first";
+    });
+
+    const second = store.streamRepository.withLock("stream-ada", async () => {
+      order.push("second:start");
+      return "second";
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+
+    gate.resolve();
+
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  it("allows different lock keys to proceed independently", async () => {
+    const store = createInMemoryPersistenceStore();
+    const gate = deferred();
+    const order: string[] = [];
+
+    const first = store.streamRepository.withLock("stream-ada", async () => {
+      order.push("first:start");
+      await gate.promise;
+      order.push("first:end");
+    });
+
+    const second = store.streamRepository.withLock("stream-kemi", async () => {
+      order.push("second:start");
+    });
+
+    await second;
+    expect(order).toContain("second:start");
+
+    gate.resolve();
+    await first;
+  });
+
+  it("preserves cursor encoding and decoding semantics", () => {
+    const id = "stream-ada";
+    const cursor = encodeCursor(id);
+
+    expect(decodeCursor(cursor)).toBe(id);
+    expect(() => decodeCursor("")).toThrow("Invalid cursor: must be non-empty string");
+  });
+
+  it("preserves idempotency token scoping", () => {
+    expect(idempotencyToken("streams.create", "abc123")).toBe("streams.create:abc123");
+  });
+
+  it("tracks idempotency and export state through the repository seam", () => {
+    const store = createInMemoryPersistenceStore();
+
+    store.idempotencyStore.set("streams.pause:key-1", { data: "cached" });
+    expect(store.idempotencyStore.has("streams.pause:key-1")).toBe(true);
+    expect(store.idempotencyStore.get("streams.pause:key-1")).toEqual({ data: "cached" });
+
+    store.exportRepository.jobs.set("job-1", {
+      id: "job-1",
+      ownerId: "owner-1",
+      status: "ready",
+      requestedAt: "2026-05-01T00:00:00Z",
+      expiresAt: "2026-05-08T00:00:00Z",
+      fileName: "job-1.csv",
+      rows: 3,
+    });
+    store.exportRepository.audit.push({
+      id: "audit-1",
+      exportId: "job-1",
+      type: "export.downloaded",
+      timestamp: "2026-05-02T00:00:00Z",
+    });
+    store.exportRepository.processing.set("job-1", Promise.resolve());
+
+    expect(store.exportRepository.jobs.get("job-1")?.status).toBe("ready");
+    expect(store.exportRepository.audit.some((record) => record.type === "export.downloaded")).toBe(true);
+    expect(store.exportRepository.processing.has("job-1")).toBe(true);
+    expect(store.exportRepository.jobs.entries().next().value?.[0]).toBe("job-1");
+    expect(store.exportRepository.jobs.delete("job-1")).toBe(true);
+    expect(store.exportRepository.jobs.has("job-1")).toBe(false);
+    expect(store.exportRepository.audit.toArray()).toHaveLength(1);
+  });
+
+  it("exposes a postgres adapter seam plus schema and rollout notes", () => {
+    const store = createPostgresPersistenceStore({
+      executor: {
+        query: async () => ({ rows: [] }),
+      },
+    });
+
+    expect(store.kind).toBe("postgres");
+    expect(POSTGRES_SCHEMA_SKETCH).toContain("create table streams");
+    expect(POSTGRES_SCHEMA_SKETCH).toContain("create table idempotency_keys");
+    expect(POSTGRES_ROLLOUT_NOTES.length).toBeGreaterThanOrEqual(4);
+    expect(() => store.streamRepository.streams.get("stream-ada")).toThrow(
+      "PostgreSQL persistence seam is defined",
+    );
+    expect(() => store.exportRepository.audit.toArray()).toThrow(
+      "PostgreSQL persistence seam is defined",
+    );
+    expect(() => store.idempotencyStore.reset()).toThrow(
+      "PostgreSQL persistence seam is defined",
+    );
+  });
+
+  it("resets a durable store back to the default in-memory adapter", () => {
+    setStore(
+      createPostgresPersistenceStore({
+        executor: {
+          query: async () => ({ rows: [] }),
+        },
+      }),
+    );
+
+    resetDb();
+
+    expect(getStore().kind).toBe("memory");
+    expect(getStore().streamRepository.streams.size).toBe(
+      createDefaultStore().streamRepository.streams.size,
+    );
+  });
+});

--- a/app/lib/repositories/in-memory.ts
+++ b/app/lib/repositories/in-memory.ts
@@ -1,0 +1,260 @@
+import type {
+  AppendOnlyStore,
+  ExportAuditRecord,
+  ExportRepository,
+  IdempotencyStore,
+  KeyValueStore,
+  PersistenceStore,
+  StreamRepository,
+} from "@/app/lib/db";
+import type { ActivityEvent, ExportJob, Stream, User } from "@/app/types/openapi";
+
+const initialUsers: User[] = [
+  {
+    wallet_address: "GD7H...3J4K",
+    email: "ada@creativestudio.io",
+    display_name: "Ada Creative",
+    avatar_url: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const initialStreams: Stream[] = [
+  {
+    id: "stream-ada",
+    recipient: "Ada Creative Studio",
+    rate: "120 XLM / month",
+    schedule: "Pays every 30 days",
+    status: "active",
+    nextAction: "pause",
+    createdAt: "2026-04-01T09:00:00Z",
+    updatedAt: "2026-04-28T10:30:00Z",
+    email: "ada@creativestudio.io",
+    label: "Design Retainer Q2",
+    partnerId: "PARTNER-123",
+  },
+  {
+    id: "stream-kemi",
+    recipient: "Kemi Onboarding Support",
+    rate: "32 XLM / week",
+    schedule: "Draft stream ready to launch",
+    status: "draft",
+    nextAction: "start",
+    createdAt: "2026-04-10T14:00:00Z",
+    updatedAt: "2026-04-28T11:00:00Z",
+    email: "kemi@onboarding.io",
+    memo: "April Support batch",
+  },
+  {
+    id: "stream-yusuf",
+    recipient: "Yusuf QA Partnership",
+    rate: "18 XLM / day",
+    schedule: "Ended yesterday with funds available",
+    status: "ended",
+    nextAction: "withdraw",
+    createdAt: "2026-04-15T08:00:00Z",
+    updatedAt: "2026-04-27T20:00:00Z",
+  },
+];
+
+const initialActivity: ActivityEvent[] = [
+  {
+    id: "a7383234-4224-49dc-b868-0cdf37649fda",
+    type: "wallet.connected",
+    timestamp: "2026-04-28T09:00:00Z",
+    description: "Wallet connected and authenticated.",
+  },
+  {
+    id: "2b9d1d0c-bef4-46bc-a783-3073b28353fc",
+    type: "stream.created",
+    streamId: "stream-ada",
+    timestamp: "2026-04-01T09:00:00Z",
+    description: "Stream 'Design Retainer' created and set to draft.",
+  },
+  {
+    id: "d1578871-4be9-4c6a-bef5-12b2b5836478",
+    type: "stream.started",
+    streamId: "stream-ada",
+    timestamp: "2026-04-01T09:05:00Z",
+    description: "Stream 'Design Retainer' activated.",
+  },
+  {
+    id: "288f315d-5520-46e9-8acf-96994c87b786",
+    type: "stream.created",
+    streamId: "stream-kemi",
+    timestamp: "2026-04-10T14:00:00Z",
+    description: "Stream 'Kemi Onboarding Support' created as draft.",
+  },
+  {
+    id: "3bea183d-c3b5-4e96-9fbe-804f3aee49e9",
+    type: "stream.created",
+    streamId: "stream-yusuf",
+    timestamp: "2026-04-15T08:00:00Z",
+    description: "Stream 'Yusuf QA Partnership' created.",
+  },
+  {
+    id: "5ffa85da-27a4-4f7c-bde0-e5c067a28015",
+    type: "stream.stopped",
+    streamId: "stream-yusuf",
+    timestamp: "2026-04-27T20:00:00Z",
+    description: "Stream 'Yusuf QA Partnership' stopped and settled automatically.",
+  },
+];
+
+function createUsersMap(): Map<string, User> {
+  return new Map(initialUsers.map((user) => [user.wallet_address, { ...user }]));
+}
+
+function createStreamsMap(): Map<string, Stream> {
+  return new Map(initialStreams.map((stream) => [stream.id, { ...stream }]));
+}
+
+function createActivityMap(): Map<string, ActivityEvent> {
+  return new Map(initialActivity.map((event) => [event.id, { ...event }]));
+}
+
+class InMemoryKeyValueStore<K, V> implements KeyValueStore<K, V> {
+  constructor(private readonly backing: Map<K, V>) {}
+
+  get size(): number {
+    return this.backing.size;
+  }
+
+  clear(): void {
+    this.backing.clear();
+  }
+
+  delete(key: K): boolean {
+    return this.backing.delete(key);
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.backing.entries();
+  }
+
+  forEach(callbackfn: (value: V, key: K) => void): void {
+    this.backing.forEach((value, key) => callbackfn(value, key));
+  }
+
+  get(key: K): V | undefined {
+    return this.backing.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.backing.has(key);
+  }
+
+  set(key: K, value: V): void {
+    this.backing.set(key, value);
+  }
+
+  values(): IterableIterator<V> {
+    return this.backing.values();
+  }
+}
+
+class InMemoryAppendOnlyStore<T> implements AppendOnlyStore<T> {
+  constructor(private readonly backing: T[]) {}
+
+  get length(): number {
+    return this.backing.length;
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    return this.backing[Symbol.iterator]();
+  }
+
+  clear(): void {
+    this.backing.length = 0;
+  }
+
+  push(value: T): number {
+    return this.backing.push(value);
+  }
+
+  some(predicate: (value: T, index: number, array: T[]) => boolean): boolean {
+    return this.backing.some(predicate);
+  }
+
+  toArray(): T[] {
+    return [...this.backing];
+  }
+}
+
+class InMemoryStreamRepository implements StreamRepository {
+  readonly activity = new InMemoryKeyValueStore<string, ActivityEvent>(createActivityMap());
+  readonly streams = new InMemoryKeyValueStore<string, Stream>(createStreamsMap());
+  readonly users = new InMemoryKeyValueStore<string, User>(createUsersMap());
+  private readonly locks = new Map<string, Promise<void>>();
+
+  reset(): void {
+    resetKeyValueStore(this.users, createUsersMap());
+    resetKeyValueStore(this.streams, createStreamsMap());
+    resetKeyValueStore(this.activity, createActivityMap());
+    this.locks.clear();
+  }
+
+  async withLock<T>(id: string, callback: () => Promise<T>): Promise<T> {
+    const existingLock = this.locks.get(id) ?? Promise.resolve();
+    let releaseCurrent!: () => void;
+    const currentLock = new Promise<void>((resolve) => {
+      releaseCurrent = resolve;
+    });
+
+    this.locks.set(id, currentLock);
+
+    try {
+      await existingLock;
+      return await callback();
+    } finally {
+      if (this.locks.get(id) === currentLock) {
+        this.locks.delete(id);
+      }
+      releaseCurrent();
+    }
+  }
+}
+
+class InMemoryIdempotencyStore
+  extends InMemoryKeyValueStore<string, unknown>
+  implements IdempotencyStore
+{
+  constructor() {
+    super(new Map<string, unknown>());
+  }
+
+  reset(): void {
+    this.clear();
+  }
+}
+
+class InMemoryExportRepository implements ExportRepository {
+  readonly audit = new InMemoryAppendOnlyStore<ExportAuditRecord>([]);
+  readonly jobs = new InMemoryKeyValueStore<string, ExportJob>(new Map<string, ExportJob>());
+  readonly processing = new InMemoryKeyValueStore<string, Promise<void>>(new Map<string, Promise<void>>());
+
+  reset(): void {
+    this.jobs.clear();
+    this.audit.clear();
+    this.processing.clear();
+  }
+}
+
+function resetKeyValueStore<K, V>(
+  store: KeyValueStore<K, V>,
+  nextValues: Map<K, V>,
+): void {
+  store.clear();
+  for (const [key, value] of nextValues.entries()) {
+    store.set(key, value);
+  }
+}
+
+export function createInMemoryPersistenceStore(): PersistenceStore {
+  return {
+    kind: "memory",
+    streamRepository: new InMemoryStreamRepository(),
+    idempotencyStore: new InMemoryIdempotencyStore(),
+    exportRepository: new InMemoryExportRepository(),
+  };
+}

--- a/app/lib/repositories/postgres.ts
+++ b/app/lib/repositories/postgres.ts
@@ -1,0 +1,238 @@
+import type {
+  AppendOnlyStore,
+  ExportAuditRecord,
+  ExportRepository,
+  IdempotencyStore,
+  KeyValueStore,
+  PersistenceStore,
+  StreamRepository,
+} from "@/app/lib/db";
+import type { ActivityEvent, ExportJob, Stream, User } from "@/app/types/openapi";
+
+export interface SqlExecutor {
+  query<TResult = unknown>(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<{ rows: TResult[] }>;
+}
+
+export interface PostgresStoreConfig {
+  executor: SqlExecutor;
+}
+
+export const POSTGRES_SCHEMA_SKETCH = `
+-- Streams remain the source of truth for lifecycle state.
+create table streams (
+  id text primary key,
+  status text not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null,
+  payload jsonb not null
+);
+
+create index streams_status_created_at_idx on streams (status, created_at, id);
+
+create table users (
+  wallet_address text primary key,
+  created_at timestamptz not null,
+  payload jsonb not null
+);
+
+create table activity_events (
+  id text primary key,
+  stream_id text null references streams(id) on delete set null,
+  event_type text not null,
+  happened_at timestamptz not null,
+  payload jsonb not null
+);
+
+create index activity_events_stream_happened_at_idx
+  on activity_events (stream_id, happened_at desc, id desc);
+
+create index activity_events_type_happened_at_idx
+  on activity_events (event_type, happened_at desc, id desc);
+
+create table idempotency_keys (
+  token text primary key,
+  response_json jsonb not null,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz null
+);
+
+create index idempotency_keys_expires_at_idx on idempotency_keys (expires_at);
+
+create table export_jobs (
+  id text primary key,
+  owner_id text not null,
+  status text not null,
+  requested_at timestamptz not null,
+  expires_at timestamptz not null,
+  signed_url text null,
+  signed_url_expires_at timestamptz null,
+  rows integer not null default 0,
+  payload jsonb not null
+);
+
+create index export_jobs_owner_requested_at_idx
+  on export_jobs (owner_id, requested_at desc, id desc);
+
+create table export_audit_records (
+  id text primary key,
+  export_id text not null references export_jobs(id) on delete cascade,
+  audit_type text not null,
+  happened_at timestamptz not null,
+  details_json jsonb null
+);
+
+create index export_audit_records_export_happened_at_idx
+  on export_audit_records (export_id, happened_at desc, id desc);
+
+-- Lock semantics should use pg_advisory_xact_lock(hashtext(stream_id))
+-- or an equivalent row-level lease table so cross-instance settles and
+-- withdraws preserve the current single-writer behavior.
+`;
+
+export const POSTGRES_ROLLOUT_NOTES = [
+  "Ship the repository interface with the in-memory adapter as default so all routes stay backward compatible.",
+  "Create additive SQL tables first; write dual-read tests against the in-memory adapter before turning on any durable writes.",
+  "Backfill seeded and runtime stream state into PostgreSQL, then dual-write streams, idempotency tokens, and export jobs during the migration window.",
+  "Switch reads route-by-route behind a feature flag after parity checks confirm cursor ordering, lock behavior, and idempotency replay match the in-memory adapter.",
+  "Keep idempotency keys on a retention/TTL policy in the durable store so replay safety is preserved without unbounded growth.",
+];
+
+class UnsupportedKeyValueStore<K, V> implements KeyValueStore<K, V> {
+  constructor(private readonly resourceName: string) {}
+
+  get size(): number {
+    throw unsupported(this.resourceName, "size");
+  }
+
+  clear(): void {
+    throw unsupported(this.resourceName, "clear");
+  }
+
+  delete(_key: K): boolean {
+    throw unsupported(this.resourceName, "delete");
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    throw unsupported(this.resourceName, "entries");
+  }
+
+  forEach(_callbackfn: (value: V, key: K) => void): void {
+    throw unsupported(this.resourceName, "forEach");
+  }
+
+  get(_key: K): V | undefined {
+    throw unsupported(this.resourceName, "get");
+  }
+
+  has(_key: K): boolean {
+    throw unsupported(this.resourceName, "has");
+  }
+
+  set(_key: K, _value: V): void {
+    throw unsupported(this.resourceName, "set");
+  }
+
+  values(): IterableIterator<V> {
+    throw unsupported(this.resourceName, "values");
+  }
+}
+
+class UnsupportedAppendOnlyStore<T> implements AppendOnlyStore<T> {
+  constructor(private readonly resourceName: string) {}
+
+  get length(): number {
+    throw unsupported(this.resourceName, "length");
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    throw unsupported(this.resourceName, "iterator");
+  }
+
+  clear(): void {
+    throw unsupported(this.resourceName, "clear");
+  }
+
+  push(_value: T): number {
+    throw unsupported(this.resourceName, "push");
+  }
+
+  some(_predicate: (value: T, index: number, array: T[]) => boolean): boolean {
+    throw unsupported(this.resourceName, "some");
+  }
+
+  toArray(): T[] {
+    throw unsupported(this.resourceName, "toArray");
+  }
+}
+
+class PostgresStreamRepository implements StreamRepository {
+  readonly activity: KeyValueStore<string, ActivityEvent>;
+  readonly streams: KeyValueStore<string, Stream>;
+  readonly users: KeyValueStore<string, User>;
+
+  constructor(private readonly executor: SqlExecutor) {
+    void this.executor;
+    this.activity = new UnsupportedKeyValueStore<string, ActivityEvent>("activity_events");
+    this.streams = new UnsupportedKeyValueStore<string, Stream>("streams");
+    this.users = new UnsupportedKeyValueStore<string, User>("users");
+  }
+
+  reset(): void {
+    throw unsupported("postgres-stream-repository", "reset");
+  }
+
+  async withLock<T>(_id: string, _callback: () => Promise<T>): Promise<T> {
+    throw unsupported("postgres-stream-repository", "withLock");
+  }
+}
+
+class PostgresIdempotencyStore
+  extends UnsupportedKeyValueStore<string, unknown>
+  implements IdempotencyStore
+{
+  constructor(executor: SqlExecutor) {
+    void executor;
+    super("idempotency_keys");
+  }
+
+  reset(): void {
+    throw unsupported("postgres-idempotency-store", "reset");
+  }
+}
+
+class PostgresExportRepository implements ExportRepository {
+  readonly audit: AppendOnlyStore<ExportAuditRecord>;
+  readonly jobs: KeyValueStore<string, ExportJob>;
+  readonly processing: KeyValueStore<string, Promise<void>>;
+
+  constructor(private readonly executor: SqlExecutor) {
+    void this.executor;
+    this.audit = new UnsupportedAppendOnlyStore<ExportAuditRecord>("export_audit_records");
+    this.jobs = new UnsupportedKeyValueStore<string, ExportJob>("export_jobs");
+    this.processing = new UnsupportedKeyValueStore<string, Promise<void>>("export_job_processing");
+  }
+
+  reset(): void {
+    throw unsupported("postgres-export-repository", "reset");
+  }
+}
+
+function unsupported(resourceName: string, methodName: string): Error {
+  return new Error(
+    `PostgreSQL persistence seam is defined, but ${resourceName}.${methodName} is not wired yet.`,
+  );
+}
+
+export function createPostgresPersistenceStore(
+  config: PostgresStoreConfig,
+): PersistenceStore {
+  return {
+    kind: "postgres",
+    streamRepository: new PostgresStreamRepository(config.executor),
+    idempotencyStore: new PostgresIdempotencyStore(config.executor),
+    exportRepository: new PostgresExportRepository(config.executor),
+  };
+}

--- a/app/lib/stream-service.ts
+++ b/app/lib/stream-service.ts
@@ -1,4 +1,4 @@
-import { db } from "./db";
+import { getStore } from "./db";
 import { transition } from "./state-machine";
 import { StreamAction, ApiError } from "@/app/types/openapi";
 
@@ -8,7 +8,8 @@ export type ServiceResult<T> =
 
 export class StreamService {
   static async applyAction(streamId: string, action: StreamAction, idempotencyKey?: string): Promise<ServiceResult<any>> {
-    const stream = db.streams.get(streamId);
+    const { idempotencyStore, streamRepository } = getStore();
+    const stream = streamRepository.streams.get(streamId);
     if (!stream) {
       return { 
         ok: false, 
@@ -18,8 +19,8 @@ export class StreamService {
     }
 
     // Idempotency check (simplified for mock)
-    if (idempotencyKey && db.idempotency.has(idempotencyKey)) {
-      return { ok: true, data: db.idempotency.get(idempotencyKey) };
+    if (idempotencyKey && idempotencyStore.has(idempotencyKey)) {
+      return { ok: true, data: idempotencyStore.get(idempotencyKey) };
     }
 
     const result = transition(stream.status, action);
@@ -41,10 +42,10 @@ export class StreamService {
     if (stream.status === "ended") stream.nextAction = "withdraw";
     if (stream.status === "withdrawn") stream.nextAction = undefined;
 
-    db.streams.set(streamId, stream);
+    streamRepository.streams.set(streamId, stream);
 
     if (idempotencyKey) {
-      db.idempotency.set(idempotencyKey, stream);
+      idempotencyStore.set(idempotencyKey, stream);
     }
 
     // Emit event for real-time updates

--- a/docs/persistent-store-interface.md
+++ b/docs/persistent-store-interface.md
@@ -1,0 +1,81 @@
+# Persistent Store Interface
+
+Issue #249 introduces a persistence seam for backend state that was previously
+kept only in process memory.
+
+## Interfaces
+
+`app/lib/db.ts` now defines three backend-facing interfaces:
+
+- `StreamRepository`
+  - owns stream records, user records, activity events, and per-stream lock semantics
+- `IdempotencyStore`
+  - owns replay tokens and cached idempotent responses
+- `ExportRepository`
+  - owns export jobs, export audit records, and async export processing state
+
+The default runtime store is still the in-memory adapter so existing local and
+test flows remain backward compatible.
+
+## Adapters
+
+Adapters live in `app/lib/repositories/`:
+
+- `in-memory.ts`
+  - default adapter backed by `Map`s and an in-process lock queue
+- `postgres.ts`
+  - durable adapter seam with a PostgreSQL-oriented schema sketch and rollout notes
+
+The PostgreSQL adapter is intentionally a seam, not a live cutover. It gives
+the route layer a stable contract before the SQL migration track is wired in.
+
+## Lock, Cursor, and Idempotency Semantics
+
+The refactor preserves the existing behavior:
+
+- `withLock(streamId, callback)` still serializes concurrent settle/withdraw
+  work per stream ID
+- `encodeCursor` and `decodeCursor` remain base64 wrappers over stable record IDs
+- `idempotencyToken(scope, key)` remains the canonical replay token format
+
+## PostgreSQL Schema Sketch
+
+The durable adapter exports `POSTGRES_SCHEMA_SKETCH` in
+`app/lib/repositories/postgres.ts`.
+
+Highlights:
+
+- `streams`
+  - canonical stream lifecycle state
+  - indexed by `(status, created_at, id)` for cursor-friendly listing
+- `users`
+  - wallet-address keyed user records
+- `activity_events`
+  - append-only stream/activity history
+  - indexed for stream-scoped and type-scoped pagination
+- `idempotency_keys`
+  - cached response payloads with an optional expiry/TTL column
+- `export_jobs`
+  - async export lifecycle state per tenant
+- `export_audit_records`
+  - append-only audit trail for request/download/expiry events
+
+Locking should move to transaction-scoped PostgreSQL advisory locks or an
+equivalent lease mechanism so cross-instance writers preserve the current
+single-writer settle/withdraw behavior.
+
+## Rollout Notes
+
+The durable migration path is designed to be backward compatible:
+
+1. Land the interface and keep the in-memory adapter as the default.
+2. Create additive SQL tables first; do not switch reads yet.
+3. Backfill stream, idempotency, and export state into PostgreSQL.
+4. Dual-write during the migration window.
+5. Cut reads over behind a feature flag after parity checks confirm:
+   - cursor ordering is unchanged
+   - idempotency replay returns the same payloads
+   - per-stream lock semantics still prevent double settle/withdraw
+
+This sequencing aligns with the existing SQL migration track by separating the
+contract change from the storage cutover.


### PR DESCRIPTION
Closes: #249 

## Summary

This PR replaces the hard-coded in-memory database shape with a pluggable persistence interface so stream state can move to a durable backend without rewriting routes.

## What changed

- extracted `StreamRepository`, `IdempotencyStore`, `ExportRepository`, and `PersistenceStore` in `app/lib/db.ts`
- kept the current `Map`-backed behavior as the default adapter in `app/lib/repositories/in-memory.ts`
- added a PostgreSQL-oriented durable adapter seam in `app/lib/repositories/postgres.ts`
- rewired stream, export, activity, privacy, and reconciliation code to depend on `getStore()` instead of raw process-memory Maps
- preserved compatibility through the legacy `db` facade, `withLock`, `encodeCursor` / `decodeCursor`, and `idempotencyToken`
- added repository-layer tests for lock semantics, cursor stability, idempotency parity, reset behavior, and durable-store fallback behavior
- documented the migration seam, schema sketch, and rollout plan in `docs/persistent-store-interface.md`
- added a README section pointing to the new persistence architecture docs

## Design notes

### In-memory adapter

The in-memory adapter remains the runtime default, so current local behavior and existing route assumptions stay intact while the SQL migration track is built out.

### Durable adapter seam

The PostgreSQL adapter is intentionally a seam, not a cutover. It exposes:

- a schema sketch for streams, users, activity events, idempotency keys, export jobs, and export audit records
- rollout notes for additive schema creation, backfill, dual-write, and feature-flagged read cutover
- explicit unsupported operations so an accidental production switch fails loudly instead of silently degrading behavior

### Behavior preserved

- `withLock(streamId, callback)` still serializes concurrent work per stream
- cursor encoding/decoding still uses the same base64 record-id format
- `idempotencyToken(scope, key)` is unchanged
- the legacy `db.*` facade still points at the active store for compatibility with existing tests and helpers

## Testing

Completed:

- repository seam smoke checks passed against the new adapters:
  - seed/reset behavior
  - legacy `db` facade wiring
  - same-key lock serialization
  - different-key lock independence
  - cursor/idempotency compatibility
  - export/idempotency repository operations
  - PostgreSQL seam fallback behavior

Attempted but blocked:

```bash
npm install
npm test