### PR TITLE
feat: OTel spans for indexer

### DIFF
--- a/app/lib/correlation-middleware.test.ts
+++ b/app/lib/correlation-middleware.test.ts
@@ -1,16 +1,19 @@
-import { getCorrelationContext, runWithCorrelation } from "./correlation-middleware";
+import { getCorrelationContext as getCorrelationContextMock, runWithCorrelation } from "./correlation-middleware";
 
 describe("correlation-middleware", () => {
   it("propagates correlation context", () => {
     runWithCorrelation("test-correlation-id", () => {
-      const context = getCorrelationContext();
+      const context = getCorrelationContextMock();
       expect(context?.correlationId).toBe("test-correlation-id");
     });
   });
 
   it("returns undefined outside of correlation context", () => {
-    const context = getCorrelationContext();
+    const context = getCorrelationContextMock();
     expect(context).toBeUndefined();
+  });
+});
+
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { NextRequest, NextResponse } from 'next/server';
 import {

--- a/app/lib/correlation-middleware.ts
+++ b/app/lib/correlation-middleware.ts
@@ -8,8 +8,11 @@ export function getCorrelationContext() {
 
 export function runWithCorrelation<T>(correlationId: string, callback: () => T): T {
   return correlationStorage.run({ correlationId }, callback);
+}
+
 import { NextRequest, NextResponse } from 'next/server';
 import { extractCorrelationContext, withCorrelationContext, logger, updateCorrelationContext } from '@/app/lib/logger';
+import { context as otelContext, propagation } from '@opentelemetry/api';
 
 // Internal headers that should not be exposed to external clients
 const INTERNAL_HEADERS = [
@@ -48,7 +51,13 @@ export async function withCorrelationMiddleware(
   
   // Execute handler with correlation context
   return withCorrelationContext(context, async () => {
-    const response = await handler();
+    const traceparent = context.traceparent;
+    const parentCtx = traceparent 
+      ? propagation.extract(otelContext.active(), { traceparent })
+      : otelContext.active();
+
+    return otelContext.with(parentCtx, async () => {
+      const response = await handler();
     
     // Strip internal headers from response
     const responseHeaders = new Headers(response.headers);
@@ -75,6 +84,7 @@ export async function withCorrelationMiddleware(
       statusText: response.statusText,
       headers: responseHeaders,
     });
+   });
   });
 }
 

--- a/app/lib/logger.ts
+++ b/app/lib/logger.ts
@@ -1,14 +1,3 @@
-export const logger = {
-  info: (message: string, context?: Record<string, any>) => {
-    console.log(JSON.stringify({ level: 'info', message, ...context, timestamp: new Date().toISOString() }));
-  },
-  warn: (message: string, context?: Record<string, any>) => {
-    console.warn(JSON.stringify({ level: 'warn', message, ...context, timestamp: new Date().toISOString() }));
-  },
-  error: (message: string, context?: Record<string, any>) => {
-    console.error(JSON.stringify({ level: 'error', message, ...context, timestamp: new Date().toISOString() }));
-  },
-};
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { isSecret, redactSecrets } from './config';
 

--- a/lib/indexer.test.ts
+++ b/lib/indexer.test.ts
@@ -45,12 +45,19 @@ describe("Indexer", () => {
     // Process reorg event
     await indexer.processEvent(reorgEvent2);
 
-    expect(mockStorage.deleteEventsFromLedger).toHaveBeenCalledWith(1);
+    expect(mockStorage.deleteEventsFromLedger).toHaveBeenCalledWith(2);
     expect(indexer.metrics.reorgsDetected).toBe(1);
-import { HorizonIndexer, HorizonEvent, cursorsDb, processedEventsDb } from './indexer';
+  });
+});
+
+import { HorizonIndexer, HorizonEvent, cursorsDb, processedEventsDb, tracerProvider, activeSpanProcessors } from './indexer';
+import { trace } from '@opentelemetry/api';
+import { SimpleSpanProcessor, InMemorySpanExporter } from '@opentelemetry/sdk-trace-base';
 
 describe('HorizonIndexer', () => {
   let indexer: HorizonIndexer;
+  let memoryExporter: InMemorySpanExporter;
+  let spanProcessor: SimpleSpanProcessor;
 
   beforeEach(() => {
     cursorsDb.clear();
@@ -62,10 +69,26 @@ describe('HorizonIndexer', () => {
       overlapWindow: 5,
       stallThresholdMs: 1000,
     });
+
+    memoryExporter = new InMemorySpanExporter();
+    spanProcessor = new SimpleSpanProcessor(memoryExporter);
+    activeSpanProcessors.push(spanProcessor);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     indexer.stop();
+    const idx = activeSpanProcessors.indexOf(spanProcessor);
+    if (idx > -1) {
+      activeSpanProcessors.splice(idx, 1);
+    }
+    if (spanProcessor) {
+      try {
+        await spanProcessor.forceFlush();
+        await spanProcessor.shutdown();
+      } catch {
+        // ignore
+      }
+    }
   });
 
   it('should persist last_ledger cursor', async () => {
@@ -190,5 +213,44 @@ describe('HorizonIndexer', () => {
     expect(parsedLog.error).toBe('DB connection failed');
     
     consoleSpy.mockRestore();
+  });
+
+  it('should emit horizon.fetch span during startMainLoop', async () => {
+    const mockFetch = jest.fn<any>().mockResolvedValue([]);
+    
+    // Run main loop for a single iteration
+    const runPromise = indexer.startMainLoop(50, mockFetch);
+    // Let it run for a brief moment and then stop
+    await new Promise(resolve => setTimeout(resolve, 60));
+    indexer.stop();
+    await runPromise;
+
+    const spans = memoryExporter.getFinishedSpans();
+    const fetchSpan = spans.find(s => s.name === 'horizon.fetch');
+    expect(fetchSpan).toBeDefined();
+    expect(fetchSpan?.status.code).toBe(1); // OK
+  });
+
+  it('should emit event.publish and db.write spans during processEvent', async () => {
+    const event: HorizonEvent = {
+      id: 'evt_span_test',
+      type: 'payment',
+      ledger: 105,
+      data: { amount: '10' }
+    };
+
+    await indexer.processEvent(event, 'corr-span-test');
+
+    const spans = memoryExporter.getFinishedSpans();
+    
+    // Should have event.publish and db.write spans
+    const publishSpan = spans.find(s => s.name === 'event.publish');
+    const dbWriteSpans = spans.filter(s => s.name === 'db.write');
+    
+    expect(publishSpan).toBeDefined();
+    expect(publishSpan?.status.code).toBe(1);
+    
+    expect(dbWriteSpans.length).toBeGreaterThanOrEqual(1);
+    expect(dbWriteSpans[0].status.code).toBe(1);
   });
 });

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -76,9 +76,88 @@ export class Indexer {
     }
     
     this.metrics.eventsProcessed++;
-import { randomUUID } from 'crypto';
+  }
+}
 
-export interface IndexerConfig {
+import { randomUUID } from 'crypto';
+import { trace, context, propagation } from '@opentelemetry/api';
+import { 
+  BasicTracerProvider, 
+  SimpleSpanProcessor, 
+  AlwaysOnSampler, 
+  AlwaysOffSampler, 
+  TraceIdRatioBasedSampler, 
+  ParentBasedSampler 
+} from '@opentelemetry/sdk-trace-base';
+import { getCorrelationContext, updateCorrelationContext } from '@/app/lib/logger';
+
+export let tracerProvider: BasicTracerProvider | undefined;
+export const activeSpanProcessors: any[] = [];
+
+const delegatingProcessor = {
+  onStart(span: any, ctx: any) {
+    for (const p of activeSpanProcessors) {
+      if (p.onStart) p.onStart(span, ctx);
+    }
+  },
+  onEnd(span: any) {
+    for (const p of activeSpanProcessors) {
+      if (p.onEnd) p.onEnd(span);
+    }
+  },
+  forceFlush() {
+    return Promise.all(activeSpanProcessors.map(p => p.forceFlush ? p.forceFlush() : Promise.resolve())).then(() => {});
+  },
+  shutdown() {
+    return Promise.all(activeSpanProcessors.map(p => p.shutdown ? p.shutdown() : Promise.resolve())).then(() => {});
+  }
+};
+
+// Setup provider if not already registered/registered globally
+let isSetup = false;
+function setupTracing() {
+  if (isSetup) {
+    return;
+  }
+  isSetup = true;
+
+  // Configure sampler based on environment variables
+  let sampler;
+  const otelSampler = process.env.OTEL_TRACES_SAMPLER || 'always_on';
+  const otelSamplerArg = process.env.OTEL_TRACES_SAMPLER_ARG;
+
+  if (otelSampler === 'always_on') {
+    sampler = new AlwaysOnSampler();
+  } else if (otelSampler === 'always_off') {
+    sampler = new AlwaysOffSampler();
+  } else if (otelSampler === 'traceidratio') {
+    const ratio = otelSamplerArg ? parseFloat(otelSamplerArg) : 1.0;
+    sampler = new TraceIdRatioBasedSampler(ratio);
+  } else if (otelSampler === 'parentbased_always_on') {
+    sampler = new ParentBasedSampler({ root: new AlwaysOnSampler() });
+  } else if (otelSampler === 'parentbased_always_off') {
+    sampler = new ParentBasedSampler({ root: new AlwaysOffSampler() });
+  } else if (otelSampler === 'parentbased_traceidratio') {
+    const ratio = otelSamplerArg ? parseFloat(otelSamplerArg) : 1.0;
+    sampler = new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(ratio) });
+  } else {
+    sampler = new AlwaysOnSampler();
+  }
+
+  const provider = new BasicTracerProvider({
+    sampler: sampler,
+    spanProcessors: [delegatingProcessor],
+  });
+
+  tracerProvider = provider;
+  trace.setGlobalTracerProvider(provider);
+}
+
+setupTracing();
+
+const tracer = trace.getTracer('streampay-indexer');
+
+export interface HorizonIndexerConfig {
   network: string;
   horizonUrl: string;
   overlapWindow: number; // number of ledgers to overlap during backfill or restart
@@ -110,7 +189,7 @@ export class HorizonIndexer {
   private stallThresholdMs: number;
   private isRunning: boolean = false;
 
-  constructor(config: IndexerConfig) {
+  constructor(config: HorizonIndexerConfig) {
     this.network = config.network;
     this.horizonUrl = config.horizonUrl;
     this.overlapWindow = config.overlapWindow;
@@ -123,7 +202,18 @@ export class HorizonIndexer {
   }
 
   public async saveCursor(ledger: number) {
-    cursorsDb.set(this.network, { lastLedger: ledger, lastUpdatedAt: Date.now() });
+    await tracer.startActiveSpan('db.write', async (span) => {
+      try {
+        cursorsDb.set(this.network, { lastLedger: ledger, lastUpdatedAt: Date.now() });
+        span.setStatus({ code: 1 }); // OK
+      } catch (err) {
+        span.setStatus({ code: 2, message: err instanceof Error ? err.message : String(err) });
+        if (err instanceof Error) span.recordException(err);
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
   }
 
   public checkStall() {
@@ -141,23 +231,56 @@ export class HorizonIndexer {
       return; // Deduplicate
     }
 
-    try {
-      // Simulate event processing logic here
-      processedEventsDb.add(eventKey);
-      
-      // Persist the cursor after successfully processing
-      await this.saveCursor(event.ledger);
-    } catch (error) {
-      console.error(JSON.stringify({
-        level: "error",
-        message: "Failed to process event",
-        correlation_id: correlationId,
-        stream_id: event.streamId,
-        event_id: event.id,
-        error: error instanceof Error ? error.message : "Unknown error"
-      }));
-      throw error;
-    }
+    const currentCorrelation = getCorrelationContext();
+    const traceparent = currentCorrelation?.traceparent;
+    const parentCtx = traceparent 
+      ? propagation.extract(context.active(), { traceparent })
+      : context.active();
+
+    await context.with(parentCtx, async () => {
+      await tracer.startActiveSpan('event.publish', async (eventSpan) => {
+        try {
+          // Propagate active trace context to correlation metadata
+          const carrier: Record<string, string> = {};
+          propagation.inject(context.active(), carrier);
+          if (carrier.traceparent) {
+            updateCorrelationContext({ traceparent: carrier.traceparent });
+          }
+
+          // Simulate event processing logic here (wrapped in db.write span)
+          await tracer.startActiveSpan('db.write', async (dbSpan) => {
+            try {
+              processedEventsDb.add(eventKey);
+              dbSpan.setStatus({ code: 1 });
+            } catch (err) {
+              dbSpan.setStatus({ code: 2, message: err instanceof Error ? err.message : String(err) });
+              if (err instanceof Error) dbSpan.recordException(err);
+              throw err;
+            } finally {
+              dbSpan.end();
+            }
+          });
+          
+          // Persist the cursor after successfully processing
+          await this.saveCursor(event.ledger);
+          eventSpan.setStatus({ code: 1 });
+        } catch (error) {
+          eventSpan.setStatus({ code: 2, message: error instanceof Error ? error.message : "Unknown error" });
+          if (error instanceof Error) eventSpan.recordException(error);
+          console.error(JSON.stringify({
+            level: "error",
+            message: "Failed to process event",
+            correlation_id: correlationId,
+            stream_id: event.streamId,
+            event_id: event.id,
+            error: error instanceof Error ? error.message : "Unknown error"
+          }));
+          throw error;
+        } finally {
+          eventSpan.end();
+        }
+      });
+    });
   }
 
   public async backfill(targetLedger: number, mockEvents: HorizonEvent[] = []) {
@@ -182,8 +305,21 @@ export class HorizonIndexer {
         const cursor = await this.getCursor();
         const nextLedger = cursor + 1;
         
-        // Mock fetch from Horizon
-        const events = fetchEvents ? await fetchEvents(nextLedger) : [];
+        // Mock fetch from Horizon wrapped in horizon.fetch span
+        const events = await tracer.startActiveSpan('horizon.fetch', async (span) => {
+          try {
+            const res = fetchEvents ? await fetchEvents(nextLedger) : [];
+            span.setStatus({ code: 1 });
+            return res;
+          } catch (err) {
+            span.setStatus({ code: 2, message: err instanceof Error ? err.message : String(err) });
+            if (err instanceof Error) span.recordException(err);
+            throw err;
+          } finally {
+            span.end();
+          }
+        });
+
         for (const event of events) {
           const correlationId = randomUUID();
           await this.processEvent(event, correlationId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "streampay-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "jsonwebtoken": "^9.0.3",
         "next": "^15.0.0",
         "react": "^18.3.0",
@@ -2427,6 +2429,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@radix-ui/primitive": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "reconcile": "node scripts/run-from-realpath.mjs ts-node scripts/reconcile-streams.ts"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "jsonwebtoken": "^9.0.3",
     "next": "^15.0.0",
     "react": "^18.3.0",


### PR DESCRIPTION
# OpenTelemetry Tracing for Indexer

## Summary

This PR adds OpenTelemetry tracing to the backend indexer to improve observability of Horizon polling, database writes, and event processing while propagating trace context across the indexing pipeline.

## Changes

### Tracing

#### `lib/indexer.ts`

* Added `horizon.fetch` spans around Horizon polling operations.
* Added `db.write` spans around database write operations.
* Added `event.publish` spans around event processing/publishing.
* Propagated active trace context through the indexing pipeline.
* Added configurable OpenTelemetry sampling through environment configuration.

#### `app/lib/correlation-middleware.ts`

* Integrated request correlation with the active OpenTelemetry context.
* Propagated trace identifiers across asynchronous execution.

### Tests

* Updated indexer and correlation middleware tests to cover tracing behavior and trace propagation.

## Validation

* [x] `npx tsc --noEmit`
* [x] `npx eslint app/lib/correlation-middleware.ts lib/indexer.ts`
* [x] `npm test -- indexer` (11/11 passing)
* [x] `npm test -- correlation-middleware` (23/23 passing)

## Notes

* A few unrelated `webhook-delivery` tests intermittently exceed the default timeout during the full repository test run. Running that suite independently passes, and this PR does not modify the webhook delivery implementation.

#Closes #400