### PR TITLE
feat: implement pause and resume with accrual freeze

### DIFF
--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -35,6 +35,8 @@ pub struct Stream {
     pub duration: u64,
     pub last_update: u64,
     pub status: StreamStatus,
+    pub pause_time: u64,
+    pub total_paused_duration: u64,
 }
 
 #[derive(Clone)]
@@ -143,6 +145,8 @@ impl Contract {
             duration,
             last_update,
             status,
+            pause_time: 0,
+            total_paused_duration: 0,
         };
 
         env.storage()
@@ -212,7 +216,9 @@ impl Contract {
             return Err(Error::AlreadySettled);
         }
 
-        if stream.status != StreamStatus::Active {
+        // Allow withdrawals from Active or Paused streams
+        // Paused streams have vested amounts settled in released_amount
+        if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
             return Err(Error::InvalidState);
         }
 
@@ -240,6 +246,73 @@ impl Contract {
 
         Ok(amount)
     }
+
+    /// Pauses an active stream, freezing accrual while preserving vested funds.
+    ///
+    /// Only the stream sender may call this. On pause, status is set to Paused
+    /// and pause_time is recorded. Vested amount remains withdrawable but does
+    /// not increase while paused.
+    pub fn pause(env: Env, stream_id: u64) -> Result<Stream, Error> {
+        let mut stream = get_existing_stream(&env, stream_id)?;
+        stream.sender.require_auth();
+
+        if stream.status != StreamStatus::Active {
+            return Err(Error::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        
+        stream.last_update = now;
+        stream.status = StreamStatus::Paused;
+        stream.pause_time = now;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+
+        Ok(stream)
+    }
+
+    /// Resumes a paused stream, extending end_time to preserve unstreamed time.
+    ///
+    /// Only the stream sender may call this. On resume, the end_time is extended
+    /// by the paused duration so the remaining streamable amount is preserved.
+    /// Status is set back to Active.
+    pub fn resume(env: Env, stream_id: u64) -> Result<Stream, Error> {
+        let mut stream = get_existing_stream(&env, stream_id)?;
+        stream.sender.require_auth();
+
+        if stream.status != StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        let paused_duration = now
+            .checked_sub(stream.pause_time)
+            .ok_or(Error::InvalidTimeRange)?;
+
+        // Track total paused duration for accrual calculations
+        stream.total_paused_duration = stream
+            .total_paused_duration
+            .checked_add(paused_duration)
+            .ok_or(Error::InvalidTimeRange)?;
+
+        // Extend end_time by the paused duration to preserve unstreamed time
+        stream.end_time = stream
+            .end_time
+            .checked_add(paused_duration)
+            .ok_or(Error::InvalidTimeRange)?;
+        
+        stream.last_update = now;
+        stream.status = StreamStatus::Active;
+        stream.pause_time = 0;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+
+        Ok(stream)
+    }
 }
 
 fn next_stream_id(env: &Env) -> u64 {
@@ -257,13 +330,22 @@ fn get_existing_stream(env: &Env, stream_id: u64) -> Result<Stream, Error> {
 }
 
 fn withdrawable_amount(env: &Env, stream: &Stream) -> i128 {
-    if stream.status != StreamStatus::Active || stream.start_time == 0 {
+    // Draft streams and streams that haven't started don't accrue
+    if stream.start_time == 0 {
         return 0;
     }
 
-    let now = env.ledger().timestamp();
+    // For paused streams, calculate accrued amount at pause time
+    let now = if stream.status == StreamStatus::Paused {
+        stream.pause_time
+    } else {
+        env.ledger().timestamp()
+    };
+
     let elapsed = min(now, stream.end_time) - stream.start_time;
-    let accrued = (stream.total_amount * elapsed as i128) / stream.duration as i128;
+    // Subtract total paused duration from elapsed time
+    let active_elapsed = elapsed.saturating_sub(stream.total_paused_duration);
+    let accrued = (stream.total_amount * active_elapsed as i128) / stream.duration as i128;
 
     accrued - stream.released_amount
 }

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -232,3 +232,190 @@ fn blocked_token_returns_token_not_allowed() {
         Error::TokenNotAllowed
     );
 }
+
+#[test]
+fn pause_freezes_accrual_and_preserves_vested_funds() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    assert_eq!(data.client.withdrawable(&stream_id), 500);
+
+    // Pause the stream
+    let paused = data.client.pause(&stream_id);
+    assert_eq!(paused.status, StreamStatus::Paused);
+    assert_eq!(paused.pause_time, 1_050);
+    assert_eq!(paused.released_amount, 0);
+
+    // No accrual while paused - vested amount remains withdrawable
+    data.env.ledger().set_timestamp(1_100);
+    assert_eq!(data.client.withdrawable(&stream_id), 500);
+}
+
+#[test]
+fn resume_extends_end_time_to_preserve_unstreamed_amount() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Pause for 30 seconds
+    data.env.ledger().set_timestamp(1_080);
+
+    // Resume the stream
+    let resumed = data.client.resume(&stream_id);
+    assert_eq!(resumed.status, StreamStatus::Active);
+    assert_eq!(resumed.pause_time, 0);
+    // End time should be extended by 30 seconds (paused duration)
+    assert_eq!(resumed.end_time, 1_130); // Original 1_100 + 30
+
+    // Accrual resumes from where it left off
+    // 50 seconds active before pause, 30 seconds paused, 10 seconds active after resume
+    // Total active: 60 seconds, but we only count 50 before pause + 10 after = 60
+    // At timestamp 1_090: elapsed from start (1_000) = 90 seconds
+    // Subtract paused duration (30) = 60 seconds active
+    // Accrued: (1000 * 60) / 100 = 600
+    // Withdrawable: 600 - 0 (no withdrawals yet) = 600
+    data.env.ledger().set_timestamp(1_090);
+    assert_eq!(data.client.withdrawable(&stream_id), 600);
+}
+
+#[test]
+fn double_pause_is_rejected() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    assert_contract_error!(
+        data.client.try_pause(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn resume_without_pause_is_rejected() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    assert_contract_error!(
+        data.client.try_resume(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn pause_non_active_stream_is_rejected() {
+    let data = setup();
+
+    // Create a draft stream
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &true,
+    );
+
+    assert_contract_error!(
+        data.client.try_pause(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn pause_then_withdraw() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Withdraw the vested amount while paused
+    assert_eq!(data.client.withdraw(&stream_id, &500), 500);
+
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.released_amount, 500); // 500 withdrawn
+    assert_eq!(stream.status, StreamStatus::Paused);
+}
+
+#[test]
+fn pause_preserves_total_streamable_amount() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Pause for 30 seconds
+    data.env.ledger().set_timestamp(1_080);
+    data.client.resume(&stream_id);
+
+    // Stream to the new end time (1_130)
+    // At timestamp 1_130: elapsed from start (1_000) = 130 seconds
+    // Subtract paused duration (30) = 100 seconds active
+    // Accrued: (1000 * 100) / 100 = 1000
+    // Withdrawable: 1000 - 0 = 1000
+    data.env.ledger().set_timestamp(1_130);
+    assert_eq!(data.client.withdrawable(&stream_id), 1000);
+
+    // Total should still be 1_000
+    data.client.withdraw(&stream_id, &1000);
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+}


### PR DESCRIPTION
Closes #254

---

macbook@MACBOOKs-MacBook-Pro-3 contracts % cargo test -p streampay-stream
   Compiling streampay-stream v0.0.0 (/Users/macbook/stellar_wave_5/StreamPay-Frontend/contracts/contracts/streampay-stream)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.88s
     Running unittests src/lib.rs (target/debug/deps/streampay_stream-bc3729a38fe85134)

running 16 tests
test test::invalid_create_inputs_return_stable_errors ... ok
test test::missing_stream_returns_not_found ... ok
test test::admin_guards_return_stable_errors ... ok
test test::blocked_token_returns_token_not_allowed ... ok
test test::over_withdraw_is_rejected ... ok
test test::pause_non_active_stream_is_rejected ... ok
test test::active_stream_starts_accruing_at_creation ... ok
test test::draft_stream_accrues_nothing_until_started ... ok
test test::double_pause_is_rejected ... ok
test test::pause_freezes_accrual_and_preserves_vested_funds ... ok
test test::resume_without_pause_is_rejected ... ok
test test::resume_extends_end_time_to_preserve_unstreamed_amount ... ok
test test::pause_preserves_total_streamable_amount ... ok
test test::pause_then_withdraw ... ok
test test::starting_non_draft_is_rejected_with_invalid_state ... ok
test test::withdraw_settles_when_total_is_released ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s