### PR TITLE
feat: add stream etag revalidation

### DIFF
--- a/app/api/streams/[id]/route.test.ts
+++ b/app/api/streams/[id]/route.test.ts
@@ -77,6 +77,62 @@ describe("Stream Details Route - GET /api/streams/:id and mutations", () => {
     }
   });
 
+  it("adds ETag and cache-control headers to GET responses", async () => {
+    const req = new Request(`http://localhost/api/streams/${streamId}`, {
+      method: "GET",
+      headers: { "x-tenant-id": tenantId },
+    });
+
+    const res = await GET(req, { params: Promise.resolve({ id: streamId }) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe(`W/"2026-04-28T10:30:00Z"`);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+  });
+
+  it("returns 304 Not Modified when If-None-Match matches the stream ETag", async () => {
+    const req = new Request(`http://localhost/api/streams/${streamId}`, {
+      method: "GET",
+      headers: {
+        "x-tenant-id": tenantId,
+        "If-None-Match": `W/"2026-04-28T10:30:00Z"`,
+      },
+    });
+
+    const res = await GET(req, { params: Promise.resolve({ id: streamId }) });
+
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe(`W/"2026-04-28T10:30:00Z"`);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    await expect(res.text()).resolves.toBe("");
+  });
+
+  it("returns 304 when If-None-Match is wildcard or contains the stream ETag in a list", async () => {
+    const wildcardReq = new Request(`http://localhost/api/streams/${streamId}`, {
+      method: "GET",
+      headers: {
+        "x-tenant-id": tenantId,
+        "If-None-Match": "*",
+      },
+    });
+
+    const wildcardRes = await GET(wildcardReq, { params: Promise.resolve({ id: streamId }) });
+    expect(wildcardRes.status).toBe(304);
+
+    const listReq = new Request(`http://localhost/api/streams/${streamId}`, {
+      method: "GET",
+      headers: {
+        "x-tenant-id": tenantId,
+        "If-None-Match": `W/"other", W/"2026-04-28T10:30:00Z"`,
+      },
+    });
+
+    const listRes = await GET(listReq, { params: Promise.resolve({ id: streamId }) });
+    expect(listRes.status).toBe(304);
+  });
+
   it("enforces cross-tenant isolation on DB reads", async () => {
     const req = new Request(`http://localhost/api/streams/${streamId}`, {
       method: "GET",

--- a/app/api/streams/[id]/route.ts
+++ b/app/api/streams/[id]/route.ts
@@ -8,6 +8,8 @@ import { streamCache } from "@/app/lib/cache";
 
 type Context = { params: Promise<{ id: string }> };
 
+const REVALIDATION_CACHE_CONTROL = "public, max-age=0, must-revalidate";
+
 function createErrorResponse(code: string, message: string, status: number) {
   const context = getCorrelationContext();
   return NextResponse.json({ error: { code, message, request_id: context?.request_id } }, { status });
@@ -15,6 +17,40 @@ function createErrorResponse(code: string, message: string, status: number) {
 
 function errorResponse(code: string, message: string, status: number) {
   return createErrorResponse(code, message, status);
+}
+
+function getStreamEtag(stream: { id?: string; updatedAt?: string }) {
+  const version = stream.updatedAt ?? stream.id ?? "unknown";
+  return `W/"${version}"`;
+}
+
+function ifNoneMatchMatches(headerValue: string | null, etag: string) {
+  if (!headerValue) {
+    return false;
+  }
+
+  return headerValue
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .some((candidate) => candidate === "*" || candidate === etag);
+}
+
+function streamResponse(request: Request, stream: any, id: string, cacheStatus: "HIT" | "MISS") {
+  const etag = getStreamEtag(stream);
+  const headers = {
+    "Cache-Control": REVALIDATION_CACHE_CONTROL,
+    ETag: etag,
+    "X-Cache": cacheStatus,
+  };
+
+  if (ifNoneMatchMatches(request.headers.get("if-none-match"), etag)) {
+    return new NextResponse(null, { status: 304, headers });
+  }
+
+  return NextResponse.json(
+    { data: stream, links: { self: `/api/v1/streams/${id}` } },
+    { headers }
+  );
 }
 
 function getRequestUrl(request: Request, fallbackPath: string): URL {
@@ -59,10 +95,7 @@ export async function GET(
   // Check cache first
   const cachedStream = streamCache.get(tenant, id);
   if (cachedStream) {
-    return NextResponse.json(
-      { data: cachedStream, links: { self: `/api/v1/streams/${id}` } },
-      { headers: { "X-Cache": "HIT" } }
-    );
+    return streamResponse(request, cachedStream, id, "HIT");
   }
 
   // Fetch from DB using findOne
@@ -74,10 +107,7 @@ export async function GET(
   // Set cache on read miss
   streamCache.set(tenant, id, stream);
 
-  return NextResponse.json(
-    { data: stream, links: { self: `/api/v1/streams/${id}` } },
-    { headers: { "X-Cache": "MISS" } }
-  );
+  return streamResponse(request, stream, id, "MISS");
 }
 
 export async function POST(


### PR DESCRIPTION
﻿## Summary
- adds weak ETag generation for `GET /api/streams/:id` using the stream `updatedAt` version
- returns `304 Not Modified` for matching `If-None-Match` values, including wildcard and comma-separated ETag lists
- preserves the existing `X-Cache` HIT/MISS header and adds `Cache-Control: public, max-age=0, must-revalidate`
- adds focused route tests for 200 ETag headers and 304 short-circuit behaviour

Closes #574

## Validation
- `git diff --check`
- `./node_modules/.bin/jest.cmd --runTestsByPath app/api/streams/[id]/route.test.ts --runInBand` (blocked by a pre-existing syntax error in `app/lib/db.ts`: `export const mockDb = {` is immediately followed by `export const legacyDb = {`)
