### PR TITLE
feat: add receipt builder with custom note

### DIFF
--- a/app/components/Card.test.tsx
+++ b/app/components/Card.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen, fireEvent } = require("@testing-library/react") as any;
 import "@testing-library/jest-dom";

--- a/app/components/EmptyState.test.tsx
+++ b/app/components/EmptyState.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { EmptyState } from "./EmptyState";

--- a/app/components/ErrorRecovery.test.tsx
+++ b/app/components/ErrorRecovery.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { ErrorRecovery } from "./ErrorRecovery";

--- a/app/components/Modal.test.tsx
+++ b/app/components/Modal.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { fireEvent, screen, waitFor } = require("@testing-library/react") as any;
 import { useState } from "react";

--- a/app/components/ReceiptBuilder.test.tsx
+++ b/app/components/ReceiptBuilder.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ReceiptBuilder } from "./ReceiptBuilder";
+import type { Stream } from "../types/openapi";
+
+const MOCK_STREAM: Stream = {
+  id: "stream-ada",
+  recipient: "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G",
+  rate: "120 XLM / month",
+  schedule: "Pays every 30 days",
+  status: "active",
+  label: "Ada Creative Studio",
+  email: "ada@example.com",
+  createdAt: "2024-11-01T09:00:00.000Z",
+  updatedAt: "2024-11-20T14:30:00.000Z",
+  settlementTxHash:
+    "c3f8a12e4b76d09e1a23f456bc78d90e1f234a5678b9c0d1e2f3a4b5c6d7e8f9",
+  token: "XLM",
+};
+
+describe("ReceiptBuilder", () => {
+  it("renders the receipt document with stream info", () => {
+    render(<ReceiptBuilder stream={MOCK_STREAM} />);
+
+    expect(
+      screen.getByRole("article", { name: /payment stream receipt/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ada Creative Studio")).toBeInTheDocument();
+    expect(screen.getByText("120 XLM / month")).toBeInTheDocument();
+  });
+
+  it("renders the note textarea with placeholder", () => {
+    render(<ReceiptBuilder stream={MOCK_STREAM} />);
+
+    const textarea = screen.getByRole("textbox", { name: /custom note/i });
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveAttribute(
+      "placeholder",
+      expect.stringContaining("optional"),
+    );
+  });
+
+  it("updates note on user input and displays it in the receipt", () => {
+    render(<ReceiptBuilder stream={MOCK_STREAM} />);
+
+    const textarea = screen.getByRole("textbox", { name: /custom note/i });
+    fireEvent.change(textarea, { target: { value: "Test note for receipt" } });
+
+    expect(textarea).toHaveValue("Test note for receipt");
+    expect(screen.getAllByText("Test note for receipt")).toHaveLength(2);
+    expect(screen.getByText("Receipt Note")).toBeInTheDocument();
+  });
+
+  it("renders print and share buttons", () => {
+    render(<ReceiptBuilder stream={MOCK_STREAM} />);
+
+    expect(
+      screen.getAllByRole("button", { name: /print \/ save as pdf/i })[0],
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^share$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not display note section when note is empty", () => {
+    render(<ReceiptBuilder stream={MOCK_STREAM} />);
+
+    expect(screen.queryByText("Receipt Note")).not.toBeInTheDocument();
+  });
+
+  it("respects network prop", () => {
+    render(<ReceiptBuilder network="mainnet" stream={MOCK_STREAM} />);
+
+    expect(screen.getAllByText("Stellar Mainnet").length).toBeGreaterThan(0);
+  });
+
+  it("renders without optional fields", () => {
+    const minimalStream: Stream = {
+      id: "stream-minimal",
+      recipient: "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G",
+      rate: "10 XLM / month",
+      schedule: "Monthly",
+      status: "draft",
+      createdAt: "2024-12-01T00:00:00.000Z",
+      updatedAt: "2024-12-01T00:00:00.000Z",
+      token: "XLM",
+    };
+
+    render(<ReceiptBuilder stream={minimalStream} />);
+
+    expect(
+      screen.getByRole("article", { name: /payment stream receipt/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/ReceiptBuilder.tsx
+++ b/app/components/ReceiptBuilder.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { Stream } from "../types/openapi";
+import { StreamReceipt } from "./StreamReceipt";
+import { receiptCopy } from "../content/copy";
+
+type ReceiptBuilderProps = {
+  stream: Stream;
+  network?: "testnet" | "mainnet";
+  generatedAt?: string;
+};
+
+export function ReceiptBuilder({
+  stream,
+  network = "testnet",
+  generatedAt,
+}: ReceiptBuilderProps) {
+  const [note, setNote] = useState("");
+  const [shareCopied, setShareCopied] = useState(false);
+
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    const url = window.location.href;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `Stream Receipt — ${stream.label || stream.id}`,
+          text: `Payment stream receipt for ${stream.label || stream.id}`,
+          url,
+        });
+      } catch {
+        // user cancelled
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(url);
+        setShareCopied(true);
+        setTimeout(() => setShareCopied(false), 2000);
+      } catch {
+        // clipboard unavailable
+      }
+    }
+  }, [stream.label, stream.id]);
+
+  return (
+    <div className="receipt-shell">
+      {/* Toolbar */}
+      <div className="receipt-toolbar no-print">
+        <div className="receipt-note-builder__actions">
+          <button
+            className="button button--primary"
+            onClick={handlePrint}
+            type="button"
+          >
+            {receiptCopy.print}
+          </button>
+          <button
+            className={`receipt-share-btn${shareCopied ? " receipt-share-btn--copied" : ""}`}
+            onClick={handleShare}
+            type="button"
+          >
+            {shareCopied ? receiptCopy.shareCopied : receiptCopy.share}
+          </button>
+        </div>
+      </div>
+
+      {/* Note builder */}
+      <div className="receipt-note-builder no-print">
+        <label className="receipt-note-builder__label" htmlFor="receipt-note">
+          {receiptCopy.noteLabel}
+        </label>
+        <textarea
+          className="receipt-note-builder__textarea"
+          id="receipt-note"
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={receiptCopy.notePlaceholder}
+          value={note}
+        />
+        <p className="receipt-note-builder__helper">{receiptCopy.noteHelper}</p>
+      </div>
+
+      {/* Receipt document */}
+      <StreamReceipt
+        generatedAt={generatedAt}
+        hideToolbar
+        network={network}
+        note={note}
+        stream={stream}
+      />
+    </div>
+  );
+}

--- a/app/components/SplashScreen.test.tsx
+++ b/app/components/SplashScreen.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render, act } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import "@testing-library/jest-dom";

--- a/app/components/StatusBadge.test.tsx
+++ b/app/components/StatusBadge.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { StatusBadge } from "./StatusBadge";

--- a/app/components/StreamReceipt.tsx
+++ b/app/components/StreamReceipt.tsx
@@ -7,6 +7,8 @@ type StreamReceiptProps = {
   stream: Stream;
   network?: "testnet" | "mainnet";
   generatedAt?: string;
+  note?: string;
+  hideToolbar?: boolean;
 };
 
 function truncateAddress(address: string, chars = 6): string {
@@ -75,6 +77,8 @@ export function StreamReceipt({
   stream,
   network = "testnet",
   generatedAt,
+  note,
+  hideToolbar = false,
 }: StreamReceiptProps) {
   const generated = generatedAt ?? new Date().toISOString();
   const networkLabel = network === "mainnet" ? "Stellar Mainnet" : "Stellar Testnet";
@@ -85,11 +89,13 @@ export function StreamReceipt({
   return (
     <div className="receipt-shell">
       {/* On-screen print trigger */}
-      <div className="receipt-toolbar no-print">
-        <button className="button button--primary" onClick={handlePrint} type="button">
-          Print / Save as PDF
-        </button>
-      </div>
+      {!hideToolbar && (
+        <div className="receipt-toolbar no-print">
+          <button className="button button--primary" onClick={handlePrint} type="button">
+            Print / Save as PDF
+          </button>
+        </div>
+      )}
 
       {/* ── Receipt document ── */}
       <article aria-label="Payment stream receipt" className="receipt-doc">
@@ -259,6 +265,16 @@ export function StreamReceipt({
             )}
           </dl>
         </section>
+
+        {note && (
+          <>
+            <div className="receipt-divider" />
+            <section className="receipt-section">
+              <h2 className="receipt-h2">Receipt Note</h2>
+              <p className="receipt-note-text">{note}</p>
+            </section>
+          </>
+        )}
 
         <div className="receipt-divider receipt-divider--thick" />
 

--- a/app/content/copy.ts
+++ b/app/content/copy.ts
@@ -61,6 +61,16 @@ export const onboardingCopy = {
  * DO NOT use these in production until a feature-flag issue is created
  * and analytics instrumentation is in place.
  */
+export const receiptCopy = {
+  noteLabel: "Custom Note",
+  notePlaceholder: "Add a note to this receipt (optional)",
+  noteHelper: "Your note will appear on the printed receipt.",
+  print: "Print / Save as PDF",
+  share: "Share",
+  shareCopied: "Link copied to clipboard",
+  noteSectionTitle: "Receipt Note",
+} as const;
+
 export const heroCtaVariants = {
   a: { label: "Connect Stellar wallet", hypothesis: "Naming the network signals trust and specificity for Stellar-native users" },
   b: { label: "Link wallet", hypothesis: "Shorter verb lowers perceived friction for users unfamiliar with Stellar terminology" },

--- a/app/globals.css
+++ b/app/globals.css
@@ -873,6 +873,91 @@ a:hover {
   font-style: italic;
 }
 
+/* Note text */
+.receipt-note-text {
+  background: #f9fafb;
+  border-left: 3px solid #3b82f6;
+  border-radius: 0.25rem;
+  color: #1f2937;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  padding: 0.75rem 1rem;
+  white-space: pre-wrap;
+}
+
+/* Note builder UI */
+.receipt-note-builder {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.receipt-note-builder__label {
+  color: #6b7280;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.receipt-note-builder__textarea {
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  color: #111827;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  min-height: 5rem;
+  padding: 0.75rem;
+  resize: vertical;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.receipt-note-builder__textarea:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+  outline: none;
+}
+
+.receipt-note-builder__textarea::placeholder {
+  color: #9ca3af;
+}
+
+.receipt-note-builder__helper {
+  color: #9ca3af;
+  font-size: 0.75rem;
+}
+
+.receipt-note-builder__actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.receipt-share-btn {
+  align-items: center;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  color: #374151;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.receipt-share-btn:hover {
+  border-color: #6b7280;
+  color: #111827;
+}
+
+.receipt-share-btn--copied {
+  border-color: #22c55e;
+  color: #15803d;
+}
+
 /* Footer */
 .receipt-footer {
   display: grid;
@@ -993,6 +1078,13 @@ a:hover {
   .receipt-footer__timestamp,
   .receipt-support-id {
     color: #444444 !important;
+  }
+
+  .receipt-note-text {
+    background: transparent !important;
+    border-left-color: #666666 !important;
+    color: #000000 !important;
+    padding-left: 0.75rem !important;
   }
 
   /* Keep everything on one page; allow section breaks only at dividers */

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import Home from "./page";

--- a/app/streams/[id]/receipt/page.test.tsx
+++ b/app/streams/[id]/receipt/page.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import StreamReceiptPage from "./page";
+import { notFound } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+describe("StreamReceiptPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the receipt builder for a known stream", async () => {
+    const params = Promise.resolve({ id: "stream-ada" });
+    const jsx = await StreamReceiptPage({ params });
+    render(jsx);
+
+    expect(
+      screen.getByRole("article", { name: /payment stream receipt/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("stream-ada")).toBeInTheDocument();
+    expect(screen.getByText("Ada Creative Studio")).toBeInTheDocument();
+  });
+
+  it("renders the note textarea", async () => {
+    const params = Promise.resolve({ id: "stream-ada" });
+    const jsx = await StreamReceiptPage({ params });
+    render(jsx);
+
+    expect(
+      screen.getByRole("textbox", { name: /custom note/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders print and share buttons", async () => {
+    const params = Promise.resolve({ id: "stream-kemi" });
+    const jsx = await StreamReceiptPage({ params });
+    render(jsx);
+
+    expect(
+      screen.getByRole("button", { name: /print \/ save as pdf/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^share$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls notFound for unknown stream id", async () => {
+    const params = Promise.resolve({ id: "non-existent" });
+    await StreamReceiptPage({ params });
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/streams/[id]/receipt/page.tsx
+++ b/app/streams/[id]/receipt/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { StreamReceipt } from "../../../components/StreamReceipt";
+import { ReceiptBuilder } from "../../../components/ReceiptBuilder";
 import type { Stream } from "../../../types/openapi";
 
 // Placeholder streams that match the mock data used across the app.
@@ -65,7 +65,7 @@ export default async function StreamReceiptPage({ params }: Props) {
     process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
 
   return (
-    <StreamReceipt
+    <ReceiptBuilder
       generatedAt={new Date().toISOString()}
       network={network}
       stream={stream}

--- a/app/streams/page.test.tsx
+++ b/app/streams/page.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { StreamsPageContent } from "./StreamsPageContent";

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const config = {
   // Component tests will run in a separate command with jsdom
   testEnvironment: "node",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  testMatch: ["**/*.test.ts", "**/*.spec.ts"],
+  testMatch: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
   collectCoverageFrom: [
     "app/**/*.{ts,tsx}",
     "lib/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary

Adds a `ReceiptBuilder` component that wraps `StreamReceipt` with an interactive note field, share button, and print action. Users can attach a custom note to the stream receipt that appears in the printed/PDF output.

## Changes

### New Components
- **`app/components/ReceiptBuilder.tsx`** — Interactive wrapper with:
  - Custom note textarea (`.no-print` class hides it from print output)
  - Print button triggering `window.print()`
  - Share button using Web Share API (falls back to clipboard copy)
  - Note passed to `StreamReceipt` and rendered inside the receipt document

### Modified Components
- **`app/components/StreamReceipt.tsx`** — Added optional `note` and `hideToolbar` props:
  - `note`: renders a "Receipt Note" section with blue left-border accent
  - `hideToolbar`: suppresses the internal toolbar (used by `ReceiptBuilder` to avoid duplicate print buttons)
- **`app/streams/[id]/receipt/page.tsx`** — Switched from `StreamReceipt` to `ReceiptBuilder`

### Styling (`app/globals.css`)
- `.receipt-note-text` — styled block with blue left border, `pre-wrap` whitespace, print-safe fallback
- `.receipt-note-builder*` — textarea, label, helper, and action bar styles
- `.receipt-share-btn` — share button with hover and "copied" success state
- Print media query rules for the note text

### Content (`app/content/copy.ts`)
- Added `receiptCopy` object with label, placeholder, helper text, print, share, and copied-state strings

### Configuration
- **`jest.config.js`** — Fixed `testMatch` to include `*.test.tsx` and `*.spec.tsx` (pre-existing `.tsx` test files were not being discovered)
- Added `@jest-environment jsdom` docblocks to all `.tsx` test files

## Testing

### New Tests
- **`app/components/ReceiptBuilder.test.tsx`** — 7 tests:
  - Renders receipt document with stream info
  - Renders note textarea with placeholder
  - Updates note on user input and displays it in receipt
  - Renders print and share buttons
  - Hides note section when note is empty
  - Respects network prop
  - Renders without optional stream fields

- **`app/streams/[id]/receipt/page.test.tsx`** — 4 tests:
  - Renders receipt builder for known stream
  - Renders note textarea
  - Renders print and share buttons
  - Calls notFound for unknown stream id

## Accessibility
- Note textarea has `<label htmlFor>` association
- Receipt article has `aria-label`
- Buttons have descriptive text
- Print output hides interactive elements via `.no-print` / `.print-only` classes

## Closes
Closes #537