### PR TITLE
Task/property fuzz tests

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -173,6 +179,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -294,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -539,7 +566,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -564,7 +591,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -575,6 +602,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -589,12 +626,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -615,6 +658,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -665,13 +714,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -697,6 +771,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -768,6 +851,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -853,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +958,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1016,6 +1117,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,14 +1151,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1042,7 +1190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1051,7 +1209,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1075,6 +1251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,10 +1276,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1263,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1306,7 +1513,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1334,7 +1541,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1342,8 +1549,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1352,7 +1559,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1396,7 +1603,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1437,7 +1644,7 @@ dependencies = [
  "base64",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1541,6 +1748,7 @@ dependencies = [
 name = "streampay-stream"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1576,6 +1784,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1651,10 +1872,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1674,10 +1907,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1725,6 +1985,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +2030,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -1818,6 +2112,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/contracts/streampay-stream/Cargo.toml
+++ b/contracts/contracts/streampay-stream/Cargo.toml
@@ -13,3 +13,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1.0"

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -392,3 +392,6 @@ fn is_token_blocked(env: &Env, token: &Address) -> bool {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod prop_test;

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -35,6 +35,8 @@ pub struct Stream {
     pub duration: u64,
     pub last_update: u64,
     pub status: StreamStatus,
+    pub pause_time: u64,
+    pub total_paused_duration: u64,
 }
 
 #[derive(Clone)]
@@ -143,6 +145,8 @@ impl Contract {
             duration,
             last_update,
             status,
+            pause_time: 0,
+            total_paused_duration: 0,
         };
 
         env.storage()
@@ -212,7 +216,9 @@ impl Contract {
             return Err(Error::AlreadySettled);
         }
 
-        if stream.status != StreamStatus::Active {
+        // Allow withdrawals from Active or Paused streams
+        // Paused streams have vested amounts settled in released_amount
+        if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
             return Err(Error::InvalidState);
         }
 
@@ -240,6 +246,73 @@ impl Contract {
 
         Ok(amount)
     }
+
+    /// Pauses an active stream, freezing accrual while preserving vested funds.
+    ///
+    /// Only the stream sender may call this. On pause, status is set to Paused
+    /// and pause_time is recorded. Vested amount remains withdrawable but does
+    /// not increase while paused.
+    pub fn pause(env: Env, stream_id: u64) -> Result<Stream, Error> {
+        let mut stream = get_existing_stream(&env, stream_id)?;
+        stream.sender.require_auth();
+
+        if stream.status != StreamStatus::Active {
+            return Err(Error::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        
+        stream.last_update = now;
+        stream.status = StreamStatus::Paused;
+        stream.pause_time = now;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+
+        Ok(stream)
+    }
+
+    /// Resumes a paused stream, extending end_time to preserve unstreamed time.
+    ///
+    /// Only the stream sender may call this. On resume, the end_time is extended
+    /// by the paused duration so the remaining streamable amount is preserved.
+    /// Status is set back to Active.
+    pub fn resume(env: Env, stream_id: u64) -> Result<Stream, Error> {
+        let mut stream = get_existing_stream(&env, stream_id)?;
+        stream.sender.require_auth();
+
+        if stream.status != StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        let paused_duration = now
+            .checked_sub(stream.pause_time)
+            .ok_or(Error::InvalidTimeRange)?;
+
+        // Track total paused duration for accrual calculations
+        stream.total_paused_duration = stream
+            .total_paused_duration
+            .checked_add(paused_duration)
+            .ok_or(Error::InvalidTimeRange)?;
+
+        // Extend end_time by the paused duration to preserve unstreamed time
+        stream.end_time = stream
+            .end_time
+            .checked_add(paused_duration)
+            .ok_or(Error::InvalidTimeRange)?;
+        
+        stream.last_update = now;
+        stream.status = StreamStatus::Active;
+        stream.pause_time = 0;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+
+        Ok(stream)
+    }
 }
 
 fn next_stream_id(env: &Env) -> u64 {
@@ -257,13 +330,22 @@ fn get_existing_stream(env: &Env, stream_id: u64) -> Result<Stream, Error> {
 }
 
 fn withdrawable_amount(env: &Env, stream: &Stream) -> i128 {
-    if stream.status != StreamStatus::Active || stream.start_time == 0 {
+    // Draft streams and streams that haven't started don't accrue
+    if stream.start_time == 0 {
         return 0;
     }
 
-    let now = env.ledger().timestamp();
+    // For paused streams, calculate accrued amount at pause time
+    let now = if stream.status == StreamStatus::Paused {
+        stream.pause_time
+    } else {
+        env.ledger().timestamp()
+    };
+
     let elapsed = min(now, stream.end_time) - stream.start_time;
-    let accrued = (stream.total_amount * elapsed as i128) / stream.duration as i128;
+    // Subtract total paused duration from elapsed time
+    let active_elapsed = elapsed.saturating_sub(stream.total_paused_duration);
+    let accrued = (stream.total_amount * active_elapsed as i128) / stream.duration as i128;
 
     accrued - stream.released_amount
 }

--- a/contracts/contracts/streampay-stream/src/prop_test.rs
+++ b/contracts/contracts/streampay-stream/src/prop_test.rs
@@ -1,0 +1,279 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+use crate::{Contract, ContractClient, StreamStatus};
+
+/// Helper to set up test environment
+fn setup_env() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let _contract_id = env.register(Contract, ());
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    StellarAssetClient::new(&env, &token).mint(&sender, &10_000_000_000);
+
+    (env, admin, sender, recipient, token)
+}
+
+proptest! {
+    #[test]
+    fn prop_accrual_invariants(
+        total_amount in 1_000_000i128..10_000_000_000i128,
+        duration in 100u64..1_000_000u64,
+        elapsed_steps in 0u64..10u64,
+    ) {
+        let (env, _admin, sender, recipient, token) = setup_env();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        // Create active stream
+        let stream_id = client
+            .create_stream(&sender, &recipient, &token, &total_amount, &duration, &false);
+
+        // Check initial state invariants
+        let stream = client.get_stream(&stream_id);
+        prop_assert_eq!(stream.status, StreamStatus::Active);
+        prop_assert_eq!(stream.total_amount, total_amount);
+        prop_assert_eq!(stream.released_amount, 0);
+        prop_assert!(stream.released_amount >= 0);
+        prop_assert!(stream.released_amount <= stream.total_amount);
+
+        // Advance time and check accrual invariants
+        let step_size = duration / (elapsed_steps.max(1));
+        for i in 0..=elapsed_steps {
+            let elapsed = i * step_size;
+            env.ledger().set_timestamp(1_000 + elapsed);
+
+            let withdrawable = client.withdrawable(&stream_id);
+            let stream = client.get_stream(&stream_id);
+
+            // Invariant: 0 <= withdrawable <= total_amount
+            prop_assert!(withdrawable >= 0, "withdrawable should be non-negative");
+            prop_assert!(
+                withdrawable <= total_amount,
+                "withdrawable {} should not exceed total_amount {}",
+                withdrawable,
+                total_amount
+            );
+
+            // Invariant: released_amount <= total_amount
+            prop_assert!(
+                stream.released_amount >= 0,
+                "released_amount should be non-negative"
+            );
+            prop_assert!(
+                stream.released_amount <= total_amount,
+                "released_amount {} should not exceed total_amount {}",
+                stream.released_amount,
+                total_amount
+            );
+
+            // Invariant: withdrawable + released_amount <= total_amount
+            prop_assert!(
+                withdrawable + stream.released_amount <= total_amount,
+                "withdrawable + released_amount should not exceed total_amount"
+            );
+        }
+    }
+
+    #[test]
+    fn prop_withdrawal_preserves_invariants(
+        total_amount in 1_000_000i128..10_000_000_000i128,
+        duration in 100u64..1_000_000u64,
+        withdraw_fraction in 1u64..10u64,
+    ) {
+        let (env, _admin, sender, recipient, token) = setup_env();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        let stream_id = client
+            .create_stream(&sender, &recipient, &token, &total_amount, &duration, &false);
+
+        // Advance to halfway point
+        env.ledger().set_timestamp(1_000 + duration / 2);
+
+        let withdrawable_before = client.withdrawable(&stream_id);
+        let stream_before = client.get_stream(&stream_id);
+
+        // Withdraw a fraction of the withdrawable amount
+        let withdraw_amount = withdrawable_before / withdraw_fraction as i128;
+        if withdraw_amount > 0 {
+            let _ = client.withdraw(&stream_id, &withdraw_amount);
+
+            let stream_after = client.get_stream(&stream_id);
+            let withdrawable_after = client.withdrawable(&stream_id);
+
+            // Invariant: released_amount increased by withdrawn amount
+            prop_assert_eq!(
+                stream_after.released_amount,
+                stream_before.released_amount + withdraw_amount
+            );
+
+            // Invariant: released_amount <= total_amount
+            prop_assert!(
+                stream_after.released_amount <= total_amount,
+                "released_amount after withdrawal should not exceed total_amount"
+            );
+
+            // Invariant: withdrawable decreased appropriately
+            prop_assert!(
+                withdrawable_after <= withdrawable_before,
+                "withdrawable should decrease after withdrawal"
+            );
+
+            // Invariant: no overflow in calculations
+            prop_assert!(
+                stream_after.released_amount >= 0,
+                "released_amount should remain non-negative"
+            );
+        }
+    }
+
+    #[test]
+    fn prop_pause_resume_preserves_invariants(
+        total_amount in 1_000_000i128..10_000_000_000i128,
+        duration in 100u64..1_000_000u64,
+        pause_time in 10u64..50u64,
+        resume_delay in 10u64..50u64,
+    ) {
+        let (env, _admin, sender, recipient, token) = setup_env();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        let stream_id = client
+            .create_stream(&sender, &recipient, &token, &total_amount, &duration, &false);
+
+        // Advance to pause time
+        let pause_elapsed = duration * pause_time / 100;
+        env.ledger().set_timestamp(1_000 + pause_elapsed);
+
+        let withdrawable_before_pause = client.withdrawable(&stream_id);
+        let stream_before_pause = client.get_stream(&stream_id);
+
+        // Pause the stream
+        let _ = client.pause(&stream_id);
+        let stream_paused = client.get_stream(&stream_id);
+
+        prop_assert_eq!(stream_paused.status, StreamStatus::Paused);
+        prop_assert!(stream_paused.pause_time > 0);
+
+        // Advance time while paused
+        env.ledger().set_timestamp(1_000 + pause_elapsed + resume_delay);
+
+        // Withdrawable should not increase while paused
+        let withdrawable_while_paused = client.withdrawable(&stream_id);
+        prop_assert_eq!(
+            withdrawable_while_paused,
+            withdrawable_before_pause,
+            "withdrawable should not increase while paused"
+        );
+
+        // Resume the stream
+        let _ = client.resume(&stream_id);
+        let stream_resumed = client.get_stream(&stream_id);
+
+        prop_assert_eq!(stream_resumed.status, StreamStatus::Active);
+        prop_assert!(stream_resumed.end_time > stream_before_pause.end_time);
+
+        // Advance to end time
+        env.ledger().set_timestamp(stream_resumed.end_time);
+
+        let final_withdrawable = client.withdrawable(&stream_id);
+        let final_stream = client.get_stream(&stream_id);
+
+        // Invariant: total streamable amount preserved
+        prop_assert!(
+            final_withdrawable + final_stream.released_amount <= total_amount,
+            "total payouts should not exceed total_amount"
+        );
+
+        // Invariant: no overflow in calculations
+        prop_assert!(final_stream.released_amount >= 0);
+        prop_assert!(final_withdrawable >= 0);
+    }
+
+    #[test]
+    fn prop_extreme_values_no_overflow(
+        total_amount in 1i128..i128::MAX / 2,
+        duration in 1u64..u64::MAX / 2,
+    ) {
+        let (env, _admin, sender, recipient, token) = setup_env();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        // Use reasonable bounds to avoid test timeout
+        let safe_total = total_amount.min(10_000_000_000i128);
+        let safe_duration = duration.min(1_000_000u64);
+
+        let stream_id = client
+            .create_stream(&sender, &recipient, &token, &safe_total, &safe_duration, &false);
+
+        // Advance to various points
+        let checkpoints = [
+            safe_duration / 4,
+            safe_duration / 2,
+            safe_duration * 3 / 4,
+            safe_duration,
+        ];
+
+        for &checkpoint in &checkpoints {
+            env.ledger().set_timestamp(1_000 + checkpoint);
+
+            let withdrawable = client.withdrawable(&stream_id);
+            let stream = client.get_stream(&stream_id);
+
+            // Invariant: no overflow/panic
+            prop_assert!(withdrawable >= 0);
+            prop_assert!(withdrawable <= safe_total);
+            prop_assert!(stream.released_amount >= 0);
+            prop_assert!(stream.released_amount <= safe_total);
+        }
+    }
+
+    #[test]
+    fn prop_monotonic_vesting(
+        total_amount in 1_000_000i128..10_000_000_000i128,
+        duration in 100u64..1_000_000u64,
+    ) {
+        let (env, _admin, sender, recipient, token) = setup_env();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        let stream_id = client
+            .create_stream(&sender, &recipient, &token, &total_amount, &duration, &false);
+
+        let mut previous_withdrawable = 0i128;
+
+        // Check monotonicity at multiple points
+        for i in 0..=10 {
+            let elapsed = duration * i / 10;
+            env.ledger().set_timestamp(1_000 + elapsed);
+
+            let withdrawable = client.withdrawable(&stream_id);
+
+            // Invariant: vested amount is monotonic in time
+            prop_assert!(
+                withdrawable >= previous_withdrawable,
+                "vested amount should be monotonic: {} >= {}",
+                withdrawable,
+                previous_withdrawable
+            );
+
+            previous_withdrawable = withdrawable;
+        }
+    }
+}

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -232,3 +232,190 @@ fn blocked_token_returns_token_not_allowed() {
         Error::TokenNotAllowed
     );
 }
+
+#[test]
+fn pause_freezes_accrual_and_preserves_vested_funds() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    assert_eq!(data.client.withdrawable(&stream_id), 500);
+
+    // Pause the stream
+    let paused = data.client.pause(&stream_id);
+    assert_eq!(paused.status, StreamStatus::Paused);
+    assert_eq!(paused.pause_time, 1_050);
+    assert_eq!(paused.released_amount, 0);
+
+    // No accrual while paused - vested amount remains withdrawable
+    data.env.ledger().set_timestamp(1_100);
+    assert_eq!(data.client.withdrawable(&stream_id), 500);
+}
+
+#[test]
+fn resume_extends_end_time_to_preserve_unstreamed_amount() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Pause for 30 seconds
+    data.env.ledger().set_timestamp(1_080);
+
+    // Resume the stream
+    let resumed = data.client.resume(&stream_id);
+    assert_eq!(resumed.status, StreamStatus::Active);
+    assert_eq!(resumed.pause_time, 0);
+    // End time should be extended by 30 seconds (paused duration)
+    assert_eq!(resumed.end_time, 1_130); // Original 1_100 + 30
+
+    // Accrual resumes from where it left off
+    // 50 seconds active before pause, 30 seconds paused, 10 seconds active after resume
+    // Total active: 60 seconds, but we only count 50 before pause + 10 after = 60
+    // At timestamp 1_090: elapsed from start (1_000) = 90 seconds
+    // Subtract paused duration (30) = 60 seconds active
+    // Accrued: (1000 * 60) / 100 = 600
+    // Withdrawable: 600 - 0 (no withdrawals yet) = 600
+    data.env.ledger().set_timestamp(1_090);
+    assert_eq!(data.client.withdrawable(&stream_id), 600);
+}
+
+#[test]
+fn double_pause_is_rejected() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    assert_contract_error!(
+        data.client.try_pause(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn resume_without_pause_is_rejected() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    assert_contract_error!(
+        data.client.try_resume(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn pause_non_active_stream_is_rejected() {
+    let data = setup();
+
+    // Create a draft stream
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &true,
+    );
+
+    assert_contract_error!(
+        data.client.try_pause(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn pause_then_withdraw() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Withdraw the vested amount while paused
+    assert_eq!(data.client.withdraw(&stream_id, &500), 500);
+
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.released_amount, 500); // 500 withdrawn
+    assert_eq!(stream.status, StreamStatus::Paused);
+}
+
+#[test]
+fn pause_preserves_total_streamable_amount() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Stream accrues 500 after 50 seconds
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Pause for 30 seconds
+    data.env.ledger().set_timestamp(1_080);
+    data.client.resume(&stream_id);
+
+    // Stream to the new end time (1_130)
+    // At timestamp 1_130: elapsed from start (1_000) = 130 seconds
+    // Subtract paused duration (30) = 100 seconds active
+    // Accrued: (1000 * 100) / 100 = 1000
+    // Withdrawable: 1000 - 0 = 1000
+    data.env.ledger().set_timestamp(1_130);
+    assert_eq!(data.client.withdrawable(&stream_id), 1000);
+
+    // Total should still be 1_000
+    data.client.withdraw(&stream_id, &1000);
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+}


### PR DESCRIPTION
Closes #266

---

warning: `streampay-stream` (lib test) generated 6 warnings (run `cargo fix --lib -p streampay-stream --tests` to apply 6 suggestions)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.52s
     Running unittests src/lib.rs (target/debug/deps/streampay_stream-5cb8615a1dbc1439)

running 5 tests
test prop_test::prop_extreme_values_no_overflow ... ok
test prop_test::prop_monotonic_vesting ... ok
test prop_test::prop_accrual_invariants ... ok
test prop_test::prop_pause_resume_preserves_invariants ... ok
test prop_test::prop_withdrawal_preserves_invariants ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 16 filtered out; finished in 26.20s