### PR TITLE
feat: 256KB request size cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,15 @@ INTERNAL_AUTH_TOKEN=
 ANOMALY_CREATION_THRESHOLD=50
 ANOMALY_SETTLE_THRESHOLD=20
 
+# Request Body Size Cap for /api/v2/streams* (POST, PUT, PATCH)
+# Required: No (defaults to 262144 = 256 KB)
+# Purpose: Middleware rejects requests whose Content-Length exceeds this value
+#          with a 413 status and a machine-readable error envelope.
+#          Only write methods on /api/v2/streams* are subject to this cap;
+#          GET/HEAD/OPTIONS/DELETE and all other paths are unaffected.
+# Example: 131072 for a 128 KB cap, 524288 for a 512 KB cap
+MAX_STREAM_BODY_BYTES=262144
+
 # =============================================================================
 # NETWORK PROFILES
 # =============================================================================

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -79,3 +79,212 @@ describe('CORS middleware', () => {
     expect(response.headers.get('access-control-allow-origin')).toBeNull();
   });
 });
+
+// =============================================================================
+// Request body size cap
+// =============================================================================
+
+describe('request size cap middleware', () => {
+  /** The default cap enforced by the middleware (256 KB). */
+  const DEFAULT_CAP = 256 * 1024; // 262 144 bytes
+
+  let middleware: any;
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build a synthetic NextRequest-compatible object aimed at a v2 streams path.
+   * We construct the URL with `localhost` as the host because NextURL (used by
+   * the Edge runtime) requires an absolute URL.
+   */
+  function makeRequest(
+    path: string,
+    method: string,
+    contentLength: number | null,
+    extra: Record<string, string> = {},
+  ): Request {
+    const headers: Record<string, string> = { ...extra };
+    if (contentLength !== null) {
+      headers['content-length'] = String(contentLength);
+    }
+    return new Request(`http://localhost${path}`, { method, headers });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Setup / teardown
+  // ---------------------------------------------------------------------------
+
+  beforeEach(async () => {
+    jest.resetModules();
+    delete (process.env as any).MAX_STREAM_BODY_BYTES;
+
+    (process.env as any).STELLAR_NETWORK = 'testnet';
+    (process.env as any).JWT_SECRET = 'test-secret-at-least-32-characters-long';
+    (process.env as any).NODE_ENV = 'production';
+    (process.env as any).ALLOWED_ORIGINS = 'https://allowed.example.com';
+
+    const imported = await import('./middleware');
+    middleware = imported.middleware;
+  });
+
+  afterEach(() => {
+    delete (process.env as any).STELLAR_NETWORK;
+    delete (process.env as any).JWT_SECRET;
+    delete (process.env as any).NODE_ENV;
+    delete (process.env as any).ALLOWED_ORIGINS;
+    delete (process.env as any).MAX_STREAM_BODY_BYTES;
+  });
+
+  // ---------------------------------------------------------------------------
+  // Core enforcement
+  // ---------------------------------------------------------------------------
+
+  it('returns 413 when Content-Length exceeds the default 256 KB cap on POST /api/v2/streams', async () => {
+    const request = makeRequest('/api/v2/streams', 'POST', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(413);
+  });
+
+  it('returns 413 when Content-Length exceeds the cap on PUT /api/v2/streams/{id}', async () => {
+    const request = makeRequest('/api/v2/streams/stream-abc-123', 'PUT', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(413);
+  });
+
+  it('returns 413 when Content-Length exceeds the cap on PATCH /api/v2/streams/{id}/pause', async () => {
+    const request = makeRequest('/api/v2/streams/stream-abc-123/pause', 'PATCH', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(413);
+  });
+
+  it('passes through when Content-Length is exactly at the 256 KB cap', async () => {
+    const request = makeRequest('/api/v2/streams', 'POST', DEFAULT_CAP);
+    const response = await middleware(request as any);
+
+    // Should NOT be a 413 — at-limit is allowed.
+    expect(response.status).not.toBe(413);
+  });
+
+  it('passes through when Content-Length is below the cap', async () => {
+    const request = makeRequest('/api/v2/streams', 'POST', 1024); // 1 KB
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Missing / malformed Content-Length
+  // ---------------------------------------------------------------------------
+
+  it('passes through when Content-Length header is absent (let downstream enforce streaming limits)', async () => {
+    const request = makeRequest('/api/v2/streams', 'POST', null);
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path scoping
+  // ---------------------------------------------------------------------------
+
+  it('does not apply the size cap to paths outside /api/v2/streams', async () => {
+    // /api/v1/streams must NOT be blocked by the v2-specific cap.
+    const request = makeRequest('/api/v1/streams', 'POST', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  it('does not apply the size cap to other v2 routes (e.g. /api/v2/other)', async () => {
+    const request = makeRequest('/api/v2/other', 'POST', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Method scoping
+  // ---------------------------------------------------------------------------
+
+  it('does not apply the size cap to GET requests on /api/v2/streams', async () => {
+    // GET requests must never be blocked by the body size cap.
+    const request = makeRequest('/api/v2/streams', 'GET', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  it('does not apply the size cap to DELETE requests on /api/v2/streams/{id}', async () => {
+    const request = makeRequest('/api/v2/streams/stream-abc-123', 'DELETE', DEFAULT_CAP + 1);
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(413);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error envelope shape
+  // ---------------------------------------------------------------------------
+
+  it('returns the canonical error envelope with code REQUEST_TOO_LARGE on 413', async () => {
+    const overLimit = DEFAULT_CAP + 512;
+    const request = makeRequest('/api/v2/streams', 'POST', overLimit);
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(413);
+
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      error: {
+        code: 'REQUEST_TOO_LARGE',
+        message: expect.stringContaining(String(overLimit)),
+        request_id: expect.any(String),
+      },
+    });
+  });
+
+  it('forwards x-request-id from the incoming request into the 413 error envelope', async () => {
+    const requestId = 'req_test_forwarded_id';
+    const request = makeRequest('/api/v2/streams', 'POST', DEFAULT_CAP + 1, {
+      'x-request-id': requestId,
+    });
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(413);
+
+    const body = await response.json();
+    expect(body.error.request_id).toBe(requestId);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Configurable cap
+  // ---------------------------------------------------------------------------
+
+  it('honours MAX_STREAM_BODY_BYTES env override', async () => {
+    // Re-import with a custom cap of 1024 bytes so the test is self-contained
+    // and does not depend on build-time module caching.
+    jest.resetModules();
+    (process.env as any).MAX_STREAM_BODY_BYTES = '1024';
+    (process.env as any).STELLAR_NETWORK = 'testnet';
+    (process.env as any).JWT_SECRET = 'test-secret-at-least-32-characters-long';
+    (process.env as any).NODE_ENV = 'production';
+    (process.env as any).ALLOWED_ORIGINS = 'https://allowed.example.com';
+
+    const { middleware: mw } = await import('./middleware');
+
+    // 1025 bytes — just above the custom 1 KB cap.
+    const over = makeRequest('/api/v2/streams', 'POST', 1025);
+    const overResponse = await mw(over as any);
+    expect(overResponse.status).toBe(413);
+
+    // 1024 bytes — exactly at the custom cap.
+    const at = makeRequest('/api/v2/streams', 'POST', 1024);
+    const atResponse = await mw(at as any);
+    expect(atResponse.status).not.toBe(413);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,114 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateConfig } from './app/lib/config/index';
 import { buildAllowedOriginSet, isOriginAllowed, DEFAULT_CORS_HEADERS, DEFAULT_CORS_METHODS, DEFAULT_CORS_MAX_AGE_SECONDS } from './app/lib/cors';
 
+// ---------------------------------------------------------------------------
+// Request body size cap
+// ---------------------------------------------------------------------------
+//
+// Operators may override the default via the MAX_STREAM_BODY_BYTES environment
+// variable (e.g. MAX_STREAM_BODY_BYTES=131072 for 128 KB).
+//
+// The check is intentionally O(1): we read the Content-Length header rather
+// than buffering the body.  Clients that omit Content-Length are allowed
+// through — the application layer is responsible for streaming limits.
+//
+// Only write methods (POST, PUT, PATCH) are checked; safe methods (GET, HEAD,
+// OPTIONS, DELETE) are not expected to carry a body and are skipped.
+
+/** Default cap: 256 KB */
+const DEFAULT_MAX_BODY_BYTES = 256 * 1024; // 262 144
+
+/**
+ * Resolved cap in bytes, honoring the optional env override.
+ *
+ * Validation:
+ *  - Must be a finite positive integer.
+ *  - Falls back to DEFAULT_MAX_BODY_BYTES for invalid / missing values.
+ */
+function resolveMaxBodyBytes(): number {
+  const raw = process.env.MAX_STREAM_BODY_BYTES;
+  if (raw !== undefined) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+    // Invalid override — log once and fall back to the default.
+    console.warn(
+      `[middleware] MAX_STREAM_BODY_BYTES="${raw}" is not a valid positive number; ` +
+        `falling back to ${DEFAULT_MAX_BODY_BYTES} bytes.`,
+    );
+  }
+  return DEFAULT_MAX_BODY_BYTES;
+}
+
+const MAX_BODY_BYTES = resolveMaxBodyBytes();
+
+/** HTTP methods that legitimately carry a request body. */
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+
+/**
+ * Prefix for the paths where the size cap is enforced.
+ *
+ * Matches:
+ *  - /api/v2/streams
+ *  - /api/v2/streams/{id}
+ *  - /api/v2/streams/{id}/pause  … etc.
+ */
+const SIZE_CAP_PATH_PREFIX = '/api/v2/streams';
+
+/**
+ * Check whether the incoming request exceeds the configured body size limit.
+ *
+ * @returns A 413 `NextResponse` when the limit is breached, or `null` to
+ *          signal that processing should continue normally.
+ */
+function checkRequestBodySize(request: NextRequest): NextResponse | null {
+  // Only enforce on paths we care about.
+  // `request.nextUrl` is provided by the Edge runtime on a real NextRequest.
+  // Plain Request objects (used in unit tests) only have `request.url`.
+  // We fall back to standard URL parsing so both environments work correctly.
+  const pathname = (request as { nextUrl?: { pathname: string } }).nextUrl?.pathname
+    ?? new URL(request.url).pathname;
+  if (!pathname.startsWith(SIZE_CAP_PATH_PREFIX)) {
+    return null;
+  }
+
+  // Only enforce on write methods — GET / HEAD / OPTIONS / DELETE are skipped.
+  if (!WRITE_METHODS.has(request.method)) {
+    return null;
+  }
+
+  // Read Content-Length without buffering the body.
+  const contentLengthHeader = request.headers.get('content-length');
+  if (contentLengthHeader === null) {
+    // Absent header: allow through — downstream can enforce streaming limits.
+    return null;
+  }
+
+  const contentLength = Number(contentLengthHeader);
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    // Malformed Content-Length: allow through; let the runtime reject it.
+    return null;
+  }
+
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'REQUEST_TOO_LARGE',
+          message:
+            `Request body exceeds the ${MAX_BODY_BYTES}-byte limit. ` +
+            `Received Content-Length: ${contentLength} bytes.`,
+          request_id: request.headers.get('x-request-id') ?? `req_${Date.now().toString(36)}`,
+        },
+      },
+      { status: 413 },
+    );
+  }
+
+  return null;
+}
+
 // Validate configuration at middleware initialization so invalid CORS settings fail early.
 validateConfig();
 
@@ -22,6 +130,17 @@ function buildCorsHeaders(origin: string) {
 }
 
 export function middleware(request: NextRequest) {
+  // ------------------------------------------------------------------
+  // 1. Request body size cap (path-scoped, O(1) — reads Content-Length)
+  // ------------------------------------------------------------------
+  const sizeError = checkRequestBodySize(request);
+  if (sizeError !== null) {
+    return sizeError;
+  }
+
+  // ------------------------------------------------------------------
+  // 2. CORS
+  // ------------------------------------------------------------------
   const origin = request.headers.get('origin');
   const originAllowed = isOriginAllowed(origin, allowedOrigins);
 


### PR DESCRIPTION
closes #428 

## Problem

`/api/v2/streams*` route handlers accepted arbitrarily large request bodies. A malicious or misconfigured client could send a multi-megabyte payload, forcing the Next.js Edge runtime to buffer it in memory — a denial-of-service vector against the stream-creation path.

## Solution

A **path-scoped, O(1) body-size guard** in `middleware.ts` that rejects over-limit requests before they reach any route handler, by reading the `Content-Length` header — no body buffering, no stream reads.

---

## Decision table

| Condition | Result |
|---|---|
| Path does not start with `/api/v2/streams` | Pass through (no check) |
| Method is GET / HEAD / DELETE / OPTIONS | Pass through (no check) |
| `Content-Length` header absent | Pass through |
| `Content-Length` ≤ `MAX_BODY_BYTES` | Pass through |
| `Content-Length` > `MAX_BODY_BYTES` | **413** with canonical error envelope |

## 413 body shape

```json
{
  "error": {
    "code": "REQUEST_TOO_LARGE",
    "message": "Request body exceeds the 262144-byte limit. Received Content-Length: 300000 bytes.",
    "request_id": "req_forwarded-or-generated"
  }
}
```

---

## Files changed

| File | +/- | Description |
|---|---|---|
| `middleware.ts` | +119 | Size-cap guard + env resolution + updated `middleware()` entrypoint |
| `middleware.test.ts` | +209 | 13 new test cases in `describe('request size cap middleware')` |
| `.env.example` | +9 | Documents `MAX_STREAM_BODY_BYTES` optional variable |

## Test results

```
npm test -- --testPathPattern=middleware.test --no-coverage
→ 17 passed, 0 failed
```

---

## Configuration

| Variable | Required | Default | Notes |
|---|---|---|---|
| `MAX_STREAM_BODY_BYTES` | No | `262144` | Must be a positive integer; invalid values warn + fall back |

---

## Checklist

- [x] 413 returned for `Content-Length > 256 KB` on `POST`/`PUT`/`PATCH` to `/api/v2/streams*`
- [x] Canonical `{ error: { code, message, request_id } }` envelope
- [x] All 17 middleware tests pass
- [x] Path-scoped — v1 and non-stream routes unaffected
- [x] Method-scoped — GET/HEAD/DELETE/OPTIONS never blocked
- [x] Missing `Content-Length` is allowed through (no false positives for streaming clients)
- [x] Operator-configurable via `MAX_STREAM_BODY_BYTES`
- [x] No body buffering — O(1) overhead
- [x] Runs before CORS and route handlers
- [x] No changes to existing CORS behaviour

