### PR TITLE
feat(webhooks): add admin redeliver endpoint (#594)

### DIFF
--- a/app/api/admin/webhooks/redeliver/route.test.ts
+++ b/app/api/admin/webhooks/redeliver/route.test.ts
@@ -1,0 +1,277 @@
+/** @jest-environment node */
+import { POST } from "./route";
+import { requireInternalServiceAuth } from "@/app/lib/internal-service-auth";
+import { tryAuthenticateRequest } from "@/app/lib/auth";
+import { webhookDeliveryWorker } from "@/app/lib/webhook-delivery-worker";
+import { NextResponse } from "next/server";
+
+jest.mock("@/app/lib/internal-service-auth", () => ({
+  requireInternalServiceAuth: jest.fn(),
+}));
+
+jest.mock("@/app/lib/auth", () => ({
+  tryAuthenticateRequest: jest.fn(),
+}));
+
+jest.mock("@/app/lib/webhook-delivery-worker", () => ({
+  webhookDeliveryWorker: {
+    reissueDelivery: jest.fn(),
+  },
+}));
+
+const mockAuthFailureResponse = NextResponse.json(
+  { error: { code: "INTERNAL_AUTH_REQUIRED", message: "Auth required" } },
+  { status: 401 },
+);
+
+const mockDeliveryWorker = webhookDeliveryWorker as {
+  reissueDelivery: jest.Mock;
+};
+
+describe("POST /api/admin/webhooks/redeliver", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Auth tests ─────────────────────────────────────────────────────────────
+
+  it("returns 401 when internal-service auth fails and no admin JWT is present", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue(mockAuthFailureResponse);
+    (tryAuthenticateRequest as jest.Mock).mockReturnValue(null);
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error?.code).toBe("INTERNAL_AUTH_REQUIRED");
+  });
+
+  it("allows access when internal-service auth succeeds", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+      keyId: "current",
+      timestamp: new Date().toISOString(),
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: true,
+      newDeliveryId: "redeliver-new-uuid",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("allows access when admin JWT is present (role admin)", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue(mockAuthFailureResponse);
+    (tryAuthenticateRequest as jest.Mock).mockReturnValue({
+      walletAddress: "GB..." as string,
+      actorId: "admin-1" as string,
+      role: "admin" as const,
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: true,
+      newDeliveryId: "redeliver-new-uuid",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123" }),
+      headers: { Authorization: "Bearer some-admin-token" },
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 401 when JWT is present but role is not admin", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue(mockAuthFailureResponse);
+    (tryAuthenticateRequest as jest.Mock).mockReturnValue({
+      walletAddress: "GB..." as string,
+      actorId: "user-1" as string,
+      role: "user" as const,
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123" }),
+      headers: { Authorization: "Bearer some-user-token" },
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  // ── Body parsing / validation tests ───────────────────────────────────────
+
+  it("returns 400 for malformed JSON body", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: "not-json",
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error?.code).toBe("INVALID_REQUEST_BODY");
+  });
+
+  it("returns 400 for missing deliveryId in body", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error?.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 for empty deliveryId in body", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error?.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("accepts extra unexpected fields in body", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: true,
+      newDeliveryId: "redeliver-new-uuid",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123", extraField: "should not cause issues" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  // ── Worker interaction tests ──────────────────────────────────────────────
+
+  it("calls reissueDelivery with the deliveryId from the body", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: true,
+      newDeliveryId: "redeliver-new-uuid",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-456" }),
+    });
+    await POST(request);
+
+    expect(mockDeliveryWorker.reissueDelivery).toHaveBeenCalledTimes(1);
+    expect(mockDeliveryWorker.reissueDelivery).toHaveBeenCalledWith("del-456");
+  });
+
+  it("returns 200 with newDeliveryId on successful redelivery", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: true,
+      newDeliveryId: "redeliver-abc-123",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-789" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data?.deliveryId).toBe("redeliver-abc-123");
+    expect(body.data?.originalDeliveryId).toBe("del-789");
+  });
+
+  it("returns 404 when worker reports delivery not found", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: false,
+      error: "Delivery 'del-999' not found.",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-999" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error?.code).toBe("DELIVERY_NOT_FOUND");
+  });
+
+  it("returns 400 when worker reports delivery lacks snapshots", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue({
+      serviceName: "admin-cli",
+    });
+    mockDeliveryWorker.reissueDelivery.mockResolvedValue({
+      ok: false,
+      error: "Delivery 'del-old' does not have full event/endpoint data.",
+    });
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-old" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error?.code).toBe("DELIVERY_NO_SNAPSHOT");
+  });
+
+  it("includes request_id in the error envelope", async () => {
+    (requireInternalServiceAuth as jest.Mock).mockResolvedValue(mockAuthFailureResponse);
+    (tryAuthenticateRequest as jest.Mock).mockReturnValue(null);
+
+    const request = new Request("http://localhost/api/admin/webhooks/redeliver", {
+      method: "POST",
+      body: JSON.stringify({ deliveryId: "del-123" }),
+    });
+    const response = await POST(request);
+
+    const body = await response.json();
+    expect(body.error?.request_id).toBeDefined();
+    expect(typeof body.error.request_id).toBe("string");
+  });
+});

--- a/app/api/admin/webhooks/redeliver/route.ts
+++ b/app/api/admin/webhooks/redeliver/route.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /api/admin/webhooks/redeliver
+ *
+ * Force-redeliver a webhook event by its delivery ID.
+ *
+ * Creates a brand-new delivery with the same endpoint and event payload as the
+ * original delivery, then processes it through the standard retry lifecycle.
+ * The original delivery record is left unchanged so its audit trail is intact.
+ *
+ * ## Authorization
+ * Requires internal-service HMAC auth OR a valid admin JWT. This route is
+ * NEVER publicly reachable - it must sit behind an internal network boundary
+ * or API gateway rule in production.
+ *
+ * ## Data availability
+ * Deliveries recorded *before* the introduction of full event/endpoint
+ * snapshots lack the data needed for redelivery and return HTTP 400.
+ * Use the DLQ replay route (`POST /api/webhooks/dlq/:dlqId/replay`) for
+ * those older deliveries.
+ *
+ * ## Error codes
+ * | Code                    | HTTP | Meaning                                      |
+ * |---|---|---|
+ * | INTERNAL_AUTH_REQUIRED  | 401  | Missing / invalid internal-service signature  |
+ * | DELIVERY_NOT_FOUND      | 404  | No delivery with the given deliveryId         |
+ * | DELIVERY_NO_SNAPSHOT    | 400  | Delivery exists but lacks event/endpoint data |
+ * | INVALID_REQUEST_BODY    | 400  | Request body is malformed JSON                |
+ * | VALIDATION_ERROR        | 400  | Request body fails schema validation          |
+ */
+
+import crypto from "crypto";
+import { NextResponse } from "next/server";
+import { requireInternalServiceAuth } from "@/app/lib/internal-service-auth";
+import { tryAuthenticateRequest } from "@/app/lib/auth";
+import { webhookDeliveryWorker } from "@/app/lib/webhook-delivery-worker";
+import { logger, withCorrelationContext, getCorrelationContext } from "@/app/lib/logger";
+import { z } from "zod";
+
+const redeliverSchema = z.object({
+  deliveryId: z.string().min(1, "deliveryId is required"),
+});
+
+function errorResponse(code: string, message: string, status: number) {
+  const ctx = getCorrelationContext();
+  return NextResponse.json(
+    { error: { code, message, request_id: ctx?.request_id ?? "unknown" } },
+    { status },
+  );
+}
+
+async function authenticate(request: Request): Promise<NextResponse | null> {
+  const internalResult = await requireInternalServiceAuth(request, {
+    concealFailure: false,
+  });
+
+  if (!(internalResult instanceof NextResponse)) {
+    return null;
+  }
+
+  const jwtIdentity = tryAuthenticateRequest(request);
+  if (jwtIdentity && jwtIdentity.role === "admin") {
+    return null;
+  }
+
+  return internalResult;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const correlation_id =
+    request.headers.get("X-Correlation-ID") ?? `redeliver-${crypto.randomUUID()}`;
+  const request_id = `req-${crypto.randomUUID()}`;
+
+  return withCorrelationContext({ correlation_id, request_id }, async () => {
+    const ctx = getCorrelationContext();
+
+    logger.info("Admin redeliver request received", {
+      correlation_id: ctx?.correlation_id,
+    });
+
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    const authError = await authenticate(request);
+    if (authError) {
+      logger.warn("Admin redeliver rejected: unauthorized", {
+        correlation_id: ctx?.correlation_id,
+      });
+      return authError;
+    }
+
+    // ── Parse body ───────────────────────────────────────────────────────────
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return errorResponse(
+        "INVALID_REQUEST_BODY",
+        "Request body is not valid JSON.",
+        400,
+      );
+    }
+
+    const parsed = redeliverSchema.safeParse(body);
+    if (!parsed.success) {
+      const firstIssue = parsed.error.issues[0];
+      return errorResponse(
+        "VALIDATION_ERROR",
+        firstIssue?.message ?? "Validation failed",
+        400,
+      );
+    }
+
+    const { deliveryId } = parsed.data;
+
+    logger.info("Admin redeliver authenticated", {
+      delivery_id:     deliveryId,
+      correlation_id:  ctx?.correlation_id,
+    });
+
+    // ── Redeliver ────────────────────────────────────────────────────────────
+    const result = await webhookDeliveryWorker.reissueDelivery(deliveryId);
+
+    if (!result.ok) {
+      if (result.error?.includes("not found")) {
+        return errorResponse("DELIVERY_NOT_FOUND", result.error!, 404);
+      }
+      return errorResponse("DELIVERY_NO_SNAPSHOT", result.error!, 400);
+    }
+
+    logger.info("Admin redeliver succeeded", {
+      original_delivery_id: deliveryId,
+      new_delivery_id:      result.newDeliveryId,
+      correlation_id:       ctx?.correlation_id,
+    });
+
+    return NextResponse.json({
+      data: {
+        deliveryId: result.newDeliveryId,
+        originalDeliveryId: deliveryId,
+      },
+      links: {
+        delivery: `/api/webhooks/deliveries?delivery_id=${result.newDeliveryId}`,
+      },
+    });
+  });
+}

--- a/app/lib/webhook-delivery-store.ts
+++ b/app/lib/webhook-delivery-store.ts
@@ -22,7 +22,8 @@ export class WebhookDeliveryStore {
   createDelivery(
     deliveryId: string,
     endpoint: WebhookEndpoint,
-    event: WebhookEvent
+    event: WebhookEvent,
+    reissuedFrom?: string,
   ): WebhookDeliveryRecord {
     const now = new Date().toISOString();
     const record: WebhookDeliveryRecord = {
@@ -34,6 +35,9 @@ export class WebhookDeliveryStore {
       attempts: [],
       createdAt: now,
       updatedAt: now,
+      event,
+      endpoint,
+      ...(reissuedFrom !== undefined ? { reissuedFrom } : {}),
     };
 
     this.deliveries.set(deliveryId, record);

--- a/app/lib/webhook-delivery-worker.ts
+++ b/app/lib/webhook-delivery-worker.ts
@@ -47,6 +47,7 @@ export class WebhookDeliveryWorker {
     endpoint: WebhookEndpoint,
     event: WebhookEvent,
     deliveryId: string,
+    reissuedFrom?: string,
   ): Promise<{ success: boolean; deliveryId: string; attempts: number; dlqed?: boolean }> {
     const ctx = getCorrelationContext();
     withWebhookContext(deliveryId);
@@ -59,7 +60,7 @@ export class WebhookDeliveryWorker {
     });
 
     try {
-      webhookDeliveryStore.createDelivery(deliveryId, endpoint, event);
+      webhookDeliveryStore.createDelivery(deliveryId, endpoint, event, reissuedFrom);
 
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         const result = await this.client.attemptDelivery(
@@ -230,6 +231,82 @@ export class WebhookDeliveryWorker {
     return { totalDLQEntries: s.dlqEntries, dlqedDeliveries: s.dlq,
              dlqEntries: webhookDeliveryStore.getAllDLQEntries() };
   }
-}
 
-export const webhookDeliveryWorker = new WebhookDeliveryWorker();
+  /**
+   * Reissue a webhook delivery for a given delivery ID.
+   *
+   * Creates a brand-new delivery with the same endpoint and event payload
+   * as the original delivery, then processes it through the standard retry
+   * lifecycle. The original delivery record is left unchanged — its status
+   * and attempt history are preserved for audit purposes.
+   *
+   * **Data availability:** The original delivery must have been created
+   * after the introduction of full event/endpoint snapshots (i.e. the
+   * `event` and `endpoint` fields on `WebhookDeliveryRecord`). Deliveries
+   * created before this change will not have the necessary data and cannot
+   * be reissued. In that case the caller should use the DLQ replay route
+   * (`POST /api/webhooks/dlq/:dlqId/replay`) instead, which works from
+   * DLQ entries that always carry the full payload.
+   *
+   * **Idempotency:** Not enforced at this level — the route handler may
+   * layer its own idempotency key check (e.g. `Idempotency-Key` header).
+   * A single delivery ID may be reissued multiple times; each call creates
+   * a separate new delivery.
+   *
+   * **Auth:** The caller (route handler) is responsible for verifying
+   * admin or internal-service auth before calling this method.
+   *
+   * @param deliveryId  - The ID of the delivery to reissue.
+   * @returns Result object with the new deliveryId and success flag.
+   */
+  async reissueDelivery(deliveryId: string): Promise<{
+    ok: boolean;
+    newDeliveryId?: string;
+    error?: string;
+  }> {
+    const context = getCorrelationContext();
+
+    const record = webhookDeliveryStore.getDelivery(deliveryId);
+    if (!record) {
+      return { ok: false, error: `Delivery '${deliveryId}' not found.` };
+    }
+
+    if (!record.event || !record.endpoint) {
+      return {
+        ok: false,
+        error: `Delivery '${deliveryId}' does not have full event/endpoint data. ` +
+               "Use the DLQ replay endpoint for older deliveries.",
+      };
+    }
+
+    const newDeliveryId = `redeliver-${crypto.randomUUID()}`;
+
+    logger.info("Reissuing webhook delivery", {
+      original_delivery_id: deliveryId,
+      new_delivery_id:      newDeliveryId,
+      endpoint_id:          record.endpoint.id,
+      endpoint_url:         record.endpoint.url,
+      event_id:             record.event.id,
+      event_type:           record.event.eventType,
+      correlation_id:       context?.correlation_id,
+    });
+
+    // Fire-and-forget: processDelivery manages its own retry/DLQ lifecycle.
+    // We do not await here so the HTTP response returns immediately.
+    this.processDelivery(
+      record.endpoint,
+      record.event,
+      newDeliveryId,
+      deliveryId, // reissuedFrom
+    ).catch((err) => {
+      logger.error("Reissued delivery failed unexpectedly", {
+        original_delivery_id: deliveryId,
+        new_delivery_id:      newDeliveryId,
+        error:                err instanceof Error ? err.message : String(err),
+        correlation_id:       context?.correlation_id,
+      });
+    });
+
+    return { ok: true, newDeliveryId };
+  }
+}

--- a/app/lib/webhook-delivery.ts
+++ b/app/lib/webhook-delivery.ts
@@ -61,6 +61,28 @@ export interface WebhookDeliveryRecord {
   createdAt: string;
   updatedAt: string;
   finalizedAt?: string;
+
+  /**
+   * Full event snapshot stored at delivery creation time.
+   * Populated for deliveries created *after* the introduction of
+   * event/endpoint snapshots. Older deliveries will not have this field.
+   *
+   * Required by the admin redeliver endpoint to reissue a delivery.
+   * When absent, the caller should fall back to DLQ replay.
+   */
+  event?: WebhookEvent;
+
+  /**
+   * Full endpoint snapshot stored at delivery creation time.
+   * Same availability constraints as `event`.
+   */
+  endpoint?: WebhookEndpoint;
+
+  /**
+   * When set, this delivery was reissued from an existing delivery (redeliver).
+   * The value is the original deliveryId that triggered this reissue.
+   */
+  reissuedFrom?: string;
 }
 
 export interface DLQEntry {

--- a/docs/webhook-delivery.md
+++ b/docs/webhook-delivery.md
@@ -566,6 +566,51 @@ Response:
 }
 ```
 
+### Admin Redeliver Endpoint
+
+```
+POST /api/admin/webhooks/redeliver
+Auth: Internal-service HMAC or admin JWT
+
+Request Body:
+{
+  "deliveryId": "del-01HZ9ABCDEF"
+}
+
+Response (200):
+{
+  "data": {
+    "deliveryId": "redeliver-<uuid>",
+    "originalDeliveryId": "del-01HZ9ABCDEF"
+  },
+  "links": {
+    "delivery": "/api/webhooks/deliveries?delivery_id=redeliver-<uuid>"
+  }
+}
+
+Error (404 - delivery not found):
+{
+  "error": {
+    "code": "DELIVERY_NOT_FOUND",
+    "message": "Delivery 'del-id' not found.",
+    "request_id": "req_..."
+  }
+}
+
+Error (400 - no snapshot data):
+{
+  "error": {
+    "code": "DELIVERY_NO_SNAPSHOT",
+    "message": "Delivery 'del-id' does not have full event/endpoint data...",
+    "request_id": "req_..."
+  }
+}
+
+**Idempotency:** Not enforced per call; each request creates a new delivery.
+**Data availability:** Requires deliveries recorded with full event/endpoint snapshots.
+Use the DLQ replay endpoint for older deliveries without snapshots.
+```
+
 ---
 
 ## Related Documentation

--- a/openapi.json
+++ b/openapi.json
@@ -1427,6 +1427,74 @@
         }
       }
     },
+    "/api/admin/webhooks/redeliver": {
+      "post": {
+        "operationId": "adminRedeliverWebhook",
+        "summary": "Force-redeliver a webhook event",
+        "description": "Creates a new delivery for an existing delivery ID, reusing the original endpoint and event payload.\n\n**Auth:** Internal-service HMAC or admin JWT required.\n\n**Data availability:** The original delivery must have full event/endpoint snapshots (deliveries created after snapshot support shipped).\n\n**Idempotency:** Not enforced at the endpoint level; each call creates a new delivery.",
+        "tags": ["Webhooks", "Admin"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["deliveryId"],
+                "properties": {
+                  "deliveryId": {
+                    "type": "string",
+                    "description": "The delivery ID to reissue.",
+                    "example": "del-01HZ9ABCDEF"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Redelivery enqueued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": ["deliveryId", "originalDeliveryId"],
+                      "properties": {
+                        "deliveryId": {
+                          "type": "string",
+                          "description": "The ID of the newly created delivery."
+                        },
+                        "originalDeliveryId": {
+                          "type": "string",
+                          "description": "The original delivery ID that was reissued."
+                        }
+                      }
+                    },
+                    "links": {
+                      "type": "object",
+                      "properties": {
+                        "delivery": {
+                          "type": "string",
+                          "description": "URL to query this delivery's status."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/400" },
+          "401": { "$ref": "#/components/responses/401" },
+          "404": { "$ref": "#/components/responses/404" },
+          "500": { "$ref": "#/components/responses/500" }
+        }
+      }
+    },
     "/api/debug/kms-sign": {
       "post": {
         "operationId": "debugKmsSign",


### PR DESCRIPTION
Closes #594

---

## Summary

Implements `POST /api/admin/webhooks/redeliver` to force-redeliver a webhook event by delivery ID for issue #594.

## Changes

### New files
- `app/api/admin/webhooks/redeliver/route.ts` — POST handler with Zod validation, dual auth (HMAC + admin JWT)
- `app/api/admin/webhooks/redeliver/route.test.ts` — 12 tests covering auth, validation, worker interaction, error codes

### Modified files
- `app/lib/webhook-delivery.ts` — Extended `WebhookDeliveryRecord` with `event?`, `endpoint?`, `reissuedFrom?` fields
- `app/lib/webhook-delivery-store.ts` — `createDelivery()` now accepts `reissuedFrom` and stores full event/endpoint snapshots
- `app/lib/webhook-delivery-worker.ts` — `processDelivery()` accepts optional `reissuedFrom` param; added `reissueDelivery()` method
- `openapi.json` — Added `/api/admin/webhooks/redeliver` path spec
- `docs/webhook-delivery.md` — Added Admin Redeliver Endpoint section

## Design decisions
- Fire-and-forget for the new delivery (not awaited) so HTTP response returns immediately
- Original delivery record left unchanged for audit trail preservation
- Fallback to DLQ replay for older deliveries without snapshots
- Dual auth: internal-service HMAC first, admin JWT fallback