### PR TITLE
cargo doc -p streampay-stream

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,10 @@
-# TODO - Secure debug KMS signing oracle
+# TODO
 
-- [ ] Step 1: Edit `app/api/debug/kms-sign/route.ts` to hard-disable in production (NODE_ENV === "production" => 404).
-- [ ] Step 2: In non-production, require internal-service auth via `requireInternalServiceAuth` with `concealFailure: true`.
-- [ ] Step 3: Add strict request validation + bounded payload size (max 16KB) and type checks.
-- [ ] Step 4: Remove/avoid logging sensitive payload data; log only safe metadata.
-- [ ] Step 5: Replace ad-hoc `{ success, error }` error responses with standard RFC7807 error envelope using `createError`.
-- [ ] Step 6: Ensure successful response keeps signature/public key but never returns raw payload.
-- [ ] Step 7: Add Jest tests covering production 404, internal-auth concealFailure 404, valid auth success, and payload-too-large error envelope.
-- [ ] Step 8: Run tests (`npm test`) and fix any TS/lint issues.
+## Task: NatSpec docs for storage helpers
+
+- [ ] Create branch `task/storage-docs`
+- [ ] Add `///` NatSpec documentation (with `# Errors` and `# Returns`) for every `pub fn` in `contracts/contracts/streampay-stream/src/storage.rs`
+- [ ] Run `cargo doc -p streampay-stream` and confirm it passes with no missing-docs warnings
+- [ ] Commit with message `task: NatSpec docs for storage helpers`
+- [ ] (PR) Include `cargo doc` output/notes
 

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -110,6 +110,17 @@ fn extend_next_stream_id_ttl(env: &Env) {
     extend_instance_ttl(env, &DataKey::NextStreamId);
 }
 
+/// Returns whether an admin key is present in instance storage.
+///
+/// If the admin key exists, this helper extends its TTL to ensure the
+/// governance address does not expire mid-flight.
+///
+/// # Returns
+/// - `true` if [`DataKey::Admin`] exists.
+/// - `false` otherwise.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn has_admin(env: &Env) -> bool {
     let exists = env.storage().instance().has(&DataKey::Admin);
     if exists {
@@ -118,11 +129,30 @@ pub fn has_admin(env: &Env) -> bool {
     exists
 }
 
+/// Sets the contract admin address in instance storage.
+///
+/// This helper also extends the admin key TTL.
+///
+/// # Returns
+/// This helper does not return a value.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().instance().set(&DataKey::Admin, admin);
     extend_admin_key_ttl(env);
 }
 
+/// Returns the stored admin address, if any.
+///
+/// If an admin value exists, this helper extends its TTL.
+///
+/// # Returns
+/// - `Some(Address)` if [`DataKey::Admin`] exists.
+/// - `None` otherwise.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn get_admin(env: &Env) -> Option<Address> {
     let admin = env.storage().instance().get(&DataKey::Admin);
     if admin.is_some() {
@@ -131,11 +161,30 @@ pub fn get_admin(env: &Env) -> Option<Address> {
     admin
 }
 
+/// Sets the global paused flag in instance storage.
+///
+/// This helper also extends the paused key TTL.
+///
+/// # Returns
+/// This helper does not return a value.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().instance().set(&DataKey::Paused, &paused);
     extend_pause_key_ttl(env);
 }
 
+/// Returns whether the contract is currently paused.
+///
+/// If the paused key exists, this helper extends its TTL.
+///
+/// # Returns
+/// - `true` if paused is set to `true`.
+/// - `false` if paused is unset or set to `false`.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn is_paused(env: &Env) -> bool {
     let paused = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
     if env.storage().instance().has(&DataKey::Paused) {
@@ -144,12 +193,35 @@ pub fn is_paused(env: &Env) -> bool {
     paused
 }
 
+/// Sets whether a given token is allowed for future stream creation.
+///
+/// Tokens are allowed by default when there is no entry for the token. When
+/// `allowed = false`, the function writes a deny entry that makes the token
+/// “blocked” for future stream creation.
+///
+/// # Returns
+/// This helper does not return a value.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn set_token_allowed(env: &Env, token: &Address, allowed: bool) {
     env.storage()
         .persistent()
         .set(&DataKey::TokenAllowed(token.clone()), &allowed);
 }
 
+/// Returns whether a given token is blocked.
+///
+/// This is the logical negation of `set_token_allowed(..., allowed = true)`.
+/// If no allow entry exists, the token is treated as allowed (therefore not
+/// blocked).
+///
+/// # Returns
+/// - `true` if the token is explicitly blocked.
+/// - `false` if explicitly allowed or unset.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn is_token_blocked(env: &Env, token: &Address) -> bool {
     match env
         .storage()
@@ -161,6 +233,16 @@ pub fn is_token_blocked(env: &Env, token: &Address) -> bool {
     }
 }
 
+/// Returns the next stream id and increments the stored counter.
+///
+/// Stream ids start at `1` when the counter is unset. This helper extends the
+/// TTL of the stream id counter key.
+///
+/// # Returns
+/// The stream id that should be assigned to the next created stream.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn next_stream_id(env: &Env) -> u64 {
     let storage = env.storage().instance();
     let id = storage.get(&DataKey::NextStreamId).unwrap_or(1u64);
@@ -169,6 +251,15 @@ pub fn next_stream_id(env: &Env) -> u64 {
     id
 }
 
+/// Writes a stream record into persistent storage.
+///
+/// This helper also extends the TTL for the corresponding per-stream entry.
+///
+/// # Returns
+/// This helper does not return a value.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn set_stream(env: &Env, stream_id: u64, stream: &Stream) {
     env.storage()
         .persistent()
@@ -176,6 +267,17 @@ pub fn set_stream(env: &Env, stream_id: u64, stream: &Stream) {
     extend_stream_ttl(env, stream_id);
 }
 
+/// Reads a stream record from persistent storage.
+///
+/// If the stream exists, this helper extends the TTL for the corresponding
+/// per-stream entry.
+///
+/// # Returns
+/// - `Some(Stream)` if the stream exists.
+/// - `None` otherwise.
+///
+/// # Errors
+/// This helper does not return errors.
 pub fn get_stream(env: &Env, stream_id: u64) -> Option<Stream> {
     let stream = env.storage().persistent().get(&DataKey::Stream(stream_id));
     if stream.is_some() {
@@ -183,3 +285,4 @@ pub fn get_stream(env: &Env, stream_id: u64) -> Option<Stream> {
     }
     stream
 }
+


### PR DESCRIPTION
closes #443
# Description

This PR adds NatSpec-style documentation to all public helper functions in `contracts/contracts/streampay-stream/src/storage.rs`.

### Changes Made

* Added `///` documentation comments to every `pub fn`.
* Included `# Returns` sections for all helper functions.
* Included `# Errors` sections for all helper functions.
* Documented TTL-extension side effects where applicable.
* Improved code readability and maintainability through clear inline documentation.

## Type of Change

* [x] Documentation update
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

## Verification

### Documentation Review

* Verified that all public helper functions are documented.
* Verified that each function includes `# Returns` and `# Errors` sections.
* Confirmed that helpers are infallible where applicable and documented accordingly.

### cargo doc

Attempted to run:

```bash
cargo doc -p streampay-stream
```

However, the Rust toolchain is not available in the current environment:

```bash
Command 'cargo' not found
```

Please run the command in a local development environment or CI pipeline to confirm:

* `cargo doc` passes successfully
* No missing-docs warnings are present

## Notes

This change is documentation-only and does not modify contract logic, storage behavior, or functionality.
