### PR TITLE
feat: implement settle to finalize fully-streamed streams (#256)

### DIFF
--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -342,6 +342,55 @@ impl Contract {
 
         Ok(stream)
     }
+
+    /// Finalizes a stream whose time window has fully elapsed, paying out
+    /// any remaining vested funds to the recipient and transitioning it to a
+    /// terminal `Settled` state.
+    ///
+    /// This function is permissionless and can be triggered by anyone after
+    /// `end_time` has been reached. Calling it on an already `Settled` stream
+    /// is a no-op (returns `Ok(())`).
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] if the contract is paused.
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::InvalidState`] if the stream is in `Draft` or cancelled state,
+    ///   or if the current ledger timestamp has not yet reached `end_time`.
+    pub fn settle(env: Env, stream_id: u64) -> Result<(), Error> {
+        require_not_paused(&env)?;
+        let mut stream = get_existing_stream(&env, stream_id)?;
+
+        if stream.status == StreamStatus::Settled {
+            return Ok(());
+        }
+
+        if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < stream.end_time {
+            return Err(Error::InvalidState);
+        }
+
+        let payout_amount = stream.total_amount - stream.released_amount;
+        if payout_amount > 0 {
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            token::Client::new(&env, &stream.token).transfer(
+                &env.current_contract_address(),
+                &stream.recipient,
+                &payout_amount,
+            );
+            stream.released_amount = stream.total_amount;
+        }
+
+        stream.status = StreamStatus::Settled;
+        stream.last_update = now;
+
+        storage::set_stream(&env, stream_id, &stream);
+
+        Ok(())
+    }
 }
 
 fn get_existing_stream(env: &Env, stream_id: u64) -> Result<Stream, Error> {

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -25,6 +25,8 @@ pub struct Stream {
     pub duration: u64,
     pub last_update: u64,
     pub status: StreamStatus,
+    pub pause_time: u64,
+    pub total_paused_duration: u64,
 }
 
 #[derive(Clone)]

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -154,6 +154,36 @@ fn assert_budget_ceiling(
 fn draft_stream_accrues_nothing_until_started() {
     let data = setup();
 
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &true,
+    );
+
+    data.env.ledger().set_timestamp(1_050);
+    assert_eq!(data.client.withdrawable(&stream_id), 0);
+
+    let draft = data.client.get_stream(&stream_id);
+    assert_eq!(draft.status, StreamStatus::Draft);
+    assert_eq!(draft.start_time, 0);
+    assert_eq!(draft.end_time, 0);
+
+    data.env.ledger().set_timestamp(2_000);
+    let active = data.client.start_stream(&stream_id);
+    assert_eq!(active.status, StreamStatus::Active);
+    assert_eq!(active.start_time, 2_000);
+    assert_eq!(active.last_update, 2_000);
+    assert_eq!(active.end_time, 2_100);
+
+    assert_eq!(data.client.withdrawable(&stream_id), 0);
+
+    data.env.ledger().set_timestamp(2_050);
+    assert_eq!(data.client.withdrawable(&stream_id), 500);
+}
+
 #[test]
 fn initialize_succeeds_once() {
     let data = setup();
@@ -588,4 +618,169 @@ fn budget_full_withdraw_settle_stays_within_ceiling() {
 
     let stream = data.client.get_stream(&stream_id);
     assert_eq!(stream.status, StreamStatus::Settled);
+}
+
+// ── Settle tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_settle_after_end_time_succeeds() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Advance time exactly to end_time
+    data.env.ledger().set_timestamp(1_100);
+
+    // Call settle permissionlessly
+    data.client.settle(&stream_id);
+
+    // Recipient holds the full total_amount
+    let recipient_balance = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(recipient_balance, 1_000);
+
+    // Stream status is Settled and released_amount == total_amount
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+    assert_eq!(stream.released_amount, 1_000);
+}
+
+#[test]
+fn test_settle_before_end_time_fails() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Advance time, but before end_time (1_100)
+    data.env.ledger().set_timestamp(1_050);
+
+    // Try settling, should fail with InvalidState
+    assert_contract_error!(
+        data.client.try_settle(&stream_id),
+        Error::InvalidState
+    );
+}
+
+#[test]
+fn test_settle_idempotent() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    data.env.ledger().set_timestamp(1_100);
+
+    // First settle call
+    data.client.settle(&stream_id);
+
+    let recipient_balance_1 = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(recipient_balance_1, 1_000);
+
+    // Second settle call should be a no-op and not fail
+    data.client.settle(&stream_id);
+
+    let recipient_balance_2 = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(recipient_balance_2, 1_000);
+}
+
+#[test]
+fn test_settle_after_partial_withdraw() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Advance time to 1_050 and withdraw 500
+    data.env.ledger().set_timestamp(1_050);
+    data.client.withdraw(&stream_id, &500);
+
+    let balance_after_withdraw = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(balance_after_withdraw, 500);
+
+    // Advance past end_time
+    data.env.ledger().set_timestamp(1_150);
+
+    // Settle should only transfer the remaining 500
+    data.client.settle(&stream_id);
+
+    let balance_after_settle = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(balance_after_settle, 1_000);
+
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+    assert_eq!(stream.released_amount, 1_000);
+}
+
+#[test]
+fn test_settle_paused_stream() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &false,
+    );
+
+    // Advance time to 1_050 and pause (accrued: 500)
+    data.env.ledger().set_timestamp(1_050);
+    data.client.pause(&stream_id);
+
+    // Advance past end_time (1_100) to 1_150
+    data.env.ledger().set_timestamp(1_150);
+
+    data.client.settle(&stream_id);
+
+    let balance = soroban_sdk::token::Client::new(&data.env, &data.token).balance(&data.recipient);
+    assert_eq!(balance, 1_000);
+
+    let stream = data.client.get_stream(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+    assert_eq!(stream.released_amount, 1_000);
+}
+
+#[test]
+fn test_settle_draft_stream_fails() {
+    let data = setup();
+
+    let stream_id = data.client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.token,
+        &1_000,
+        &100,
+        &true,
+    );
+
+    assert_contract_error!(
+        data.client.try_settle(&stream_id),
+        Error::InvalidState
+    );
 }


### PR DESCRIPTION
Closes #256

---

This PR implements the permissionless settle (close) entrypoint on the streampay-stream contract to finalize payment streams whose time duration has fully elapsed. It payouts any remaining vested/escrowed funds to the recipient and transitions the stream status to the terminal Settled state.

Additionally, this PR fixes two existing issues in the repository:

Compilation error in storage.rs: The Stream struct was missing the pause_time and total_paused_duration fields which are used in lib.rs and prop_test.rs.
Broken test compilation in test.rs: The test draft_stream_accrues_nothing_until_started was truncated and left incomplete during a previous merge.
Core Implementation details
1. The settle Entrypoint
Added settle(env: Env, stream_id: u64) -> Result<(), Error> to lib.rs:

Validation:
Checks if the contract is paused via require_not_paused.
Asserts that the stream state is active or paused (cannot settle drafts, cancelled, or ended streams).
Asserts that the current ledger timestamp has reached or exceeded end_time.
Idempotency:
Calling settle on an already Settled stream is a no-op and returns Ok(()) safely. This avoids errors on network retries or duplicate transaction submissions.
Permissionless:
Restricts auth checks: anyone (a relayer, the recipient, or the sender) can call settle once the stream duration is finished to trigger the payout to the recipient.
State Transition & Transfer:
Calculates the remaining payout: payout_amount = total_amount - released_amount.
Transfers the payout amount to the recipient.
Updates released_amount = total_amount.
Transitions the status to StreamStatus::Settled and sets last_update = now.
2. Storage Fixes
Added pause_time: u64 and total_paused_duration: u64 fields to the Stream struct in storage.rs to allow the codebase to compile and support the pause/resume functionality.

Verification and Test Coverage
We added six comprehensive unit tests to test.rs to cover all target criteria and edge cases:

test_settle_after_end_time_succeeds: Verifies that anyone can settle the stream after end_time has passed, paying the full amount to the recipient and moving status to Settled.
test_settle_before_end_time_fails: Assures that attempting to settle a stream before its end_time fails with Error::InvalidState.
test_settle_idempotent: Confirms that duplicate/repeated calls to settle are a no-op, do not error, and do not duplicate token transfers.
test_settle_after_partial_withdraw: Assures that settling a stream after a recipient has already withdrawn a portion of the funds works correctly and only transfers the remaining balance.
test_settle_paused_stream: Verifies that a stream that was paused but whose end_time has been reached can be settled correctly.
test_settle_draft_stream_fails: Confirms that draft streams cannot be settled.