### PR TITLE
Add partner streaming SDK

### DIFF
--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -1,0 +1,72 @@
+# StreamPay Partner SDK
+
+`lib/sdk` exports a small TypeScript client for partners that need REST helpers
+and live stream updates without importing Next.js route internals.
+
+## Create a Client
+
+```ts
+import { createStreamPayClient } from "../lib/sdk";
+
+const client = createStreamPayClient({
+  baseUrl: "https://app.streampay.io",
+  token: process.env.STREAMPAY_PARTNER_TOKEN,
+});
+```
+
+Every REST request sends:
+
+- `Authorization: Bearer <token>` when a token is configured
+- `Accept: application/json`
+- `x-request-id` for log correlation
+- `Idempotency-Key` when passed to mutating helpers
+
+API error envelopes are raised as `StreamPaySdkError` with `code`, `status`,
+`requestId`, and optional `details`.
+
+## REST Helpers
+
+```ts
+const streams = await client.listStreams({ status: "active", limit: 20 });
+const stream = await client.getStream("stream-ada");
+
+const created = await client.createStream(
+  { recipient: "G...", rate: "10", schedule: "month", token: "XLM" },
+  { idempotencyKey: "partner-stream-ada-2026-06" },
+);
+
+await client.deleteStream("stream-ended");
+const activity = await client.listActivity({ streamId: "stream-ada" });
+```
+
+## SSE Updates
+
+`subscribeToStream` wraps the existing live-events protocol at
+`/api/streams/events?streamId=...`.
+
+```ts
+const subscription = client.subscribeToStream("stream-ada", {
+  onUpdate: (stream) => {
+    console.log("updated", stream.status);
+  },
+  onSettlement: (stream) => {
+    console.log("settled", stream.settlement);
+  },
+  onError: (event) => {
+    console.error("stream event error", event);
+  },
+});
+
+// Later:
+subscription.close();
+```
+
+Native browser `EventSource` does not support custom headers, so the SDK follows
+the current live-events protocol and appends `token` to the SSE URL when a token
+is configured. Server-side runtimes can pass `eventSourceFactory` to use a
+custom EventSource implementation.
+
+## Testing
+
+Use injected `fetchFn`, `requestIdFactory`, and `eventSourceFactory` to make
+partner integrations deterministic without network calls.

--- a/lib/sdk/index.test.ts
+++ b/lib/sdk/index.test.ts
@@ -1,0 +1,129 @@
+import { StreamPayClient, StreamPaySdkError, type EventSourceLike } from "./index";
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...headers },
+    status,
+    statusText: status >= 400 ? "Error" : "OK",
+  });
+}
+
+class FakeEventSource implements EventSourceLike {
+  listeners = new Map<string, (event: MessageEvent<string>) => void>();
+  onerror: ((event: Event) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  closed = false;
+
+  close(): void {
+    this.closed = true;
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(type, listener);
+  }
+
+  emit(type: string, data: unknown): void {
+    const listener = this.listeners.get(type);
+    listener?.({ data: JSON.stringify(data) } as MessageEvent<string>);
+  }
+}
+
+describe("StreamPayClient", () => {
+  it("sends typed REST requests with auth and correlation headers", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: "stream-1", recipient: "Ada", rate: "10 XLM/month", status: "active" }],
+        meta: { total: 1 },
+      }),
+    );
+    const client = new StreamPayClient({
+      baseUrl: "https://api.streampay.test",
+      fetchFn,
+      requestIdFactory: () => "req-test",
+      token: "partner-token",
+    });
+
+    const result = await client.listStreams({ limit: 10, status: "active" });
+
+    expect(result.data[0].id).toBe("stream-1");
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://api.streampay.test/api/v2/streams?limit=10&status=active",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.any(Headers),
+      }),
+    );
+    const headers = fetchFn.mock.calls[0][1].headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer partner-token");
+    expect(headers.get("x-request-id")).toBe("req-test");
+  });
+
+  it("adds idempotency keys and JSON bodies for stream creation", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      jsonResponse({
+        data: { id: "stream-2", recipient: "Kemi", rate: "5 XLM/week", status: "draft" },
+      }),
+    );
+    const client = new StreamPayClient({ baseUrl: "https://api.streampay.test", fetchFn });
+
+    await client.createStream(
+      { recipient: "Kemi", rate: "5", schedule: "week" },
+      { idempotencyKey: "create-kemi" },
+    );
+
+    const init = fetchFn.mock.calls[0][1];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ recipient: "Kemi", rate: "5", schedule: "week" }));
+    expect((init.headers as Headers).get("Idempotency-Key")).toBe("create-kemi");
+  });
+
+  it("normalizes API error envelopes", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            code: "STREAM_NOT_FOUND",
+            message: "Stream not found",
+            request_id: "req-api",
+          },
+        },
+        404,
+      ),
+    );
+    const client = new StreamPayClient({ baseUrl: "https://api.streampay.test", fetchFn });
+
+    await expect(client.getStream("missing")).rejects.toMatchObject<Partial<StreamPaySdkError>>({
+      code: "STREAM_NOT_FOUND",
+      message: "Stream not found",
+      requestId: "req-api",
+      status: 404,
+    });
+  });
+
+  it("wraps SSE stream update and settlement events", () => {
+    const source = new FakeEventSource();
+    const factory = jest.fn(() => source);
+    const onUpdate = jest.fn();
+    const onSettlement = jest.fn();
+    const client = new StreamPayClient({
+      baseUrl: "https://api.streampay.test/",
+      eventSourceFactory: factory,
+      token: "partner-token",
+    });
+
+    const subscription = client.subscribeToStream("stream-ada", { onSettlement, onUpdate });
+
+    expect(subscription.url).toBe(
+      "https://api.streampay.test/api/streams/events?streamId=stream-ada&token=partner-token",
+    );
+    source.emit("stream:updated", { id: "stream-ada", status: "active" });
+    source.emit("settle:finished", { id: "stream-ada", status: "ended" });
+
+    expect(onUpdate).toHaveBeenCalledWith({ id: "stream-ada", status: "active" });
+    expect(onSettlement).toHaveBeenCalledWith({ id: "stream-ada", status: "ended" });
+
+    subscription.close();
+    expect(source.closed).toBe(true);
+  });
+});

--- a/lib/sdk/index.ts
+++ b/lib/sdk/index.ts
@@ -1,0 +1,318 @@
+export type StreamStatus = "draft" | "active" | "paused" | "ended";
+
+export interface StreamPayStream {
+  id: string;
+  recipient: string;
+  rate: string;
+  status: StreamStatus;
+  allowed_actions?: string[];
+  created_at?: string;
+  updated_at?: string;
+  settlement?: Record<string, unknown> | null;
+  [key: string]: unknown;
+}
+
+export interface StreamPayActivityEvent {
+  id: string;
+  type: string;
+  timestamp: string;
+  description?: string;
+  streamId?: string;
+  [key: string]: unknown;
+}
+
+export interface CreateStreamInput {
+  recipient: string;
+  rate: string;
+  schedule: string;
+  token?: string;
+}
+
+export interface PageQuery {
+  [key: string]: string | number | boolean | null | undefined;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface StreamListQuery extends PageQuery {
+  status?: StreamStatus;
+}
+
+export interface ActivityListQuery extends PageQuery {
+  streamId?: string;
+  type?: string;
+}
+
+export interface StreamPayPage<T> {
+  data: T[];
+  links?: Record<string, string>;
+  meta?: Record<string, unknown>;
+}
+
+export interface StreamPayItem<T> {
+  data: T;
+  links?: Record<string, string>;
+  meta?: Record<string, unknown>;
+}
+
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type EventSourceLike = {
+  close(): void;
+  addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void;
+  onerror: ((event: Event) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+};
+
+export type EventSourceFactory = (url: string) => EventSourceLike;
+
+export interface StreamPayClientOptions {
+  baseUrl: string;
+  token?: string;
+  fetchFn?: FetchLike;
+  eventSourceFactory?: EventSourceFactory;
+  requestIdFactory?: () => string;
+  streamEventsPath?: string;
+}
+
+export interface RequestOptions {
+  headers?: HeadersInit;
+  idempotencyKey?: string;
+  query?: Record<string, string | number | boolean | null | undefined>;
+}
+
+export interface StreamEventHandlers {
+  onUpdate?: (stream: StreamPayStream) => void;
+  onSettlement?: (stream: StreamPayStream) => void;
+  onMessage?: (event: MessageEvent<string>) => void;
+  onOpen?: (event: Event) => void;
+  onError?: (event: Event) => void;
+}
+
+export interface StreamSubscription {
+  url: string;
+  close(): void;
+}
+
+interface ErrorEnvelope {
+  error?: {
+    code?: string;
+    details?: unknown;
+    message?: string;
+    request_id?: string;
+  };
+}
+
+export class StreamPaySdkError extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+  readonly requestId?: string;
+  readonly status: number;
+
+  constructor(message: string, options: { code: string; details?: unknown; requestId?: string; status: number }) {
+    super(message);
+    this.name = "StreamPaySdkError";
+    this.code = options.code;
+    this.details = options.details;
+    this.requestId = options.requestId;
+    this.status = options.status;
+  }
+}
+
+function defaultRequestId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `req-${crypto.randomUUID()}`;
+  }
+  return `req-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
+}
+
+function buildUrl(baseUrl: string, path: string, query?: RequestOptions["query"]): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const url = new URL(trimSlashes(path), base);
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null && value !== "") {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  return url.toString();
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return response.text();
+  }
+  return response.json();
+}
+
+function isErrorEnvelope(value: unknown): value is ErrorEnvelope {
+  return Boolean(value && typeof value === "object" && "error" in value);
+}
+
+export class StreamPayClient {
+  private readonly baseUrl: string;
+  private readonly eventSourceFactory?: EventSourceFactory;
+  private readonly fetchFn: FetchLike;
+  private readonly requestIdFactory: () => string;
+  private readonly streamEventsPath: string;
+  private readonly token?: string;
+
+  constructor(options: StreamPayClientOptions) {
+    if (!options.baseUrl.trim()) {
+      throw new Error("StreamPayClient requires a non-empty baseUrl");
+    }
+
+    this.baseUrl = options.baseUrl;
+    this.eventSourceFactory = options.eventSourceFactory;
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis);
+    this.requestIdFactory = options.requestIdFactory ?? defaultRequestId;
+    this.streamEventsPath = options.streamEventsPath ?? "/api/streams/events";
+    this.token = options.token;
+  }
+
+  async listStreams(query: StreamListQuery = {}): Promise<StreamPayPage<StreamPayStream>> {
+    return this.request("GET", "/api/v2/streams", { query });
+  }
+
+  async getStream(id: string): Promise<StreamPayItem<StreamPayStream>> {
+    this.assertId(id, "stream id");
+    return this.request("GET", `/api/v2/streams/${encodeURIComponent(id)}`);
+  }
+
+  async createStream(input: CreateStreamInput, options: RequestOptions = {}): Promise<StreamPayItem<StreamPayStream>> {
+    if (!input.recipient.trim() || !input.rate.trim() || !input.schedule.trim()) {
+      throw new Error("recipient, rate, and schedule are required");
+    }
+    return this.request("POST", "/api/v2/streams", options, input);
+  }
+
+  async deleteStream(id: string): Promise<void> {
+    this.assertId(id, "stream id");
+    await this.request("DELETE", `/api/v2/streams/${encodeURIComponent(id)}`);
+  }
+
+  async listActivity(query: ActivityListQuery = {}): Promise<StreamPayPage<StreamPayActivityEvent>> {
+    return this.request("GET", "/api/activity", { query });
+  }
+
+  subscribeToStream(streamId: string, handlers: StreamEventHandlers = {}): StreamSubscription {
+    this.assertId(streamId, "stream id");
+    const factory =
+      this.eventSourceFactory ??
+      ((url: string) => {
+        if (typeof EventSource === "undefined") {
+          throw new Error("EventSource is not available; pass eventSourceFactory in this environment");
+        }
+        return new EventSource(url);
+      });
+
+    const query: Record<string, string> = { streamId };
+    if (this.token) {
+      query.token = this.token;
+    }
+
+    const url = buildUrl(this.baseUrl, this.streamEventsPath, query);
+    const source = factory(url);
+    source.onopen = handlers.onOpen ?? null;
+    source.onerror = handlers.onError ?? null;
+    source.onmessage = handlers.onMessage ?? null;
+    source.addEventListener("stream:updated", (event) => handlers.onUpdate?.(this.parseStreamEvent(event)));
+    source.addEventListener("settle:finished", (event) => handlers.onSettlement?.(this.parseStreamEvent(event)));
+
+    return {
+      url,
+      close: () => source.close(),
+    };
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    options: RequestOptions = {},
+    body?: unknown,
+  ): Promise<T> {
+    const requestId = this.requestIdFactory();
+    const headers = new Headers(options.headers);
+    headers.set("accept", "application/json");
+    headers.set("x-request-id", requestId);
+
+    if (this.token) {
+      headers.set("authorization", `Bearer ${this.token}`);
+    }
+
+    if (options.idempotencyKey) {
+      headers.set("Idempotency-Key", options.idempotencyKey);
+    }
+
+    let payload: string | undefined;
+    if (body !== undefined) {
+      headers.set("content-type", "application/json");
+      payload = JSON.stringify(body);
+    }
+
+    const response = await this.fetchFn(buildUrl(this.baseUrl, path, options.query), {
+      body: payload,
+      headers,
+      method,
+    });
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const parsed = await parseJson(response);
+    if (!response.ok) {
+      throw this.toSdkError(response, parsed, requestId);
+    }
+
+    return parsed as T;
+  }
+
+  private parseStreamEvent(event: MessageEvent<string>): StreamPayStream {
+    try {
+      return JSON.parse(event.data) as StreamPayStream;
+    } catch {
+      throw new StreamPaySdkError("SSE event payload was not valid JSON", {
+        code: "INVALID_SSE_PAYLOAD",
+        status: 0,
+      });
+    }
+  }
+
+  private toSdkError(response: Response, body: unknown, fallbackRequestId: string): StreamPaySdkError {
+    if (isErrorEnvelope(body) && body.error) {
+      return new StreamPaySdkError(body.error.message ?? response.statusText, {
+        code: body.error.code ?? "UNKNOWN_ERROR",
+        details: body.error.details,
+        requestId: body.error.request_id ?? response.headers.get("x-request-id") ?? fallbackRequestId,
+        status: response.status,
+      });
+    }
+
+    return new StreamPaySdkError(response.statusText || "StreamPay request failed", {
+      code: "HTTP_ERROR",
+      details: body,
+      requestId: response.headers.get("x-request-id") ?? fallbackRequestId,
+      status: response.status,
+    });
+  }
+
+  private assertId(value: string, label: string) {
+    if (!value || !value.trim()) {
+      throw new Error(`${label} is required`);
+    }
+  }
+}
+
+export function createStreamPayClient(options: StreamPayClientOptions): StreamPayClient {
+  return new StreamPayClient(options);
+}


### PR DESCRIPTION
## Summary
- Add a typed partner SDK under `lib/sdk` for stream CRUD, activity reads, and request metadata.
- Normalize SDK errors and expose a configurable Server-Sent Events stream helper.
- Document authentication, examples, and error handling in `docs/SDK.md`.

## Verification
- `node node_modules/jest/bin/jest.js lib/sdk/index.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit --pretty false --skipLibCheck lib/sdk/index.ts lib/sdk/index.test.ts`
- `node node_modules/eslint/bin/eslint.js lib/sdk/index.ts lib/sdk/index.test.ts`

Closes #599