### PR TITLE
task: unify error envelope and sync OpenAPI v2 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,65 @@ streampay-frontend/
 └── README.md
 ```
 
+## API
+
+The app exposes Next.js route handlers under `app/api/`. All routes share a single error envelope (see below).
+
+### Authentication
+
+Wallet-based auth uses a challenge/verify flow:
+
+1. `GET /api/auth/wallet?address=G…` — receive a one-time challenge nonce
+2. Sign the challenge with your Stellar private key
+3. `POST /api/auth/wallet` — submit `{ address, challenge, signature }` to receive a bearer token
+4. Pass the token as `Authorization: Bearer <token>` on all authenticated requests
+
+### Routes
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/auth/wallet` | — | Issue wallet challenge |
+| `POST` | `/api/auth/wallet` | — | Verify signature, get token |
+| `GET` | `/api/v2/streams` | Bearer | List streams (v2 shape) |
+| `POST` | `/api/v2/streams` | Bearer | Create a stream |
+| `POST` | `/api/webhooks/dlq` | — | Receive DLQ webhook events |
+| `GET` | `/api/webhooks/deliveries` | — | List delivery attempts |
+| `POST` | `/api/debug/kms-sign` | — | Sign payload via KMS (non-prod only) |
+
+### Error envelope
+
+Every error response — regardless of status code — uses this shape:
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "The requested stream does not exist.",
+    "request_id": "req_01HZ9ABCDEF"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `string` | Machine-readable error code (e.g. `BAD_REQUEST`, `UNAUTHORIZED`) |
+| `message` | `string` | Human-readable detail safe to display |
+| `request_id` | `string` | Forwarded from `x-request-id` header, or auto-generated fallback |
+
+The helper lives in `app/lib/errors/index.ts`. Use `errorResponse(code, message, status)` in every route — never return a bare `{ error: "string" }` or `{ success, error }` shape.
+
+### v2 stream shape
+
+`/api/v2/streams` returns streams in the v2 contract. Key differences from v1:
+
+| v1 field | v2 field | Notes |
+|----------|----------|-------|
+| `actions` | `allowed_actions` | Renamed |
+| `createdAt` | `created_at` | snake_case |
+| _(absent)_ | `settlement` | `null` until settled |
+
+See `app/lib/api-version.ts` for the `toV2Stream()` conversion and `openapi.json` for the full OpenAPI 3.1 spec.
+
 ## License
 
 MIT

--- a/app/api/auth/wallet/route.test.ts
+++ b/app/api/auth/wallet/route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for GET and POST /api/auth/wallet
+ */
+
+import { GET, POST } from "./route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: <T>(body: T, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+const VALID_ADDRESS = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG";
+
+function makeGetRequest(params: Record<string, string> = {}) {
+  const searchParams = new URLSearchParams(params);
+  return {
+    nextUrl: { searchParams },
+    headers: { get: () => null },
+  } as unknown as import("next/server").NextRequest;
+}
+
+function makePostRequest(body: unknown) {
+  return {
+    json: async () => {
+      if (body === "THROW") throw new Error("parse error");
+      return body;
+    },
+    headers: { get: () => null },
+  } as unknown as import("next/server").NextRequest;
+}
+
+describe("GET /api/auth/wallet", () => {
+  it("returns 200 with challenge and expires_at for a valid address", async () => {
+    const res = await GET(makeGetRequest({ address: VALID_ADDRESS }));
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { challenge: string; expires_at: string } }).body;
+    expect(typeof body.challenge).toBe("string");
+    expect(body.challenge).toMatch(/^streampay_auth_/);
+    expect(typeof body.expires_at).toBe("string");
+  });
+
+  it("returns 400 when address is missing", async () => {
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 for an invalid Stellar address", async () => {
+    const res = await GET(makeGetRequest({ address: "not-a-stellar-key" }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("error envelope has code, message, request_id", async () => {
+    const res = await GET(makeGetRequest());
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});
+
+describe("POST /api/auth/wallet", () => {
+  it("returns 200 with token and expires_at for valid body", async () => {
+    const res = await POST(
+      makePostRequest({
+        address: VALID_ADDRESS,
+        challenge: "streampay_auth_123_abc",
+        signature: "validbase64sig==",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { token: string; expires_at: string } }).body;
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.expires_at).toBe("string");
+  });
+
+  it("returns 400 when address is missing", async () => {
+    const res = await POST(
+      makePostRequest({ challenge: "ch", signature: "sig" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when challenge is missing", async () => {
+    const res = await POST(
+      makePostRequest({ address: VALID_ADDRESS, signature: "sig" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when signature is missing", async () => {
+    const res = await POST(
+      makePostRequest({ address: VALID_ADDRESS, challenge: "ch" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when body is null", async () => {
+    const res = await POST(makePostRequest(null));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when signature is empty (verification fails)", async () => {
+    const res = await POST(
+      makePostRequest({ address: VALID_ADDRESS, challenge: "ch", signature: "" }),
+    );
+    expect(res.status).toBe(401);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 500 canonical error when json() throws", async () => {
+    const res = await POST(makePostRequest("THROW"));
+    expect(res.status).toBe(500);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("WALLET_VERIFY_FAILED");
+  });
+
+  it("error envelope has code, message, request_id", async () => {
+    const res = await POST(makePostRequest(null));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});

--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest } from "next/server";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+
+/**
+ * GET /api/auth/wallet
+ *
+ * Issues a one-time challenge string for wallet-based authentication.
+ * The client signs the challenge with their Stellar private key and
+ * submits it to POST /api/auth/wallet to receive a bearer token.
+ *
+ * Query params:
+ *   - address (string, required) — Stellar public key (G…)
+ *
+ * Response: { "challenge": "<random nonce>", "expires_at": "<ISO-8601>" }
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const address = req.nextUrl.searchParams.get("address");
+
+    if (!address || !/^G[A-Z2-7]{55}$/.test(address)) {
+      return errorResponse(
+        ErrorCode.BAD_REQUEST,
+        "Query param 'address' must be a valid Stellar public key.",
+        400,
+      );
+    }
+
+    const challenge = `streampay_auth_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString(); // 5 min TTL
+
+    // TODO: persist challenge → address mapping with TTL
+    return Response.json({ challenge, expires_at: expiresAt }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.WALLET_CHALLENGE_FAILED,
+      "Failed to generate wallet authentication challenge.",
+      500,
+    );
+  }
+}
+
+/**
+ * POST /api/auth/wallet
+ *
+ * Verifies a signed challenge and issues a bearer token.
+ *
+ * Body: { "address": "G…", "challenge": "<nonce>", "signature": "<base64>" }
+ * Response: { "token": "<JWT or opaque bearer token>", "expires_at": "<ISO-8601>" }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (
+      !body ||
+      typeof body.address !== "string" ||
+      typeof body.challenge !== "string" ||
+      typeof body.signature !== "string"
+    ) {
+      return errorResponse(
+        ErrorCode.BAD_REQUEST,
+        "Request body must include 'address', 'challenge', and 'signature'.",
+        400,
+      );
+    }
+
+    // TODO: verify signature against stored challenge using Stellar SDK
+    const isValid = body.signature.length > 0; // placeholder
+
+    if (!isValid) {
+      return errorResponse(
+        ErrorCode.UNAUTHORIZED,
+        "Signature verification failed.",
+        401,
+      );
+    }
+
+    const token = `tok_${Buffer.from(body.address).toString("base64url").slice(0, 24)}`;
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); // 24 h
+
+    return Response.json({ token, expires_at: expiresAt }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.WALLET_VERIFY_FAILED,
+      "Failed to verify wallet signature.",
+      500,
+    );
+  }
+}

--- a/app/api/debug/kms-sign/route.test.ts
+++ b/app/api/debug/kms-sign/route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for POST /api/debug/kms-sign
+ *
+ * Covers:
+ *  - 200 success path with signature
+ *  - 400 for missing/empty payload
+ *  - 403 in production
+ *  - 500 on unexpected error
+ *  - canonical error envelope shape on all error paths
+ */
+
+import { POST } from "./route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: <T>(body: T, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+function makeRequest(body: unknown) {
+  return {
+    json: async () => {
+      if (body === "THROW") throw new Error("parse error");
+      return body;
+    },
+    headers: { get: () => null },
+  } as unknown as import("next/server").NextRequest;
+}
+
+const originalEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, writable: true });
+});
+
+describe("POST /api/debug/kms-sign", () => {
+  it("returns 200 with a signature for a valid payload", async () => {
+    const res = await POST(makeRequest({ payload: "aGVsbG8=" }));
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { signature: string } }).body;
+    expect(typeof body.signature).toBe("string");
+    expect(body.signature.length).toBeGreaterThan(0);
+  });
+
+  it("returns 400 when payload is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("KMS_SIGN_INVALID_INPUT");
+  });
+
+  it("returns 400 when payload is an empty string", async () => {
+    const res = await POST(makeRequest({ payload: "   " }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("KMS_SIGN_INVALID_INPUT");
+  });
+
+  it("returns 400 when payload is not a string", async () => {
+    const res = await POST(makeRequest({ payload: 42 }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("KMS_SIGN_INVALID_INPUT");
+  });
+
+  it("returns 400 when body is null", async () => {
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("KMS_SIGN_INVALID_INPUT");
+  });
+
+  it("returns 403 in production", async () => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", writable: true });
+    const res = await POST(makeRequest({ payload: "aGVsbG8=" }));
+    expect(res.status).toBe(403);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 500 canonical error when json() throws", async () => {
+    const res = await POST(makeRequest("THROW"));
+    expect(res.status).toBe(500);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("KMS_SIGN_FAILED");
+  });
+
+  it("error envelope always has code, message, request_id", async () => {
+    const res = await POST(makeRequest({}));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+
+  it("does not expose { success, error } shape (old divergent shape)", async () => {
+    const res = await POST(makeRequest({ payload: "aGVsbG8=" }));
+    const body = (res as unknown as { body: Record<string, unknown> }).body;
+    // Must NOT have top-level 'success' or top-level 'error' string
+    expect(body).not.toHaveProperty("success");
+    expect(typeof body.error).not.toBe("string");
+  });
+});

--- a/app/api/debug/kms-sign/route.ts
+++ b/app/api/debug/kms-sign/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+
+/**
+ * POST /api/debug/kms-sign
+ *
+ * Debug endpoint: signs an arbitrary payload via KMS.
+ * Only available in non-production environments.
+ *
+ * Body: { "payload": "<base64-encoded string>" }
+ * Response: { "signature": "<base64-encoded signature>" }
+ */
+export async function POST(req: NextRequest) {
+  if (process.env.NODE_ENV === "production") {
+    return errorResponse(ErrorCode.FORBIDDEN, "This endpoint is not available in production.", 403);
+  }
+
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body.payload !== "string" || body.payload.trim() === "") {
+      return errorResponse(
+        ErrorCode.KMS_SIGN_INVALID_INPUT,
+        "Request body must include a non-empty 'payload' string.",
+        400,
+      );
+    }
+
+    // TODO: call KMS signing service
+    const signature = Buffer.from(`signed:${body.payload}`).toString("base64");
+
+    return Response.json({ signature }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.KMS_SIGN_FAILED,
+      "KMS signing operation failed.",
+      500,
+    );
+  }
+}

--- a/app/api/v2/streams/route.test.ts
+++ b/app/api/v2/streams/route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for GET and POST /api/v2/streams
+ */
+
+import { GET, POST } from "./route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: <T>(body: T, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+function makeRequest(
+  opts: {
+    auth?: string | null;
+    body?: unknown;
+    params?: Record<string, string>;
+  } = {},
+) {
+  const { auth = "Bearer tok_test", body, params = {} } = opts;
+  const searchParams = new URLSearchParams(params);
+  return {
+    headers: { get: (name: string) => (name === "authorization" ? auth : null) },
+    nextUrl: { searchParams },
+    json: async () => {
+      if (body === "THROW") throw new Error("parse error");
+      return body;
+    },
+  } as unknown as import("next/server").NextRequest;
+}
+
+describe("GET /api/v2/streams", () => {
+  it("returns 200 with streams array when authenticated", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { streams: unknown[] } }).body;
+    expect(Array.isArray(body.streams)).toBe(true);
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await GET(makeRequest({ auth: null }));
+    expect(res.status).toBe(401);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when Authorization is not a Bearer token", async () => {
+    const res = await GET(makeRequest({ auth: "Basic dXNlcjpwYXNz" }));
+    expect(res.status).toBe(401);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("error envelope has code, message, request_id", async () => {
+    const res = await GET(makeRequest({ auth: null }));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});
+
+describe("POST /api/v2/streams", () => {
+  it("returns 201 with a v2 stream on valid input", async () => {
+    const res = await POST(
+      makeRequest({ body: { recipient: "GABC123", rate: "120 XLM/month" } }),
+    );
+    expect(res.status).toBe(201);
+    const body = (res as unknown as { body: Record<string, unknown> }).body;
+    // v2 shape fields
+    expect(body).toHaveProperty("id");
+    expect(body).toHaveProperty("allowed_actions");
+    expect(body).toHaveProperty("created_at");
+    expect(body).toHaveProperty("settlement");
+    expect(body.settlement).toBeNull();
+    // v1 fields must NOT be present
+    expect(body).not.toHaveProperty("actions");
+    expect(body).not.toHaveProperty("createdAt");
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await POST(
+      makeRequest({ auth: null, body: { recipient: "GABC123", rate: "120 XLM/month" } }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when recipient is missing", async () => {
+    const res = await POST(makeRequest({ body: { rate: "120 XLM/month" } }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when rate is missing", async () => {
+    const res = await POST(makeRequest({ body: { recipient: "GABC123" } }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when body is null", async () => {
+    const res = await POST(makeRequest({ body: null }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 canonical error when json() throws", async () => {
+    const res = await POST(makeRequest({ body: "THROW" }));
+    expect(res.status).toBe(500);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("STREAM_CREATE_FAILED");
+  });
+
+  it("created stream has status 'draft'", async () => {
+    const res = await POST(
+      makeRequest({ body: { recipient: "GABC123", rate: "120 XLM/month" } }),
+    );
+    const body = (res as unknown as { body: { status: string } }).body;
+    expect(body.status).toBe("draft");
+  });
+
+  it("error envelope has code, message, request_id", async () => {
+    const res = await POST(makeRequest({ auth: null, body: {} }));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});

--- a/app/api/v2/streams/route.ts
+++ b/app/api/v2/streams/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+import { toV2Stream, type StreamV1 } from "@/app/lib/api-version";
+
+/**
+ * GET /api/v2/streams
+ *
+ * Returns the authenticated user's payment streams in the v2 shape.
+ * Requires: Authorization: Bearer <token>
+ *
+ * Response: { "streams": StreamV2[] }
+ *
+ * Deprecation notice: v1 /api/streams is sunset — see Deprecation header.
+ */
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) {
+    return errorResponse(ErrorCode.UNAUTHORIZED, "Bearer token required.", 401);
+  }
+
+  try {
+    // TODO: fetch from data layer using token identity
+    const v1Streams: StreamV1[] = [];
+    const streams = v1Streams.map(toV2Stream);
+
+    return Response.json({ streams }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.INTERNAL_SERVER_ERROR,
+      "Failed to retrieve streams.",
+      500,
+    );
+  }
+}
+
+/**
+ * POST /api/v2/streams
+ *
+ * Creates a new payment stream.
+ * Requires: Authorization: Bearer <token>
+ *
+ * Body: { "recipient": "G…", "rate": "120 XLM/month", "currency": "XLM" }
+ * Response: StreamV2 (201)
+ */
+export async function POST(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) {
+    return errorResponse(ErrorCode.UNAUTHORIZED, "Bearer token required.", 401);
+  }
+
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body.recipient !== "string" || typeof body.rate !== "string") {
+      return errorResponse(
+        ErrorCode.BAD_REQUEST,
+        "Request body must include 'recipient' and 'rate'.",
+        400,
+      );
+    }
+
+    // TODO: persist stream via data layer
+    const created: StreamV1 = {
+      id: `stream_${Date.now().toString(36)}`,
+      recipient: body.recipient,
+      rate: body.rate,
+      status: "draft",
+      actions: ["start"],
+      createdAt: new Date().toISOString(),
+    };
+
+    return Response.json(toV2Stream(created), { status: 201 });
+  } catch {
+    return errorResponse(
+      ErrorCode.STREAM_CREATE_FAILED,
+      "Failed to create stream.",
+      500,
+    );
+  }
+}

--- a/app/api/webhooks/deliveries/route.test.ts
+++ b/app/api/webhooks/deliveries/route.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for GET /api/webhooks/deliveries
+ */
+
+import { GET } from "./route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: <T>(body: T, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+function makeRequest(params: Record<string, string> = {}) {
+  const searchParams = new URLSearchParams(params);
+  return {
+    nextUrl: { searchParams },
+    headers: { get: () => null },
+  } as unknown as import("next/server").NextRequest;
+}
+
+describe("GET /api/webhooks/deliveries", () => {
+  it("returns 200 with deliveries array and default limit", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { deliveries: unknown[]; limit: number } }).body;
+    expect(Array.isArray(body.deliveries)).toBe(true);
+    expect(body.limit).toBe(20);
+  });
+
+  it("respects a valid limit param", async () => {
+    const res = await GET(makeRequest({ limit: "50" }));
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { limit: number } }).body;
+    expect(body.limit).toBe(50);
+  });
+
+  it("returns 400 for limit = 0", async () => {
+    const res = await GET(makeRequest({ limit: "0" }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 for limit > 100", async () => {
+    const res = await GET(makeRequest({ limit: "101" }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 for non-numeric limit", async () => {
+    const res = await GET(makeRequest({ limit: "abc" }));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("passes cursor through in the response", async () => {
+    const res = await GET(makeRequest({ cursor: "tok_xyz" }));
+    expect(res.status).toBe(200);
+    const body = (res as unknown as { body: { cursor: string } }).body;
+    expect(body.cursor).toBe("tok_xyz");
+  });
+
+  it("returns null cursor when none provided", async () => {
+    const res = await GET(makeRequest());
+    const body = (res as unknown as { body: { cursor: null } }).body;
+    expect(body.cursor).toBeNull();
+  });
+
+  it("error envelope has code, message, request_id", async () => {
+    const res = await GET(makeRequest({ limit: "0" }));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});

--- a/app/api/webhooks/deliveries/route.ts
+++ b/app/api/webhooks/deliveries/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+
+/**
+ * GET /api/webhooks/deliveries
+ *
+ * Returns a paginated list of webhook delivery attempts.
+ * Query params:
+ *   - limit  (number, default 20, max 100)
+ *   - cursor (opaque pagination cursor)
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = req.nextUrl;
+    const rawLimit = searchParams.get("limit");
+    const cursor = searchParams.get("cursor") ?? undefined;
+
+    const limit = rawLimit !== null ? parseInt(rawLimit, 10) : 20;
+
+    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+      return errorResponse(
+        ErrorCode.BAD_REQUEST,
+        "Query param 'limit' must be an integer between 1 and 100.",
+        400,
+      );
+    }
+
+    // TODO: fetch delivery records from the data layer
+    const deliveries: unknown[] = [];
+
+    return Response.json({ deliveries, cursor: cursor ?? null, limit }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.DELIVERY_FETCH_FAILED,
+      "Failed to retrieve webhook deliveries.",
+      500,
+    );
+  }
+}

--- a/app/api/webhooks/dlq/route.test.ts
+++ b/app/api/webhooks/dlq/route.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for POST /api/webhooks/dlq
+ *
+ * Verifies that:
+ *  - valid payloads return 200
+ *  - invalid/missing body returns 400 with canonical error envelope
+ *  - unexpected errors return 500 with canonical error envelope
+ */
+
+import { POST } from "./route";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: <T>(body: T, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+function makeRequest(body: unknown, contentType = "application/json") {
+  return {
+    json: async () => {
+      if (body === "THROW") throw new Error("parse error");
+      return body;
+    },
+    headers: { get: () => contentType },
+  } as unknown as import("next/server").NextRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("POST /api/webhooks/dlq", () => {
+  it("returns 200 { received: true } for a valid JSON body", async () => {
+    const res = await POST(makeRequest({ event: "payment.failed", id: "evt_1" }));
+    expect(res.status).toBe(200);
+    expect((res as unknown as { body: { received: boolean } }).body).toEqual({ received: true });
+  });
+
+  it("returns 400 canonical error when body is null", async () => {
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(typeof body.error.request_id).toBe("string");
+  });
+
+  it("returns 400 canonical error when body is a string (not an object)", async () => {
+    const res = await POST(makeRequest("just a string"));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 canonical error when body is an array", async () => {
+    const res = await POST(makeRequest([1, 2, 3]));
+    expect(res.status).toBe(400);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 500 canonical error when json() throws", async () => {
+    const res = await POST(makeRequest("THROW"));
+    expect(res.status).toBe(500);
+    const body = (res as unknown as { body: { error: { code: string } } }).body;
+    expect(body.error.code).toBe("WEBHOOK_PROCESSING_FAILED");
+    expect(typeof body.error.request_id).toBe("string");
+  });
+
+  it("error envelope always has code, message, request_id", async () => {
+    const res = await POST(makeRequest(null));
+    const body = (res as unknown as { body: { error: Record<string, unknown> } }).body;
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(body.error).toHaveProperty("request_id");
+  });
+});

--- a/app/api/webhooks/dlq/route.ts
+++ b/app/api/webhooks/dlq/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+
+/**
+ * POST /api/webhooks/dlq
+ *
+ * Receives dead-letter-queue webhook events for reprocessing.
+ * Returns 200 on success, or the canonical error envelope on failure.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body !== "object") {
+      return errorResponse(ErrorCode.BAD_REQUEST, "Request body must be a JSON object.", 400);
+    }
+
+    // TODO: enqueue body for reprocessing
+    return Response.json({ received: true }, { status: 200 });
+  } catch {
+    return errorResponse(
+      ErrorCode.WEBHOOK_PROCESSING_FAILED,
+      "Failed to process dead-letter webhook event.",
+      500,
+    );
+  }
+}

--- a/app/lib/api-version.test.ts
+++ b/app/lib/api-version.test.ts
@@ -1,0 +1,59 @@
+import { toV2Stream, type StreamV1, type StreamV2 } from "./api-version";
+
+const baseV1: StreamV1 = {
+  id: "stream_001",
+  recipient: "GABC123",
+  rate: "120 XLM/month",
+  status: "active",
+  actions: ["pause", "stop"],
+  createdAt: "2024-01-15T10:00:00.000Z",
+};
+
+describe("toV2Stream()", () => {
+  it("maps v1 fields to v2 shape correctly", () => {
+    const v2 = toV2Stream(baseV1);
+
+    expect(v2.id).toBe(baseV1.id);
+    expect(v2.recipient).toBe(baseV1.recipient);
+    expect(v2.rate).toBe(baseV1.rate);
+    expect(v2.status).toBe(baseV1.status);
+  });
+
+  it("renames 'actions' → 'allowed_actions'", () => {
+    const v2 = toV2Stream(baseV1);
+    expect(v2.allowed_actions).toEqual(["pause", "stop"]);
+    expect((v2 as unknown as { actions?: unknown }).actions).toBeUndefined();
+  });
+
+  it("renames 'createdAt' → 'created_at'", () => {
+    const v2 = toV2Stream(baseV1);
+    expect(v2.created_at).toBe("2024-01-15T10:00:00.000Z");
+    expect((v2 as unknown as { createdAt?: unknown }).createdAt).toBeUndefined();
+  });
+
+  it("sets settlement to null by default", () => {
+    const v2 = toV2Stream(baseV1);
+    expect(v2.settlement).toBeNull();
+  });
+
+  it("preserves all four status values", () => {
+    const statuses: StreamV1["status"][] = ["draft", "active", "paused", "ended"];
+    for (const status of statuses) {
+      const v2 = toV2Stream({ ...baseV1, status });
+      expect(v2.status).toBe(status);
+    }
+  });
+
+  it("preserves an empty actions array", () => {
+    const v2 = toV2Stream({ ...baseV1, actions: [] });
+    expect(v2.allowed_actions).toEqual([]);
+  });
+
+  it("returns a plain object matching the StreamV2 interface", () => {
+    const v2: StreamV2 = toV2Stream(baseV1);
+    const keys = Object.keys(v2).sort();
+    expect(keys).toEqual(
+      ["allowed_actions", "created_at", "id", "rate", "recipient", "settlement", "status"].sort(),
+    );
+  });
+});

--- a/app/lib/api-version.ts
+++ b/app/lib/api-version.ts
@@ -1,0 +1,54 @@
+/**
+ * API versioning utilities.
+ *
+ * v1 → v2 field mapping for stream objects:
+ *   - `actions`        → `allowed_actions`  (renamed)
+ *   - `createdAt`      → `created_at`       (snake_case)
+ *   - (new)            → `settlement`       (null until settled)
+ */
+
+/** Raw stream shape returned by the data layer / v1 contract. */
+export interface StreamV1 {
+  id: string;
+  recipient: string;
+  rate: string;
+  status: "draft" | "active" | "paused" | "ended";
+  actions: string[];
+  createdAt: string;
+}
+
+/** v2 wire shape — the canonical contract for /api/v2/streams. */
+export interface StreamV2 {
+  id: string;
+  recipient: string;
+  rate: string;
+  status: "draft" | "active" | "paused" | "ended";
+  /** Replaces v1 `actions`. */
+  allowed_actions: string[];
+  /** ISO-8601 timestamp; replaces v1 `createdAt`. */
+  created_at: string;
+  /**
+   * Settlement details once a stream has been settled, otherwise `null`.
+   * Clients must handle `null` explicitly.
+   */
+  settlement: StreamSettlement | null;
+}
+
+export interface StreamSettlement {
+  settled_at: string;
+  amount: string;
+  currency: string;
+}
+
+/** Convert a v1 stream object to the v2 wire shape. */
+export function toV2Stream(v1: StreamV1): StreamV2 {
+  return {
+    id: v1.id,
+    recipient: v1.recipient,
+    rate: v1.rate,
+    status: v1.status,
+    allowed_actions: v1.actions,
+    created_at: v1.createdAt,
+    settlement: null,
+  };
+}

--- a/app/lib/errors/index.test.ts
+++ b/app/lib/errors/index.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the shared errorResponse helper.
+ *
+ * We mock next/server so these run in the jsdom Jest environment
+ * without a real Next.js request context.
+ */
+
+import { errorResponse, ErrorCode, type ErrorEnvelope } from "./index";
+
+// ---------------------------------------------------------------------------
+// Minimal NextResponse stub — mirrors the real shape we rely on
+// ---------------------------------------------------------------------------
+jest.mock("next/server", () => {
+  return {
+    NextResponse: {
+      json: <T>(body: T, init?: { status?: number }) => ({
+        status: init?.status ?? 200,
+        body,
+        json: async () => body,
+      }),
+    },
+  };
+});
+
+// headers() is called inside resolveRequestId; stub it to avoid RSC errors
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function parseBody(res: ReturnType<typeof errorResponse>): Promise<ErrorEnvelope> {
+  // Our stub stores body directly
+  return (res as unknown as { body: ErrorEnvelope }).body;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("errorResponse()", () => {
+  it("returns the canonical { error: { code, message, request_id } } shape", async () => {
+    const res = errorResponse(ErrorCode.NOT_FOUND, "Resource not found.", 404);
+    const body = await parseBody(res);
+
+    expect(body).toMatchObject({
+      error: {
+        code: "NOT_FOUND",
+        message: "Resource not found.",
+      },
+    });
+    expect(typeof body.error.request_id).toBe("string");
+    expect(body.error.request_id.length).toBeGreaterThan(0);
+  });
+
+  it("sets the HTTP status code correctly", () => {
+    const res = errorResponse(ErrorCode.BAD_REQUEST, "Bad input.", 400);
+    expect((res as unknown as { status: number }).status).toBe(400);
+  });
+
+  it("defaults to HTTP 500 when no status is provided", () => {
+    const res = errorResponse(ErrorCode.INTERNAL_SERVER_ERROR, "Oops.");
+    expect((res as unknown as { status: number }).status).toBe(500);
+  });
+
+  it("accepts arbitrary string codes (not just ErrorCode constants)", async () => {
+    const res = errorResponse("CUSTOM_CODE", "Custom error.", 422);
+    const body = await parseBody(res);
+    expect(body.error.code).toBe("CUSTOM_CODE");
+  });
+
+  it("always includes a request_id even when headers() throws", async () => {
+    // Override the mock to simulate headers() throwing
+    jest.resetModules();
+    jest.mock("next/headers", () => ({
+      headers: () => {
+        throw new Error("Not in request context");
+      },
+    }));
+
+    // Re-import after resetting modules
+    const { errorResponse: er } = await import("./index");
+    const res = er(ErrorCode.INTERNAL_SERVER_ERROR, "Oops.");
+    const body = (res as unknown as { body: ErrorEnvelope }).body;
+    expect(typeof body.error.request_id).toBe("string");
+    expect(body.error.request_id.length).toBeGreaterThan(0);
+  });
+
+  it("uses x-request-id header when present", async () => {
+    jest.resetModules();
+    jest.mock("next/headers", () => ({
+      headers: () => ({ get: (name: string) => (name === "x-request-id" ? "req_abc123" : null) }),
+    }));
+    jest.mock("next/server", () => ({
+      NextResponse: {
+        json: <T>(body: T, init?: { status?: number }) => ({ status: init?.status ?? 200, body }),
+      },
+    }));
+
+    const { errorResponse: er } = await import("./index");
+    const res = er(ErrorCode.NOT_FOUND, "Not found.", 404);
+    const body = (res as unknown as { body: ErrorEnvelope }).body;
+    expect(body.error.request_id).toBe("req_abc123");
+  });
+});

--- a/app/lib/errors/index.ts
+++ b/app/lib/errors/index.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+
+/**
+ * Canonical error envelope used by every API route.
+ *
+ * Shape:
+ * ```json
+ * {
+ *   "error": {
+ *     "code":       "STREAM_NOT_FOUND",
+ *     "message":    "The requested stream does not exist.",
+ *     "request_id": "req_01HZ..."
+ *   }
+ * }
+ * ```
+ */
+export interface ErrorEnvelope {
+  error: {
+    code: string;
+    message: string;
+    request_id: string;
+  };
+}
+
+/**
+ * Well-known error codes used across routes.
+ * Extend this list as new routes are added.
+ */
+export const ErrorCode = {
+  // Generic
+  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
+  NOT_FOUND: "NOT_FOUND",
+  BAD_REQUEST: "BAD_REQUEST",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
+  // Webhooks
+  WEBHOOK_PROCESSING_FAILED: "WEBHOOK_PROCESSING_FAILED",
+  DELIVERY_FETCH_FAILED: "DELIVERY_FETCH_FAILED",
+  // KMS / signing
+  KMS_SIGN_FAILED: "KMS_SIGN_FAILED",
+  KMS_SIGN_INVALID_INPUT: "KMS_SIGN_INVALID_INPUT",
+  // Auth
+  WALLET_CHALLENGE_FAILED: "WALLET_CHALLENGE_FAILED",
+  WALLET_VERIFY_FAILED: "WALLET_VERIFY_FAILED",
+  // Streams
+  STREAM_NOT_FOUND: "STREAM_NOT_FOUND",
+  STREAM_CREATE_FAILED: "STREAM_CREATE_FAILED",
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * Reads the `x-request-id` header forwarded by the gateway/load-balancer,
+ * or generates a lightweight fallback so every response always carries one.
+ */
+function resolveRequestId(): string {
+  try {
+    const hdrs = headers();
+    const forwarded = (hdrs as unknown as { get(name: string): string | null }).get("x-request-id");
+    if (forwarded) return forwarded;
+  } catch {
+    // headers() throws outside a request context (e.g. unit tests)
+  }
+  // Fallback: timestamp + random hex — not a UUID but stable enough for logs
+  return `req_${Date.now().toString(36)}_${Math.random().toString(16).slice(2, 10)}`;
+}
+
+/**
+ * Build a `NextResponse` with the canonical error envelope.
+ *
+ * @param code    - Machine-readable error code (use `ErrorCode.*`)
+ * @param message - Human-readable description safe to expose to clients
+ * @param status  - HTTP status code (default 500)
+ */
+export function errorResponse(
+  code: string,
+  message: string,
+  status = 500,
+): NextResponse<ErrorEnvelope> {
+  const request_id = resolveRequestId();
+  return NextResponse.json<ErrorEnvelope>(
+    { error: { code, message, request_id } },
+    { status },
+  );
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,531 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "StreamPay API",
+    "version": "2.0.0",
+    "description": "REST API for the StreamPay payment-streaming platform on Stellar.\n\nAll error responses use the canonical envelope:\n```json\n{ \"error\": { \"code\": \"ERROR_CODE\", \"message\": \"Human-readable detail.\", \"request_id\": \"req_...\" } }\n```\n\nv1 stream paths are deprecated and will be removed. Use `/api/v2/streams`."
+  },
+  "servers": [
+    { "url": "http://localhost:3000", "description": "Local development" }
+  ],
+  "security": [
+    { "bearerAuth": [] }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque",
+        "description": "Obtain a token via POST /api/auth/wallet, then pass it as `Authorization: Bearer <token>`."
+      }
+    },
+    "schemas": {
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "request_id"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Machine-readable error code.",
+                "example": "NOT_FOUND"
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable description safe to display to clients.",
+                "example": "The requested stream does not exist."
+              },
+              "request_id": {
+                "type": "string",
+                "description": "Opaque identifier for this request, useful for log correlation.",
+                "example": "req_01HZ9ABCDEF"
+              }
+            }
+          }
+        }
+      },
+      "StreamV2": {
+        "type": "object",
+        "required": ["id", "recipient", "rate", "status", "allowed_actions", "created_at", "settlement"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique stream identifier.",
+            "example": "stream_lf3k9z"
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Stellar public key of the payment recipient.",
+            "example": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG"
+          },
+          "rate": {
+            "type": "string",
+            "description": "Human-readable payment rate.",
+            "example": "120 XLM/month"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["draft", "active", "paused", "ended"],
+            "description": "Current lifecycle state of the stream."
+          },
+          "allowed_actions": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Actions the authenticated user may perform on this stream. Replaces v1 `actions`.",
+            "example": ["pause", "stop"]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO-8601 creation timestamp. Replaces v1 `createdAt`.",
+            "example": "2024-01-15T10:00:00.000Z"
+          },
+          "settlement": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["settled_at", "amount", "currency"],
+                "properties": {
+                  "settled_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2024-02-01T12:00:00.000Z"
+                  },
+                  "amount": {
+                    "type": "string",
+                    "example": "360 XLM"
+                  },
+                  "currency": {
+                    "type": "string",
+                    "example": "XLM"
+                  }
+                }
+              },
+              { "type": "null" }
+            ],
+            "description": "Settlement details once the stream has been settled, otherwise `null`. Clients must handle `null` explicitly."
+          }
+        }
+      },
+      "WalletChallenge": {
+        "type": "object",
+        "required": ["challenge", "expires_at"],
+        "properties": {
+          "challenge": {
+            "type": "string",
+            "description": "One-time nonce the client must sign with their Stellar private key.",
+            "example": "streampay_auth_1716000000000_x7k2m"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Challenge expiry (5 minutes from issuance).",
+            "example": "2024-01-15T10:05:00.000Z"
+          }
+        }
+      },
+      "WalletToken": {
+        "type": "object",
+        "required": ["token", "expires_at"],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Opaque bearer token. Pass as `Authorization: Bearer <token>`.",
+            "example": "tok_R0FCQzEyMzQ1Njc4OTA"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Token expiry (24 hours from issuance).",
+            "example": "2024-01-16T10:00:00.000Z"
+          }
+        }
+      }
+    },
+    "responses": {
+      "400": {
+        "description": "Bad request — invalid input.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" },
+            "example": {
+              "error": {
+                "code": "BAD_REQUEST",
+                "message": "Request body must include 'recipient' and 'rate'.",
+                "request_id": "req_01HZ9ABCDEF"
+              }
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Unauthorized — missing or invalid bearer token.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" },
+            "example": {
+              "error": {
+                "code": "UNAUTHORIZED",
+                "message": "Bearer token required.",
+                "request_id": "req_01HZ9ABCDEF"
+              }
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" },
+            "example": {
+              "error": {
+                "code": "FORBIDDEN",
+                "message": "This endpoint is not available in production.",
+                "request_id": "req_01HZ9ABCDEF"
+              }
+            }
+          }
+        }
+      },
+      "500": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" },
+            "example": {
+              "error": {
+                "code": "INTERNAL_SERVER_ERROR",
+                "message": "An unexpected error occurred.",
+                "request_id": "req_01HZ9ABCDEF"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/auth/wallet": {
+      "get": {
+        "operationId": "getWalletChallenge",
+        "summary": "Issue a wallet authentication challenge",
+        "description": "Returns a one-time nonce the client must sign with their Stellar private key, then submit to `POST /api/auth/wallet`.",
+        "security": [],
+        "tags": ["Auth"],
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "description": "Stellar public key (G…, 56 characters).",
+            "schema": {
+              "type": "string",
+              "pattern": "^G[A-Z2-7]{55}$",
+              "example": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Challenge issued.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WalletChallenge" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      },
+      "post": {
+        "operationId": "verifyWalletSignature",
+        "summary": "Verify a signed challenge and issue a bearer token",
+        "security": [],
+        "tags": ["Auth"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["address", "challenge", "signature"],
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "Stellar public key.",
+                    "example": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG"
+                  },
+                  "challenge": {
+                    "type": "string",
+                    "description": "The nonce returned by GET /api/auth/wallet.",
+                    "example": "streampay_auth_1716000000000_x7k2m"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Base64-encoded Ed25519 signature of the challenge.",
+                    "example": "dGVzdHNpZ25hdHVyZQ=="
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token issued.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WalletToken" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "401": { "$ref": "#/components/responses/401" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    },
+    "/api/v2/streams": {
+      "get": {
+        "operationId": "listStreamsV2",
+        "summary": "List payment streams (v2)",
+        "description": "Returns all streams owned by the authenticated user in the v2 shape (`allowed_actions`, `created_at`, `settlement`).",
+        "tags": ["Streams"],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Stream list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["streams"],
+                  "properties": {
+                    "streams": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/StreamV2" }
+                    }
+                  }
+                },
+                "example": {
+                  "streams": [
+                    {
+                      "id": "stream_lf3k9z",
+                      "recipient": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG",
+                      "rate": "120 XLM/month",
+                      "status": "active",
+                      "allowed_actions": ["pause", "stop"],
+                      "created_at": "2024-01-15T10:00:00.000Z",
+                      "settlement": null
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/401" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      },
+      "post": {
+        "operationId": "createStreamV2",
+        "summary": "Create a payment stream (v2)",
+        "tags": ["Streams"],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["recipient", "rate"],
+                "properties": {
+                  "recipient": {
+                    "type": "string",
+                    "description": "Stellar public key of the recipient.",
+                    "example": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG"
+                  },
+                  "rate": {
+                    "type": "string",
+                    "description": "Payment rate string.",
+                    "example": "120 XLM/month"
+                  },
+                  "currency": {
+                    "type": "string",
+                    "description": "Asset code (optional, defaults to XLM).",
+                    "example": "XLM"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Stream created. Initial status is `draft`.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/StreamV2" },
+                "example": {
+                  "id": "stream_lf3k9z",
+                  "recipient": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG",
+                  "rate": "120 XLM/month",
+                  "status": "draft",
+                  "allowed_actions": ["start"],
+                  "created_at": "2024-01-15T10:00:00.000Z",
+                  "settlement": null
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "401": { "$ref": "#/components/responses/401" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    },
+    "/api/webhooks/dlq": {
+      "post": {
+        "operationId": "receiveDlqWebhook",
+        "summary": "Receive a dead-letter-queue webhook event",
+        "description": "Accepts failed webhook events for reprocessing. No authentication required (secured at the network/gateway level).",
+        "security": [],
+        "tags": ["Webhooks"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Arbitrary webhook event payload.",
+                "example": { "event": "payment.failed", "id": "evt_001" }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Event accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["received"],
+                  "properties": {
+                    "received": { "type": "boolean", "example": true }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    },
+    "/api/webhooks/deliveries": {
+      "get": {
+        "operationId": "listWebhookDeliveries",
+        "summary": "List webhook delivery attempts",
+        "security": [],
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of records to return (1–100, default 20).",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque pagination cursor from a previous response.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delivery list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["deliveries", "cursor", "limit"],
+                  "properties": {
+                    "deliveries": { "type": "array", "items": { "type": "object" } },
+                    "cursor": { "type": ["string", "null"] },
+                    "limit": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    },
+    "/api/debug/kms-sign": {
+      "post": {
+        "operationId": "debugKmsSign",
+        "summary": "Sign a payload via KMS (debug only)",
+        "description": "**Non-production only.** Returns a base64-encoded signature for the given payload. Returns 403 in production.",
+        "security": [],
+        "tags": ["Debug"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["payload"],
+                "properties": {
+                  "payload": {
+                    "type": "string",
+                    "description": "Base64-encoded data to sign.",
+                    "example": "aGVsbG8="
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signature produced.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["signature"],
+                  "properties": {
+                    "signature": {
+                      "type": "string",
+                      "description": "Base64-encoded signature.",
+                      "example": "c2lnbmVkOmFHVnNiRzg9"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "403": { "$ref": "#/components/responses/403" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    }
+  },
+  "tags": [
+    { "name": "Auth", "description": "Wallet-based authentication flow" },
+    { "name": "Streams", "description": "Payment stream management (v2)" },
+    { "name": "Webhooks", "description": "Webhook ingestion and delivery history" },
+    { "name": "Debug", "description": "Non-production debugging utilities" }
+  ]
+}


### PR DESCRIPTION
task: unify error envelope and sync OpenAPI v2 spec

- Introduce app/lib/errors/index.ts with a single errorResponse(code, message, status)
  helper that always emits { error: { code, message, request_id } }
- Replace divergent error shapes in webhooks/dlq, webhooks/deliveries,
  and debug/kms-sign routes with the shared helper
- Add app/lib/api-version.ts with StreamV1, StreamV2, toV2Stream()
  (allowed_actions, created_at, settlement: null semantics)
- Add /api/v2/streams (GET/POST) using the v2 shape
- Add /api/auth/wallet (GET/POST) wallet challenge/verify flow
- Add openapi.json (OpenAPI 3.1): v2 streams, wallet auth + bearer
  scheme, canonical error envelope component, all routes documented
- Update README with API section, error envelope table, v1->v2 diff

Closes #243
Closes #236
