### PR TITLE
docs: add microcopy QA checklist

### DIFF
--- a/app/design-qa/DesignChecklist.tsx
+++ b/app/design-qa/DesignChecklist.tsx
@@ -100,7 +100,7 @@ export function DesignChecklist({ screen }: { screen?: string }) {
             </p>
           )}
           <p className="checklist-header__meta">
-            {TOTAL_ITEMS} items · a11y, interactive states, 8px grid, empty/loading/error, money actions, Stellar/Soroban
+            {TOTAL_ITEMS} items · a11y, interactive states, 8px grid, empty/loading/error, microcopy, money actions, Stellar/Soroban
           </p>
         </div>
         <button className="button button--secondary checklist-reset-btn" onClick={handleReset} type="button">
@@ -146,6 +146,9 @@ export function DesignChecklist({ screen }: { screen?: string }) {
                         {idx + 1}
                       </span>
                       <p className="checklist-item__text">{item.item}</p>
+                      {item.annotation && (
+                        <p className="checklist-item__annotation">{item.annotation}</p>
+                      )}
                       <div className="checklist-item__actions" role="group" aria-label={`Answer for item ${idx + 1}`}>
                         <AnswerButton value="yes" current={answer} label="Yes" itemId={item.id} onChange={(v) => setAnswer(item.id, v)} />
                         <AnswerButton value="no" current={answer} label="No" itemId={item.id} onChange={(v) => setAnswer(item.id, v)} />

--- a/app/design-qa/checklist-data.test.ts
+++ b/app/design-qa/checklist-data.test.ts
@@ -1,0 +1,52 @@
+import { CHECKLIST_SECTIONS, TOTAL_ITEMS } from "./checklist-data";
+
+describe("design QA checklist data", () => {
+  it("includes the microcopy review section", () => {
+    const microcopy = CHECKLIST_SECTIONS.find((section) => section.id === "microcopy");
+
+    expect(microcopy?.items).toHaveLength(6);
+    expect(microcopy?.items.every((item) => item.annotation?.startsWith("Relevant pages: "))).toBe(
+      true
+    );
+    expect(TOTAL_ITEMS).toBe(38);
+    expect(microcopy).toMatchInlineSnapshot(`
+{
+  "description": "Copy should make stream setup, wallet actions, and on-chain status understandable without internal jargon.",
+  "id": "microcopy",
+  "items": [
+    {
+      "annotation": "Relevant pages: /, /streams, /activity, /settings",
+      "id": "copy-1",
+      "item": "Error messages are written in plain language, name what happened, and give the next useful action instead of exposing raw API, wallet, or contract errors.",
+    },
+    {
+      "annotation": "Relevant pages: /, /streams, /settings",
+      "id": "copy-2",
+      "item": "Primary button copy starts with a clear verb and matches the action result, such as Create stream, Pause stream, Resume stream, Withdraw funds, or Save settings.",
+    },
+    {
+      "annotation": "Relevant pages: /, /streams, /activity",
+      "id": "copy-3",
+      "item": "Empty states explain why the screen is empty and include one helpful next step or CTA instead of generic placeholder text.",
+    },
+    {
+      "annotation": "Relevant pages: /, /streams, /activity",
+      "id": "copy-4",
+      "item": "Loading and pending states describe what is happening now, especially for wallet approval and on-chain transaction submission.",
+    },
+    {
+      "annotation": "Relevant pages: /streams, /activity",
+      "id": "copy-5",
+      "item": "Status labels use consistent tense and naming across StreamRow, StatusBadge, activity entries, and confirmation dialogs.",
+    },
+    {
+      "annotation": "Relevant pages: /, /streams, /activity",
+      "id": "copy-6",
+      "item": "Money amounts, recipients, and dates are repeated in confirmation and success copy so users can verify the exact stream outcome.",
+    },
+  ],
+  "title": "Microcopy and Content Quality",
+}
+`);
+  });
+});

--- a/app/design-qa/checklist-data.ts
+++ b/app/design-qa/checklist-data.ts
@@ -149,6 +149,44 @@ export const CHECKLIST_SECTIONS: ChecklistSection[] = [
     ],
   },
   {
+    id: "microcopy",
+    title: "Microcopy and Content Quality",
+    description:
+      "Copy should make stream setup, wallet actions, and on-chain status understandable without internal jargon.",
+    items: [
+      {
+        id: "copy-1",
+        item: "Error messages are written in plain language, name what happened, and give the next useful action instead of exposing raw API, wallet, or contract errors.",
+        annotation: "Relevant pages: /, /streams, /activity, /settings",
+      },
+      {
+        id: "copy-2",
+        item: "Primary button copy starts with a clear verb and matches the action result, such as Create stream, Pause stream, Resume stream, Withdraw funds, or Save settings.",
+        annotation: "Relevant pages: /, /streams, /settings",
+      },
+      {
+        id: "copy-3",
+        item: "Empty states explain why the screen is empty and include one helpful next step or CTA instead of generic placeholder text.",
+        annotation: "Relevant pages: /, /streams, /activity",
+      },
+      {
+        id: "copy-4",
+        item: "Loading and pending states describe what is happening now, especially for wallet approval and on-chain transaction submission.",
+        annotation: "Relevant pages: /, /streams, /activity",
+      },
+      {
+        id: "copy-5",
+        item: "Status labels use consistent tense and naming across StreamRow, StatusBadge, activity entries, and confirmation dialogs.",
+        annotation: "Relevant pages: /streams, /activity",
+      },
+      {
+        id: "copy-6",
+        item: "Money amounts, recipients, and dates are repeated in confirmation and success copy so users can verify the exact stream outcome.",
+        annotation: "Relevant pages: /, /streams, /activity",
+      },
+    ],
+  },
+  {
     id: "devmode",
     title: "Figma Dev Mode and Component Naming",
     items: [

--- a/app/globals.css
+++ b/app/globals.css
@@ -649,6 +649,12 @@ a:hover {
   margin-bottom: 1.5rem;
 }
 
+.checklist-item__annotation {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  margin: 0.25rem 0 0;
+}
+
 /* ─── Media Queries ─── */
 @media (min-width: 48rem) {
   .page-shell { padding: 3rem 2rem 4rem; }


### PR DESCRIPTION
Adds a microcopy review section to the design QA checklist so content quality is checked before handoff.

### What changed
- Added six checklist criteria for errors, action-led buttons, empty states, loading states, status language, and confirmation copy.
- Linked each criterion to the relevant StreamPay pages.
- Rendered checklist annotations so those page references are visible in the QA screen.
- Added a focused snapshot test for the new microcopy section.

### Checks
- `npm test -- --runTestsByPath app/design-qa/checklist-data.test.ts`
- `npx eslint app/design-qa/checklist-data.ts app/design-qa/checklist-data.test.ts app/design-qa/DesignChecklist.tsx`

Closes #365