### PR TITLE
feat: per-stream SSE endpoint GET /api/v2/streams/[id]/events (#429)

### DIFF
--- a/app/api/v2/streams/[id]/events/route.test.ts
+++ b/app/api/v2/streams/[id]/events/route.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for GET /api/v2/streams/[id]/events (SSE)
+ *
+ * Strategy
+ * ────────
+ * We test the HTTP-layer contract (status codes, headers, auth, 404/403)
+ * without spinning up a real SSE connection. For the streaming path we
+ * verify that the ReadableStream is returned with the correct headers and
+ * that event-bus listeners are wired and cleaned up correctly.
+ */
+
+import { GET } from "./route";
+import { resetDb } from "@/app/lib/db";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock("@/app/lib/logger");
+jest.mock("next/headers", () => ({
+  headers: () => ({ get: () => null }),
+}));
+
+// Capture event-bus listener registrations so we can assert on them.
+const busListeners: Record<string, ((...args: any[]) => void)[]> = {};
+jest.mock("@/app/lib/event-bus", () => ({
+  eventBus: {
+    on: jest.fn((event: string, fn: (...args: any[]) => void) => {
+      busListeners[event] = busListeners[event] ?? [];
+      busListeners[event].push(fn);
+    }),
+    off: jest.fn((event: string, fn: (...args: any[]) => void) => {
+      busListeners[event] = (busListeners[event] ?? []).filter((l) => l !== fn);
+    }),
+    emit: jest.fn(),
+  },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal JWT with `sub` set to `walletAddress`. */
+function makeToken(walletAddress: string): string {
+  const header  = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub: walletAddress, iss: "streampay", aud: "streampay-api" })).toString("base64url");
+  return `${header}.${payload}.fakesig`;
+}
+
+/** Build a Next.js-compatible request stub. */
+function makeRequest(opts: {
+  auth?: string | null;
+  abortController?: AbortController;
+} = {}): Request {
+  const { auth = `Bearer ${makeToken("GSENDER111")}`, abortController } = opts;
+  const headers: Record<string, string> = {};
+  if (auth) headers["authorization"] = auth;
+
+  const signal = abortController?.signal ?? new AbortController().signal;
+
+  return new Request("http://localhost/api/v2/streams/stream-1/events", {
+    headers,
+    signal,
+  }) as any;
+}
+
+/** Params stub matching Next.js dynamic route context. */
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Clear bus listener tracking between tests.
+  Object.keys(busListeners).forEach((k) => delete busListeners[k]);
+
+  resetDb({
+    "stream-1": {
+      id: "stream-1",
+      sender:    "GSENDER111",
+      recipient: "GRECIPIENT222",
+      token:     "XLM",
+      rate:      "100",
+      status:    "active",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as any,
+  });
+});
+
+afterEach(() => resetDb());
+
+// ── Auth tests ───────────────────────────────────────────────────────────────
+
+describe("authentication", () => {
+  it("returns 401 when Authorization header is absent", async () => {
+    const res = await GET(makeRequest({ auth: null }) as any, params("stream-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when token is not a Bearer token", async () => {
+    const res = await GET(makeRequest({ auth: "Basic abc" }) as any, params("stream-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when Bearer token is malformed (bad base64)", async () => {
+    const res = await GET(makeRequest({ auth: "Bearer not.a.token" }) as any, params("stream-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when token payload has no sub claim", async () => {
+    const header  = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ iss: "streampay" })).toString("base64url");
+    const token   = `${header}.${payload}.sig`;
+    const res = await GET(makeRequest({ auth: `Bearer ${token}` }) as any, params("stream-1"));
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Stream lookup ─────────────────────────────────────────────────────────────
+
+describe("stream lookup", () => {
+  it("returns 404 when stream does not exist", async () => {
+    const res = await GET(makeRequest() as any, params("nonexistent"));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Authorization ─────────────────────────────────────────────────────────────
+
+describe("authorization", () => {
+  it("returns 403 when caller is not sender or recipient", async () => {
+    const token = makeToken("GSTRANGER999");
+    const res   = await GET(
+      makeRequest({ auth: `Bearer ${token}` }) as any,
+      params("stream-1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows the stream sender to subscribe", async () => {
+    const token = makeToken("GSENDER111");
+    const res   = await GET(
+      makeRequest({ auth: `Bearer ${token}` }) as any,
+      params("stream-1"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows the stream recipient to subscribe", async () => {
+    const token = makeToken("GRECIPIENT222");
+    const res   = await GET(
+      makeRequest({ auth: `Bearer ${token}` }) as any,
+      params("stream-1"),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── SSE response shape ────────────────────────────────────────────────────────
+
+describe("SSE response", () => {
+  it("responds with Content-Type: text/event-stream", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+  });
+
+  it("responds with Cache-Control: no-cache, no-transform", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    expect(res.headers.get("cache-control")).toBe("no-cache, no-transform");
+  });
+
+  it("responds with Connection: keep-alive", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    expect(res.headers.get("connection")).toBe("keep-alive");
+  });
+
+  it("responds with X-Accel-Buffering: no to disable proxy buffering", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    expect(res.headers.get("x-accel-buffering")).toBe("no");
+  });
+
+  it("returns a ReadableStream body", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    expect(res.body).toBeInstanceOf(ReadableStream);
+  });
+});
+
+// ── Event-bus wiring ──────────────────────────────────────────────────────────
+
+describe("event-bus wiring", () => {
+  it("registers stream:updated and settle:finished listeners on connect", async () => {
+    const { eventBus } = require("@/app/lib/event-bus");
+    await GET(makeRequest() as any, params("stream-1"));
+
+    expect(eventBus.on).toHaveBeenCalledWith(
+      "stream:updated:stream-1",
+      expect.any(Function),
+    );
+    expect(eventBus.on).toHaveBeenCalledWith(
+      "settle:finished:stream-1",
+      expect.any(Function),
+    );
+  });
+
+  it("forwards stream:updated events to the SSE stream", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    const reader = res.body!.getReader();
+
+    // Emit an event and read the first chunk.
+    const payload = { streamId: "stream-1", status: "paused" };
+    const listeners = busListeners["stream:updated:stream-1"] ?? [];
+    listeners.forEach((fn) => fn(payload));
+
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("event: stream:updated");
+    expect(text).toContain(JSON.stringify(payload));
+  });
+
+  it("forwards settle:finished events to the SSE stream", async () => {
+    const res = await GET(makeRequest() as any, params("stream-1"));
+    const reader = res.body!.getReader();
+
+    const payload = { streamId: "stream-1", amount: "1000" };
+    const listeners = busListeners["settle:finished:stream-1"] ?? [];
+    listeners.forEach((fn) => fn(payload));
+
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("event: settle:finished");
+    expect(text).toContain(JSON.stringify(payload));
+  });
+
+  it("removes listeners when the connection is aborted", async () => {
+    const { eventBus } = require("@/app/lib/event-bus");
+    const ac = new AbortController();
+
+    await GET(makeRequest({ abortController: ac }) as any, params("stream-1"));
+
+    // Abort the request (simulates client disconnect / Connection: close).
+    ac.abort();
+
+    // Allow microtask queue to flush.
+    await Promise.resolve();
+
+    expect(eventBus.off).toHaveBeenCalledWith(
+      "stream:updated:stream-1",
+      expect.any(Function),
+    );
+    expect(eventBus.off).toHaveBeenCalledWith(
+      "settle:finished:stream-1",
+      expect.any(Function),
+    );
+  });
+});

--- a/app/api/v2/streams/[id]/events/route.ts
+++ b/app/api/v2/streams/[id]/events/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getStore } from "@/app/lib/db";
+import { eventBus } from "@/app/lib/event-bus";
+import { logger } from "@/app/lib/logger";
+import { errorResponse, ErrorCode } from "@/app/lib/errors";
+
+/**
+ * GET /api/v2/streams/[id]/events
+ *
+ * Server-Sent Events endpoint for per-stream lifecycle updates.
+ *
+ * Protocol
+ * ────────
+ * - Client connects with `Authorization: Bearer <token>`.
+ * - Server sends a `: keep-alive` comment every 15 s.
+ * - Server forwards two event types:
+ *     event: stream:updated   — any state mutation on this stream
+ *     event: settle:finished  — stream fully settled
+ * - On `Connection: close` / client disconnect the abort signal fires,
+ *   listeners are removed, and the stream is closed.
+ *
+ * Security
+ * ────────
+ * - Bearer token required (401 without it).
+ * - Stream must exist (404).
+ * - Caller must be the stream sender or recipient (403).
+ * - No persistent storage write; read-only subscription.
+ *
+ * Backpressure
+ * ────────────
+ * Each enqueue is wrapped in a try/catch. If the underlying
+ * ReadableStream controller is already closed (client gone), we call
+ * cleanup() immediately rather than letting errors accumulate.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  // ── 1. Auth ──────────────────────────────────────────────────────────────
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return errorResponse(ErrorCode.UNAUTHORIZED, "Bearer token required.", 401);
+  }
+
+  // Decode the JWT sub claim without full verification so the route
+  // stays dependency-light. The middleware layer handles signature
+  // verification before requests reach here.
+  let walletAddress: string | null = null;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(authHeader.slice(7).split(".")[1], "base64url").toString(),
+    ) as { sub?: string };
+    walletAddress = payload.sub ?? null;
+  } catch {
+    return errorResponse(ErrorCode.UNAUTHORIZED, "Malformed bearer token.", 401);
+  }
+
+  if (!walletAddress) {
+    return errorResponse(ErrorCode.UNAUTHORIZED, "Token missing sub claim.", 401);
+  }
+
+  // ── 2. Resolve stream ────────────────────────────────────────────────────
+  const { id } = await params;
+  const { streamRepository } = getStore();
+  const stream = streamRepository.streams.get(id);
+
+  if (!stream) {
+    return errorResponse(ErrorCode.STREAM_NOT_FOUND, `Stream '${id}' not found.`, 404);
+  }
+
+  // ── 3. Authorise ─────────────────────────────────────────────────────────
+  // Only the stream's sender or recipient may subscribe.
+  const isSender    = (stream as any).sender    === walletAddress;
+  const isRecipient = (stream as any).recipient === walletAddress;
+
+  if (!isSender && !isRecipient) {
+    logger.warn("Unauthorised SSE subscription attempt", {
+      streamId: id,
+      walletAddress,
+    });
+    return errorResponse(
+      ErrorCode.FORBIDDEN,
+      "You do not have permission to subscribe to this stream.",
+      403,
+    );
+  }
+
+  // ── 4. SSE stream ────────────────────────────────────────────────────────
+  const encoder = new TextEncoder();
+
+  const body = new ReadableStream({
+    start(controller) {
+      logger.info("SSE client connected", { streamId: id, walletAddress });
+
+      // ── helpers ──────────────────────────────────────────────────────────
+
+      /** Enqueue raw SSE bytes; call cleanup on write error (client gone). */
+      function enqueue(chunk: string) {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          cleanup();
+        }
+      }
+
+      /** Remove all listeners and close the controller. */
+      function cleanup() {
+        clearInterval(keepAlive);
+        eventBus.off(`stream:updated:${id}`,  onUpdated);
+        eventBus.off(`settle:finished:${id}`, onSettled);
+        request.signal.removeEventListener("abort", cleanup);
+        try { controller.close(); } catch { /* already closed */ }
+        logger.info("SSE client disconnected", { streamId: id, walletAddress });
+      }
+
+      // ── keep-alive (15 s comment) ─────────────────────────────────────
+      const keepAlive = setInterval(
+        () => enqueue(": keep-alive\n\n"),
+        15_000,
+      );
+
+      // ── event handlers ────────────────────────────────────────────────
+      function onUpdated(data: unknown) {
+        enqueue(`event: stream:updated\ndata: ${JSON.stringify(data)}\n\n`);
+      }
+
+      function onSettled(data: unknown) {
+        enqueue(`event: settle:finished\ndata: ${JSON.stringify(data)}\n\n`);
+      }
+
+      eventBus.on(`stream:updated:${id}`,  onUpdated);
+      eventBus.on(`settle:finished:${id}`, onSettled);
+
+      // ── disconnect ────────────────────────────────────────────────────
+      // Fires when the client closes the connection or the server sends
+      // Connection: close. We rely on the AbortSignal rather than a
+      // `cancel()` hook because Next.js/Node.js streams surface
+      // client disconnects through the request signal.
+      request.signal.addEventListener("abort", cleanup, { once: true });
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type":  "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection":    "keep-alive",
+      // Prevent buffering by proxies / CDN edges.
+      "X-Accel-Buffering": "no",
+    },
+  });
+}


### PR DESCRIPTION
Closes #429

Adds GET /api/v2/streams/[id]/events SSE endpoint.

- Bearer auth (401 without token)
- 404 unknown stream, 403 non-owner
- keep-alive comment every 15s
- Forwards stream:updated and settle:finished events from event-bus
- Backpressure-safe enqueue with try/catch
- Cleanup on AbortSignal abort (Connection: close support)
- X-Accel-Buffering: no, Cache-Control: no-cache
- Full test coverage in route.test.ts