### PR TITLE
feat: centralize stream time helpers

### DIFF
--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 mod events;
 mod release;
 mod storage;
+mod time;
 
 pub use error::Error;
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
@@ -230,16 +231,12 @@ impl Contract {
             return Err(Error::TokenNotAllowed);
         }
 
-        if end_time <= start_time {
-            return Err(Error::InvalidTimeRange);
-        }
-
-        let now = env.ledger().timestamp();
+        let duration = time::checked_duration(start_time, end_time)?;
+        let now = time::ledger_timestamp(&env);
         if start_time < now {
             return Err(Error::InvalidTimeRange);
         }
 
-        let duration = end_time - start_time;
         let id = storage::next_stream_id(&env);
         let contract_address = env.current_contract_address();
 
@@ -290,13 +287,11 @@ impl Contract {
             return Err(Error::InvalidState);
         }
 
-        let now = env.ledger().timestamp();
+        let now = time::ledger_timestamp(&env);
         stream.status = StreamStatus::Active;
         stream.start_time = now;
         stream.last_update = now;
-        stream.end_time = now
-            .checked_add(stream.duration)
-            .ok_or(Error::InvalidTimeRange)?;
+        stream.end_time = time::checked_add_timestamp(now, stream.duration)?;
 
         storage::set_stream(&env, stream_id, &stream);
         events::started(&env, stream_id, stream.start_time, stream.end_time, stream.start_time);
@@ -321,7 +316,7 @@ impl Contract {
     /// - [`Error::Overflow`] if the vested-amount computation overflows.
     pub fn withdrawable(env: Env, stream_id: u64) -> Result<i128, Error> {
         let stream = get_existing_stream(&env, stream_id)?;
-        withdrawable_amount(env.ledger().timestamp(), &stream)
+        withdrawable_amount(time::ledger_timestamp(&env), &stream)
     }
 
     /// Returns the stream balance (vested amount) at a given ledger timestamp.
@@ -362,7 +357,7 @@ impl Contract {
             return Err(Error::InvalidState);
         }
 
-        let now = env.ledger().timestamp();
+        let now = time::ledger_timestamp(&env);
         let available = withdrawable_amount(now, &stream)?;
         if amount > available {
             return Err(Error::OverWithdraw);
@@ -405,7 +400,7 @@ impl Contract {
             return Err(Error::InvalidState);
         }
 
-        let now = env.ledger().timestamp();
+        let now = time::ledger_timestamp(&env);
         
         stream.last_update = now;
         stream.status = StreamStatus::Paused;
@@ -429,22 +424,15 @@ impl Contract {
             return Err(Error::InvalidState);
         }
 
-        let now = env.ledger().timestamp();
-        let paused_duration = now
-            .checked_sub(stream.pause_time)
-            .ok_or(Error::InvalidTimeRange)?;
+        let now = time::ledger_timestamp(&env);
+        let paused_duration = time::checked_pause_duration(now, stream.pause_time)?;
 
         // Track total paused duration for accrual calculations
-        stream.total_paused_duration = stream
-            .total_paused_duration
-            .checked_add(paused_duration)
-            .ok_or(Error::InvalidTimeRange)?;
+        stream.total_paused_duration =
+            time::checked_add_timestamp(stream.total_paused_duration, paused_duration)?;
 
         // Extend end_time by the paused duration to preserve unstreamed time
-        stream.end_time = stream
-            .end_time
-            .checked_add(paused_duration)
-            .ok_or(Error::InvalidTimeRange)?;
+        stream.end_time = time::checked_add_timestamp(stream.end_time, paused_duration)?;
         
         stream.last_update = now;
         stream.status = StreamStatus::Active;
@@ -480,7 +468,7 @@ impl Contract {
             return Err(Error::InvalidState);
         }
 
-        let now = env.ledger().timestamp();
+        let now = time::ledger_timestamp(&env);
         if now < stream.end_time {
             return Err(Error::InvalidState);
         }
@@ -533,7 +521,7 @@ fn withdrawable_amount(now: u64, stream: &Stream) -> Result<i128, Error> {
 }
 
 fn stream_balance_amount(env: &Env, stream: &Stream) -> Result<i128, Error> {
-    release::vested_amount(stream, env.ledger().timestamp())
+    release::vested_amount(stream, time::ledger_timestamp(env))
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {

--- a/contracts/contracts/streampay-stream/src/time.rs
+++ b/contracts/contracts/streampay-stream/src/time.rs
@@ -1,0 +1,78 @@
+//! Time helpers for stream lifecycle calculations.
+//!
+//! Contract entrypoints work with ledger timestamps, while stream schedules
+//! also need checked duration and carry-forward arithmetic. Keeping those
+//! conversions here makes overflow and invalid-range handling consistent
+//! across create, start, pause, resume, settle, and balance queries.
+
+use soroban_sdk::Env;
+
+use crate::Error;
+
+/// Returns the current ledger timestamp.
+pub fn ledger_timestamp(env: &Env) -> u64 {
+    env.ledger().timestamp()
+}
+
+/// Returns `end - start` when the range is strictly increasing.
+pub fn checked_duration(start: u64, end: u64) -> Result<u64, Error> {
+    if end <= start {
+        return Err(Error::InvalidTimeRange);
+    }
+
+    Ok(end - start)
+}
+
+/// Adds a duration to a timestamp, mapping overflow to the contract error.
+pub fn checked_add_timestamp(timestamp: u64, duration: u64) -> Result<u64, Error> {
+    timestamp
+        .checked_add(duration)
+        .ok_or(Error::InvalidTimeRange)
+}
+
+/// Computes the elapsed pause duration from `pause_time` to `now`.
+pub fn checked_pause_duration(now: u64, pause_time: u64) -> Result<u64, Error> {
+    now.checked_sub(pause_time).ok_or(Error::InvalidTimeRange)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn checked_duration_rejects_empty_or_reversed_ranges() {
+        assert_eq!(checked_duration(10, 10), Err(Error::InvalidTimeRange));
+        assert_eq!(checked_duration(11, 10), Err(Error::InvalidTimeRange));
+    }
+
+    #[test]
+    fn checked_duration_returns_strict_range_width() {
+        assert_eq!(checked_duration(10, 15), Ok(5));
+    }
+
+    #[test]
+    fn checked_add_timestamp_rejects_overflow() {
+        assert_eq!(
+            checked_add_timestamp(u64::MAX, 1),
+            Err(Error::InvalidTimeRange)
+        );
+    }
+
+    #[test]
+    fn checked_add_timestamp_returns_sum() {
+        assert_eq!(checked_add_timestamp(100, 25), Ok(125));
+    }
+
+    #[test]
+    fn checked_pause_duration_rejects_clock_regression() {
+        assert_eq!(
+            checked_pause_duration(99, 100),
+            Err(Error::InvalidTimeRange)
+        );
+    }
+
+    #[test]
+    fn checked_pause_duration_returns_elapsed_time() {
+        assert_eq!(checked_pause_duration(125, 100), Ok(25));
+    }
+}


### PR DESCRIPTION
﻿## Summary
- adds a focused `time` helper module for ledger timestamps, checked durations, timestamp addition, and pause-duration math
- routes stream lifecycle entrypoints through the shared helpers so invalid ranges and overflows map consistently to `Error::InvalidTimeRange`
- adds unit coverage for the helper edge cases

Closes #621

## Validation
- `rustfmt --check src/time.rs`
- `git diff --check`
- `cargo test` (blocked in this Windows GNU toolchain because `dlltool.exe`/linker artifacts are unavailable while compiling transitive Rust dependencies)
