### PR TITLE
feat(streams): add stream-creation form wired to POST /api/v2/streams

### DIFF
--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -3,9 +3,10 @@ type EmptyStateProps = {
   title: string;
   description: string;
   actionLabel: string;
+  onAction?: () => void;
 };
 
-export function EmptyState({ eyebrow, title, description, actionLabel }: EmptyStateProps) {
+export function EmptyState({ eyebrow, title, description, actionLabel, onAction }: EmptyStateProps) {
   return (
     <section className="empty-state" aria-labelledby="empty-state-title">
       <p className="empty-state__eyebrow">{eyebrow}</p>
@@ -13,7 +14,7 @@ export function EmptyState({ eyebrow, title, description, actionLabel }: EmptySt
         {title}
       </h2>
       <p className="empty-state__description">{description}</p>
-      <button className="button button--primary" type="button">
+      <button className="button button--primary" type="button" onClick={onAction}>
         {actionLabel}
       </button>
     </section>

--- a/app/components/StreamForm.test.tsx
+++ b/app/components/StreamForm.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+const { fireEvent, screen, waitFor } = require("@testing-library/react") as any;
+import { StreamForm } from "./StreamForm";
+
+const mockPush = jest.fn();
+const mockPost = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  post: (...args: unknown[]) => mockPost(...args),
+}));
+
+// Mock wallet-link so our test keys always pass client-side validation
+jest.mock("@/app/lib/wallet-link", () => ({
+  isValidStellarPublicKey: (key: string) =>
+    key === "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G",
+}));
+
+const VALID_STELLAR_KEY = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G";
+
+function fillField(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+function selectOption(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+describe("StreamForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all form fields and the submit button", () => {
+    render(<StreamForm />);
+
+    expect(screen.getByLabelText(/recipient/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/rate/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/schedule/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create stream/i })).toBeInTheDocument();
+  });
+
+  it("shows client-side validation errors when submitting empty form", async () => {
+    render(<StreamForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/recipient is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/rate is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/schedule is required/i)).toBeInTheDocument();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("shows field-level error for invalid stellar key", async () => {
+    render(<StreamForm />);
+
+    fillField("Recipient", "INVALID_KEY");
+    fillField("Rate", "100");
+    selectOption("Schedule", "month");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/valid stellar public key/i)).toBeInTheDocument();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("shows field-level error for negative rate", async () => {
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "-10");
+    selectOption("Schedule", "month");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/positive decimal number/i)).toBeInTheDocument();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("submits valid data and redirects on success", async () => {
+    mockPost.mockResolvedValueOnce({
+      id: "stream_new123",
+      recipient: VALID_STELLAR_KEY,
+      rate: "100",
+      status: "draft",
+      allowed_actions: ["start"],
+      created_at: new Date().toISOString(),
+      settlement: null,
+    });
+
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "100");
+    selectOption("Schedule", "month");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/api/v2/streams", {
+        recipient: VALID_STELLAR_KEY,
+        rate: "100",
+        schedule: "month",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/streams/stream_new123");
+    });
+  });
+
+  it("submits with optional token field", async () => {
+    mockPost.mockResolvedValueOnce({
+      id: "stream_token123",
+      recipient: VALID_STELLAR_KEY,
+      rate: "50",
+      status: "draft",
+      allowed_actions: ["start"],
+      created_at: new Date().toISOString(),
+      settlement: null,
+    });
+
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "50");
+    selectOption("Schedule", "week");
+    fillField("Token (optional)", "XLM");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/api/v2/streams", {
+        recipient: VALID_STELLAR_KEY,
+        rate: "50",
+        schedule: "week",
+        token: "XLM",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/streams/stream_token123");
+    });
+  });
+
+  it("disables submit button while submitting", async () => {
+    let resolvePromise!: (value: unknown) => void;
+    mockPost.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        }),
+    );
+
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "100");
+    selectOption("Schedule", "month");
+
+    const submitBtn = screen.getByRole("button", { name: /create stream/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /creating stream/i })).toBeDisabled();
+    });
+
+    // Resolve the pending promise so the test doesn't hang
+    resolvePromise({
+      id: "stream_busy",
+      recipient: VALID_STELLAR_KEY,
+      rate: "100",
+      status: "draft",
+      allowed_actions: ["start"],
+      created_at: new Date().toISOString(),
+      settlement: null,
+    });
+  });
+
+  it("renders server validation errors mapped to fields", async () => {
+    const serverError = new Error("Validation failed");
+    (serverError as any).status = 422;
+    (serverError as any).code = "VALIDATION_ERROR";
+    (serverError as any).meta = {
+      "0": {
+        field: "recipient",
+        code: "INVALID_STELLAR_KEY",
+        message: "recipient must be a valid Stellar public key.",
+      },
+    };
+
+    mockPost.mockRejectedValueOnce(serverError);
+
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "100");
+    selectOption("Schedule", "month");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/recipient must be a valid Stellar public key/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders ErrorBanner for non-422 server errors", async () => {
+    const serverError = new Error("Server error");
+    (serverError as any).status = 500;
+    (serverError as any).code = "INTERNAL_ERROR";
+    (serverError as any).title = "Internal Server Error";
+    (serverError as any).detail = "Something went wrong on our end.";
+    (serverError as any).category = "server";
+    (serverError as any).retry = { retryable: true };
+
+    mockPost.mockRejectedValueOnce(serverError);
+
+    render(<StreamForm />);
+
+    fillField("Recipient", VALID_STELLAR_KEY);
+    fillField("Rate", "100");
+    selectOption("Schedule", "month");
+
+    fireEvent.click(screen.getByRole("button", { name: /create stream/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error-banner")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/StreamForm.tsx
+++ b/app/components/StreamForm.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState, useCallback, type FormEvent, type ChangeEvent } from "react";
+import { useRouter } from "next/navigation";
+import { SUPPORTED_SCHEDULES } from "@/app/lib/stream-validation";
+import { isValidStellarPublicKey } from "@/app/lib/wallet-link";
+import { post } from "@/lib/apiClient";
+import type { StreamV2 } from "@/app/lib/api-version";
+import type { StreamPayError } from "@/app/lib/errors/types";
+import { ErrorBanner } from "./ErrorBanner";
+
+interface FieldErrors {
+  recipient?: string;
+  rate?: string;
+  schedule?: string;
+  token?: string;
+}
+
+interface FormFields {
+  recipient: string;
+  rate: string;
+  schedule: string;
+  token: string;
+}
+
+function validateField(name: keyof FieldErrors, value: string): string | null {
+  switch (name) {
+    case "recipient": {
+      if (!value.trim()) return "Recipient is required.";
+      if (!isValidStellarPublicKey(value.trim()))
+        return "Must be a valid Stellar public key (56 chars, starts with G).";
+      return null;
+    }
+    case "rate": {
+      if (!value.trim()) return "Rate is required.";
+      if (!/^\d+(?:\.\d+)?$/.test(value.trim()))
+        return "Must be a positive decimal number.";
+      if (Number(value) <= 0) return "Must be greater than zero.";
+      const frac = value.trim().split(".")[1] ?? "";
+      if (frac.length > 7) return "At most 7 decimal places.";
+      return null;
+    }
+    case "schedule": {
+      if (!value) return "Schedule is required.";
+      if (!SUPPORTED_SCHEDULES.includes(value as (typeof SUPPORTED_SCHEDULES)[number]))
+        return `Must be one of: ${SUPPORTED_SCHEDULES.join(", ")}.`;
+      return null;
+    }
+    case "token": {
+      if (value && typeof value !== "string") return "Must be a string if provided.";
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function extractServerFieldErrors(
+  error: StreamPayError,
+): Record<string, string> | undefined {
+  if (error.meta?.fieldErrors) {
+    return error.meta.fieldErrors as Record<string, string>;
+  }
+
+  if (error.meta) {
+    const fieldErrors: Record<string, string> = {};
+    for (const key of Object.keys(error.meta)) {
+      const val = (error.meta as Record<string, unknown>)[key];
+      if (
+        val &&
+        typeof val === "object" &&
+        !Array.isArray(val) &&
+        "field" in val &&
+        "message" in val &&
+        typeof (val as { field: string }).field === "string"
+      ) {
+        const entry = val as { field: string; message: string };
+        if (!fieldErrors[entry.field]) {
+          fieldErrors[entry.field] = entry.message;
+        }
+      }
+    }
+    if (Object.keys(fieldErrors).length > 0) return fieldErrors;
+  }
+
+  if (
+    error.debug?.rawResponse?.error?.details &&
+    Array.isArray(error.debug.rawResponse.error.details)
+  ) {
+    const fieldErrors: Record<string, string> = {};
+    for (const d of error.debug.rawResponse.error.details) {
+      if (d.field && d.message && !fieldErrors[d.field]) {
+        fieldErrors[d.field] = d.message;
+      }
+    }
+    if (Object.keys(fieldErrors).length > 0) return fieldErrors;
+  }
+
+  return undefined;
+}
+
+export function StreamForm() {
+  const router = useRouter();
+  const [fields, setFields] = useState<FormFields>({
+    recipient: "",
+    rate: "",
+    schedule: "",
+    token: "",
+  });
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [serverError, setServerError] = useState<StreamPayError | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const setField = useCallback(
+    (name: keyof FormFields) =>
+      (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        setFields((prev) => ({ ...prev, [name]: e.target.value }));
+      },
+    [],
+  );
+
+  const validateAll = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    for (const field of ["recipient", "rate", "schedule", "token"] as const) {
+      const err = validateField(field, fields[field]);
+      if (err) errors[field] = err;
+    }
+    return errors;
+  }, [fields]);
+
+  const handleBlur = useCallback(
+    (field: keyof FieldErrors) => {
+      const err = validateField(field, fields[field]);
+      setFieldErrors((prev) => ({ ...prev, [field]: err ?? undefined }));
+    },
+    [fields],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      setServerError(null);
+
+      const errors = validateAll();
+      setFieldErrors(errors);
+      if (Object.keys(errors).length > 0) return;
+
+      setIsSubmitting(true);
+
+      try {
+        const body: Record<string, string> = {
+          recipient: fields.recipient.trim(),
+          rate: fields.rate.trim(),
+          schedule: fields.schedule,
+        };
+        if (fields.token.trim()) {
+          body.token = fields.token.trim();
+        }
+
+        const result = await post<StreamV2>("/api/v2/streams", body);
+
+        router.push(`/streams/${result.id}`);
+      } catch (err: unknown) {
+        const streamPayError = err as StreamPayError;
+
+        if (
+          streamPayError.status === 422 ||
+          streamPayError.code === "VALIDATION_ERROR" ||
+          streamPayError.code === "UNPROCESSABLE_ENTITY"
+        ) {
+          const serverFieldErrors = extractServerFieldErrors(streamPayError);
+          if (serverFieldErrors) {
+            setFieldErrors((prev) => ({ ...prev, ...serverFieldErrors }));
+          } else {
+            setServerError(streamPayError);
+          }
+        } else {
+          setServerError(streamPayError);
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [fields, validateAll, router],
+  );
+
+  return (
+    <div className="stream-form">
+      {serverError && (
+        <ErrorBanner
+          error={serverError}
+          onDismiss={() => setServerError(null)}
+        />
+      )}
+
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="stream-form__field">
+          <label htmlFor="recipient">Recipient</label>
+          <input
+            id="recipient"
+            type="text"
+            value={fields.recipient}
+            onChange={setField("recipient")}
+            onBlur={() => handleBlur("recipient")}
+            aria-describedby={fieldErrors.recipient ? "recipient-error" : undefined}
+            aria-invalid={!!fieldErrors.recipient}
+            disabled={isSubmitting}
+            placeholder="G..."
+          />
+          {fieldErrors.recipient && (
+            <p id="recipient-error" className="stream-form__error" role="alert">
+              {fieldErrors.recipient}
+            </p>
+          )}
+        </div>
+
+        <div className="stream-form__field">
+          <label htmlFor="rate">Rate</label>
+          <input
+            id="rate"
+            type="text"
+            inputMode="decimal"
+            value={fields.rate}
+            onChange={setField("rate")}
+            onBlur={() => handleBlur("rate")}
+            aria-describedby={fieldErrors.rate ? "rate-error" : undefined}
+            aria-invalid={!!fieldErrors.rate}
+            disabled={isSubmitting}
+            placeholder="e.g. 100"
+          />
+          {fieldErrors.rate && (
+            <p id="rate-error" className="stream-form__error" role="alert">
+              {fieldErrors.rate}
+            </p>
+          )}
+        </div>
+
+        <div className="stream-form__field">
+          <label htmlFor="schedule">Schedule</label>
+          <select
+            id="schedule"
+            value={fields.schedule}
+            onChange={setField("schedule")}
+            onBlur={() => handleBlur("schedule")}
+            aria-describedby={fieldErrors.schedule ? "schedule-error" : undefined}
+            aria-invalid={!!fieldErrors.schedule}
+            disabled={isSubmitting}
+          >
+            <option value="">Select a schedule</option>
+            {SUPPORTED_SCHEDULES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          {fieldErrors.schedule && (
+            <p id="schedule-error" className="stream-form__error" role="alert">
+              {fieldErrors.schedule}
+            </p>
+          )}
+        </div>
+
+        <div className="stream-form__field">
+          <label htmlFor="token">Token (optional)</label>
+          <input
+            id="token"
+            type="text"
+            value={fields.token}
+            onChange={setField("token")}
+            onBlur={() => handleBlur("token")}
+            aria-describedby={fieldErrors.token ? "token-error" : undefined}
+            aria-invalid={!!fieldErrors.token}
+            disabled={isSubmitting}
+            placeholder="XLM"
+          />
+          {fieldErrors.token && (
+            <p id="token-error" className="stream-form__error" role="alert">
+              {fieldErrors.token}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          className={`button button--primary${isSubmitting ? " button--busy" : ""}`}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Creating Stream..." : "Create Stream"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/streams/StreamsPageContent.tsx
+++ b/app/streams/StreamsPageContent.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import { EmptyState } from "../components/EmptyState";
 import { StreamRow, type StreamRowData } from "../components/StreamRow";
 
@@ -90,7 +93,10 @@ export function StreamsPageContent({
   state = "populated",
   streams = mockStreams,
 }: StreamsPageContentProps) {
+  const router = useRouter();
   const isEmpty = state === "empty" || streams.length === 0;
+
+  const goToNewStream = () => router.push("/streams/new");
 
   return (
     <main className="page-shell">
@@ -104,7 +110,7 @@ export function StreamsPageContent({
           <button className="button button--secondary" type="button">
             Export History
           </button>
-          <button className="button button--primary" type="button">
+          <button className="button button--primary" type="button" onClick={goToNewStream}>
             {streamListCopy.primaryCta}
           </button>
         </div>
@@ -131,6 +137,7 @@ export function StreamsPageContent({
             description={streamListCopy.empty.description}
             eyebrow={streamListCopy.empty.eyebrow}
             title={streamListCopy.empty.title}
+            onAction={goToNewStream}
           />
         ) : (
           <section aria-label="Streams list" className="stream-list">

--- a/app/streams/new/page.tsx
+++ b/app/streams/new/page.tsx
@@ -1,0 +1,24 @@
+import { StreamForm } from "@/app/components/StreamForm";
+
+export const metadata = {
+  title: "Create Stream — StreamPay",
+  description: "Create a new payment stream to pay collaborators and vendors on a steady schedule.",
+};
+
+export default function NewStreamPage() {
+  return (
+    <main className="page-shell">
+      <section className="page-hero">
+        <div>
+          <p className="page-hero__eyebrow">Streams</p>
+          <h1 className="page-hero__title">Create a new stream</h1>
+          <p className="page-hero__description">
+            Set up a payment stream to send funds on a recurring schedule.
+          </p>
+        </div>
+      </section>
+
+      <StreamForm />
+    </main>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,8 @@ const config = {
   // Component tests will run in a separate command with jsdom
   testEnvironment: "node",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  testMatch: ["**/*.test.ts", "**/*.spec.ts"],
+  testMatch: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+  moduleNameMapper: { "^@/(.*)$": "<rootDir>/$1" },
   collectCoverageFrom: [
     "app/**/*.{ts,tsx}",
     "lib/**/*.{ts,tsx}",


### PR DESCRIPTION
Closes #331

## Summary
Adds a stream-creation form at `/streams/new` with client-side validation mirroring `validateCreateStreamBody`, submission via `fetchWithIdempotency` (through the `post` helper), and field-level error handling for 422 responses.

## Changes
- **app/components/StreamForm.tsx** — New form component with fields for recipient, rate, schedule, and optional token. Validates on blur and on submit. Disables while in flight. Routes to the new stream on 201. Renders server 422 field errors next to inputs and surfaces other errors via ErrorBanner.
- **app/streams/new/page.tsx** — New route page wrapping StreamForm.
- **app/streams/StreamsPageContent.tsx** — Wired the "Create Stream" and "Create Your First Stream" CTAs to navigate to `/streams/new`.
- **app/components/EmptyState.tsx** — Added optional `onAction` callback prop.
- **jest.config.js** — Extended `testMatch` to include `.test.tsx` files and added `moduleNameMapper` for `@/` path alias.
- **app/components/StreamForm.test.tsx** — 9 tests covering: rendering, client-side validation (empty form, invalid key, negative rate), successful submission, optional token, busy state, server 422 field errors, and server ErrorBanner.