### PR TITLE
fix(assets): validate SEP-41 issuer with full StrKey checksum

### DIFF
--- a/app/lib/assets.test.ts
+++ b/app/lib/assets.test.ts
@@ -1,4 +1,9 @@
-import { parseAssetString, verifyTrustline, NATIVE_ASSET } from './assets';
+import * as fc from 'fast-check';
+import { parseAssetString, verifyTrustline, validateAssetPair, NATIVE_ASSET } from './assets';
+import { isValidStellarPublicKey } from './wallet-link';
+
+// A checksum-valid Stellar public key for testing
+const VALID_ISSUER = 'GBWFVUE66GCA5UY7KGG5T37JNCASPSRLQDVEXMCF6IWJJCDUJE25QKJ7';
 
 describe('Asset Engine', () => {
   describe('parseAssetString', () => {
@@ -7,17 +12,48 @@ describe('Asset Engine', () => {
       expect(parseAssetString('native')).toEqual(NATIVE_ASSET);
     });
 
-    it('parses custom assets correctly', () => {
-      const assetStr = 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335XOP3IA2M3QC2ED2AAA7Z5TJH';
+    it('parses custom assets correctly with valid issuer', () => {
+      const assetStr = `USDC:${VALID_ISSUER}`;
       const parsed = parseAssetString(assetStr);
       expect(parsed.code).toBe('USDC');
-      expect(parsed.issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335XOP3IA2M3QC2ED2AAA7Z5TJH');
+      expect(parsed.issuer).toBe(VALID_ISSUER);
       expect(parsed.isNative).toBe(false);
+    });
+
+    it('rejects issuer with bad checksum', () => {
+      // 56 chars, starts with G, valid base32 but fails CRC16 checksum
+      const badIssuer = 'G5555555555555555555555555555555555555555555555555555555';
+      expect(badIssuer.length).toBe(56);
+      expect(badIssuer.startsWith('G')).toBe(true);
+      expect(isValidStellarPublicKey(badIssuer)).toBe(false);
+      expect(() => parseAssetString(`USDC:${badIssuer}`)).toThrow('Invalid asset format');
     });
 
     it('throws on invalid formats', () => {
       expect(() => parseAssetString('USDC')).toThrow();
       expect(() => parseAssetString('USDC:short')).toThrow();
+    });
+
+    it('rejects issuer that is not a valid Stellar key', () => {
+      const nonKeyIssuer = 'G' + 'A'.repeat(55);
+      expect(isValidStellarPublicKey(nonKeyIssuer)).toBe(false);
+      expect(() => parseAssetString(`USDC:${nonKeyIssuer}`)).toThrow('Invalid asset format');
+    });
+
+    it('rejects issuer failing StrKey checksum (property-based)', () => {
+      const base32Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      const base32Char = fc.constantFrom(...base32Alphabet.split(''));
+
+      fc.assert(
+        fc.property(
+          fc.array(base32Char, { minLength: 55, maxLength: 55 }).map(chars => 'G' + chars.join('')),
+          (issuer) => {
+            fc.pre(!isValidStellarPublicKey(issuer));
+            expect(() => parseAssetString('CODE:' + issuer)).toThrow('Invalid asset format');
+          }
+        ),
+        { numRuns: 200, seed: 42 }
+      );
     });
   });
 
@@ -77,6 +113,48 @@ describe('Asset Engine', () => {
       const result = await verifyTrustline(mockPublicKey, customAsset);
       expect(result.exists).toBe(false);
       expect(result.error).toContain('does not exist');
+    });
+
+    it('handles non-ok non-404 response', async () => {
+      (fetch as jest.Mock).mockResolvedValue({
+        status: 500,
+        ok: false
+      });
+
+      const result = await verifyTrustline(mockPublicKey, customAsset);
+      expect(result.exists).toBe(false);
+      expect(result.error).toContain('Horizon error');
+    });
+
+    it('handles network errors', async () => {
+      (fetch as jest.Mock).mockRejectedValue(new Error('Network failure'));
+
+      const result = await verifyTrustline(mockPublicKey, customAsset);
+      expect(result.exists).toBe(false);
+      expect(result.error).toContain('Network error');
+    });
+  });
+
+  describe('validateAssetPair', () => {
+    it('validates matching native assets', () => {
+      expect(validateAssetPair(NATIVE_ASSET, NATIVE_ASSET)).toBe(true);
+    });
+
+    it('rejects mismatched native and custom assets', () => {
+      const custom = { code: 'USDC', issuer: 'G...', isNative: false };
+      expect(validateAssetPair(NATIVE_ASSET, custom)).toBe(false);
+    });
+
+    it('validates matching custom assets', () => {
+      const a = { code: 'USDC', issuer: 'G...', isNative: false };
+      const b = { code: 'USDC', issuer: 'G...', isNative: false };
+      expect(validateAssetPair(a, b)).toBe(true);
+    });
+
+    it('rejects mismatched codes', () => {
+      const a = { code: 'USDC', issuer: 'G...', isNative: false };
+      const b = { code: 'EURC', issuer: 'G...', isNative: false };
+      expect(validateAssetPair(a, b)).toBe(false);
     });
   });
 });

--- a/app/lib/assets.ts
+++ b/app/lib/assets.ts
@@ -4,6 +4,7 @@
  */
 
 import { getConfig } from './config';
+import { isValidStellarPublicKey } from './wallet-link';
 
 export interface StellarAsset {
   code: string;
@@ -26,7 +27,7 @@ export function parseAssetString(assetStr: string): StellarAsset {
 
   if (assetStr.includes(':')) {
     const [code, issuer] = assetStr.split(':');
-    if (code && issuer && issuer.length === 56 && issuer.startsWith('G')) {
+    if (code && issuer && isValidStellarPublicKey(issuer)) {
       return { code: code.toUpperCase(), issuer, isNative: false };
     }
   }

--- a/docs/supported-assets.md
+++ b/docs/supported-assets.md
@@ -14,6 +14,23 @@ StreamPay supports Stellar Native (XLM) and any valid Stellar Classic assets (Al
 - **Trustline**: The recipient **must** establish a trustline for the specific asset before a stream can be successfully funded or paid out.
 - **Pre-flight Check**: StreamPay-Frontend performs an automated check against Horizon to verify trustline existence.
 
+## Validation
+
+### Issuer Validation
+
+Custom asset issuers are validated using full StrKey checksum verification (CRC16-XMODEM) via `isValidStellarPublicKey`. A valid issuer must:
+
+1. Be exactly 56 characters long
+2. Start with `G` (Ed25519 public key version byte)
+3. Pass Base32 decoding
+4. Pass CRC16-XMODEM checksum verification
+
+This prevents malformed or checksum-invalid issuer addresses from being accepted into the system.
+
+### Native Asset Handling
+
+Native asset strings (`XLM`, `native`, case-insensitive) are handled without issuer validation. Their behavior is unchanged.
+
 ## Validation Matrix
 
 | Case | Result | Actionable Error |
@@ -23,6 +40,7 @@ StreamPay supports Stellar Native (XLM) and any valid Stellar Classic assets (Al
 | Missing Trustline | Reject | "Missing trustline for [CODE]." |
 | Account Not Found | Reject | "Recipient account does not exist on-chain." |
 | Invalid Format | Reject | "Invalid asset format. Expected CODE:ISSUER" |
+| Bad Checksum | Reject | "Invalid asset format. Expected CODE:ISSUER" |
 
 ## Minimum Reserves
 Users must maintain the Stellar base reserve + increments for each trustline. StreamPay does not currently sponsor reserves for trustlines in v1.


### PR DESCRIPTION
## Description

Reuses `isValidStellarPublicKey` from `app/lib/wallet-link.ts` instead of the weak length-56 + G-prefix check in `parseAssetString`.

## Changes

- `app/lib/assets.ts`: import `isValidStellarPublicKey`, use it in the `CODE:ISSUER` branch
- `app/lib/assets.test.ts`: 
  - Updated existing test to use a checksum-valid issuer key
  - Added test for bad-checksum issuer rejection
  - Added test for non-Stellar-key issuer rejection
  - Added property-based test (fast-check) asserting no string failing checksum is accepted
  - Added tests for `verifyTrustline` error paths and `validateAssetPair`
- `docs/supported-assets.md`: documented the strengthened validation

## Verification

- `npm test`: 100% line coverage on `assets.ts`, all 16 tests pass
- No new dependencies added
- No duplicated validation logic
- Native assets unchanged
- Error contract unchanged (`Invalid asset format: ...`)
- SEP-41 client and token allowlist compose correctly through the hardened parser

Closes #338