### PR TITLE
feat: polish empty/loading/error states across /streams /activity /receipt

### DIFF
--- a/__mocks__/next/link.js
+++ b/__mocks__/next/link.js
@@ -1,0 +1,5 @@
+const Link = ({ href, children, className, ...rest }) =>
+  require("react").createElement("a", { href, className, ...rest }, children);
+Link.displayName = "Link";
+module.exports = Link;
+module.exports.default = Link;

--- a/app/activity/page.test.tsx
+++ b/app/activity/page.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import ActivityPage from "./page";
+
+// Fake timers let us control setTimeout without actually waiting.
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("ActivityPage", () => {
+  it("shows the loading skeleton while data is fetching", () => {
+    render(<ActivityPage />);
+
+    // Skeleton is aria-hidden so we find it by the sr-only live region text.
+    expect(screen.getByText(/loading activity feed/i)).toBeInTheDocument();
+  });
+
+  it("renders the page heading and description", () => {
+    render(<ActivityPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /track every event/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/every transaction, status update/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the activity feed heading", () => {
+    render(<ActivityPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /activity feed/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("transitions to the populated state after the simulated load", async () => {
+    render(<ActivityPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByText(/new stream created for project alpha/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/wallet connected/i)).toBeInTheDocument();
+    expect(screen.getByText(/design retainer stream settled/i)).toBeInTheDocument();
+  });
+
+  it("shows timeline date groups once populated", async () => {
+    render(<ActivityPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+  });
+
+  it("uses aria-busy=true on the feed section while loading", () => {
+    render(<ActivityPage />);
+
+    const section = screen.getByRole("region", { name: /activity feed/i });
+    expect(section).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("clears aria-busy once data is loaded", async () => {
+    render(<ActivityPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    const section = screen.getByRole("region", { name: /activity feed/i });
+    expect(section).toHaveAttribute("aria-busy", "false");
+  });
+
+  it("cleans up the timeout on unmount during loading", () => {
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
+    const { unmount } = render(<ActivityPage />);
+    unmount();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { EmptyState } from "../components/EmptyState";
-import { ActivityTimeline, ActivityTimelineSkeleton, type ActivityGroup } from "../components/ActivityTimeline";
+import { PageError } from "../components/PageError";
+import {
+  ActivityTimeline,
+  ActivityTimelineSkeleton,
+  type ActivityGroup,
+} from "../components/ActivityTimeline";
+
+type ActivityPageState = "loading" | "populated" | "empty" | "error";
 
 const MOCK_ACTIVITY: ActivityGroup[] = [
   {
@@ -49,48 +56,91 @@ const MOCK_ACTIVITY: ActivityGroup[] = [
 ];
 
 export default function ActivityPage() {
-  const [loading, setLoading] = useState(true);
+  const [pageState, setPageState] = useState<ActivityPageState>("loading");
   const [activities, setActivities] = useState<ActivityGroup[]>([]);
+  // Incrementing this key re-triggers the data-loading effect (retry).
+  const [loadKey, setLoadKey] = useState(0);
+
+  const handleRetry = useCallback(() => {
+    setLoadKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
-    // Simulate initial load
+    setPageState("loading");
+
+    // In production replace with a real API call; reject to exercise error path.
     const timer = setTimeout(() => {
       setActivities(MOCK_ACTIVITY);
-      setLoading(false);
+      setPageState(MOCK_ACTIVITY.length > 0 ? "populated" : "empty");
     }, 1500);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [loadKey]);
 
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        padding: "4rem 2rem",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-      }}
-    >
-      <div style={{ maxWidth: "48rem", width: "100%", marginBottom: "3rem" }}>
-        <h1 style={{ fontSize: "2.5rem", fontWeight: 800, marginBottom: "0.5rem" }}>Activity</h1>
-        <p style={{ color: "var(--muted-light)", fontSize: "1.1rem" }}>
-          Track every transaction, status update, and wallet event in real-time.
-        </p>
-      </div>
+    <main className="page-shell">
+      <section className="page-hero">
+        <div>
+          <p className="page-hero__eyebrow">Activity</p>
+          <h1 className="page-hero__title">Track every event.</h1>
+          <p className="page-hero__description">
+            Every transaction, status update, and wallet event — visible the
+            moment it happens.
+          </p>
+        </div>
+      </section>
 
-      {loading ? (
-        <ActivityTimelineSkeleton />
-      ) : activities.length > 0 ? (
-        <ActivityTimeline groups={activities} />
-      ) : (
-        <EmptyState
-          eyebrow="Activity"
-          title="Activity will appear here"
-          description="Any payment stream updates, payments, or wallet events will show up once activity begins. Stay connected to monitor your flow."
-          actionLabel="View streams"
-        />
-      )}
+      {/*
+       * aria-live="polite" lets screen readers announce content changes without
+       * interrupting. aria-busy signals that a fetch is in progress so assistive
+       * technology can defer reading until data arrives.
+       */}
+      <section
+        aria-busy={pageState === "loading"}
+        aria-labelledby="activity-overview-title"
+        aria-live="polite"
+        className="stream-layout"
+      >
+        <div className="section-heading">
+          <div>
+            <h2 className="section-heading__title" id="activity-overview-title">
+              Activity feed
+            </h2>
+            <p className="section-heading__description">
+              Payments, stream lifecycle changes, and wallet events appear here
+              as they happen.
+            </p>
+          </div>
+        </div>
+
+        {/* Screen-reader-only live announcement for state changes */}
+        <span aria-live="polite" className="sr-only" role="status">
+          {pageState === "loading"
+            ? "Loading activity feed…"
+            : pageState === "error"
+              ? "Failed to load activity feed."
+              : ""}
+        </span>
+
+        {pageState === "loading" ? (
+          <ActivityTimelineSkeleton />
+        ) : pageState === "error" ? (
+          <PageError
+            heading="Couldn't load your activity"
+            message="There was a problem fetching your activity feed. Check your connection and try again."
+            onRetry={handleRetry}
+          />
+        ) : activities.length > 0 ? (
+          <ActivityTimeline groups={activities} />
+        ) : (
+          <EmptyState
+            actionLabel="View streams"
+            description="Any payment stream updates, payments, or wallet events will show up once activity begins. Stay connected to monitor your flow."
+            eyebrow="Activity"
+            title="Activity will appear here"
+          />
+        )}
+      </section>
     </main>
   );
 }

--- a/app/components/PageError.test.tsx
+++ b/app/components/PageError.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PageError } from "./PageError";
+
+describe("PageError", () => {
+  it("renders heading and message", () => {
+    render(
+      <PageError
+        heading="Couldn't load data"
+        message="Check your connection and try again."
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /couldn't load data/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/check your connection and try again/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Error eyebrow label", () => {
+    render(<PageError heading="Oops" message="Something failed." />);
+    expect(screen.getByText(/^error$/i)).toBeInTheDocument();
+  });
+
+  it("renders retry button and calls onRetry when clicked", () => {
+    const onRetry = jest.fn();
+    render(
+      <PageError
+        heading="Load failed"
+        message="Please retry."
+        onRetry={onRetry}
+      />,
+    );
+
+    const retryBtn = screen.getByRole("button", { name: /try again/i });
+    expect(retryBtn).toBeInTheDocument();
+    fireEvent.click(retryBtn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides retry button when onRetry is not provided", () => {
+    render(<PageError heading="Load failed" message="Contact support." />);
+    expect(
+      screen.queryByRole("button", { name: /try again/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a custom retry label", () => {
+    render(
+      <PageError
+        heading="Oops"
+        message="Reload the page."
+        onRetry={jest.fn()}
+        retryLabel="Reload"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it("always renders the contact support link", () => {
+    render(<PageError heading="Error" message="An error occurred." />);
+    expect(
+      screen.getByRole("link", { name: /contact support/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses a custom support href when provided", () => {
+    render(
+      <PageError
+        heading="Error"
+        message="An error occurred."
+        supportHref="/help"
+      />,
+    );
+    const link = screen.getByRole("link", { name: /contact support/i });
+    expect(link).toHaveAttribute("href", "/help");
+  });
+
+  it("has role=alert for immediate screen-reader announcement", () => {
+    render(<PageError heading="Error" message="Failed." />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("has data-testid for test targeting", () => {
+    render(<PageError heading="Error" message="Failed." />);
+    expect(screen.getByTestId("page-error")).toBeInTheDocument();
+  });
+});

--- a/app/components/PageError.tsx
+++ b/app/components/PageError.tsx
@@ -1,0 +1,68 @@
+type PageErrorProps = {
+  /** Short heading describing the failure. */
+  heading: string;
+  /** Friendly explanation; avoid technical jargon. */
+  message: string;
+  /** Called when the user presses the primary action. Omit to hide the button. */
+  onRetry?: () => void;
+  /** Override the retry button label. */
+  retryLabel?: string;
+  /** Destination for the "Contact support" secondary link. */
+  supportHref?: string;
+};
+
+/**
+ * Inline error panel displayed within the page body (not a full-page overlay).
+ *
+ * Uses role="alert" so screen readers announce the error immediately when it
+ * appears, without requiring the user to navigate to it.
+ */
+export function PageError({
+  heading,
+  message,
+  onRetry,
+  retryLabel = "Try again",
+  supportHref = "/settings",
+}: PageErrorProps) {
+  return (
+    <section
+      aria-labelledby="page-error-heading"
+      aria-live="assertive"
+      className="page-error"
+      data-testid="page-error"
+      role="alert"
+    >
+      <span aria-hidden="true" className="page-error__icon">
+        <svg fill="none" focusable="false" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9.25" stroke="currentColor" strokeWidth="1.6" />
+          <path
+            d="M12 8v5"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth="1.6"
+          />
+          <circle cx="12" cy="15.5" fill="currentColor" r="0.75" />
+        </svg>
+      </span>
+
+      <p className="page-error__eyebrow">Error</p>
+
+      <h2 className="page-error__heading" id="page-error-heading">
+        {heading}
+      </h2>
+
+      <p className="page-error__message">{message}</p>
+
+      <div className="page-error__actions">
+        {onRetry && (
+          <button className="button button--primary" onClick={onRetry} type="button">
+            {retryLabel}
+          </button>
+        )}
+        <a className="button button--secondary" href={supportHref}>
+          Contact support
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -440,6 +440,48 @@ a:hover {
   max-width: 48ch;
 }
 
+/* ─── Inline page error ─── */
+.page-error {
+  background: linear-gradient(180deg, var(--system-error-bg), var(--panel));
+  border: 1px solid var(--system-error-border);
+  border-radius: 1.5rem;
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.5rem;
+}
+
+.page-error__icon {
+  color: var(--system-error-text);
+  display: block;
+  height: 2rem;
+  width: 2rem;
+}
+
+.page-error__eyebrow {
+  color: var(--system-error-text);
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-error__heading {
+  font-size: 1.5rem;
+}
+
+.page-error__message {
+  color: var(--muted-light);
+  line-height: 1.6;
+  max-width: 48ch;
+}
+
+.page-error__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
 /* ─── Skeletons ─── */
 .stream-row--skeleton {
   pointer-events: none;

--- a/app/streams/StreamsPageContent.tsx
+++ b/app/streams/StreamsPageContent.tsx
@@ -1,7 +1,8 @@
 import { EmptyState } from "../components/EmptyState";
+import { PageError } from "../components/PageError";
 import { StreamRow, type StreamRowData } from "../components/StreamRow";
 
-export type StreamsViewState = "empty" | "loading" | "populated";
+export type StreamsViewState = "empty" | "loading" | "populated" | "error";
 
 const streamListCopy = {
   description:
@@ -48,6 +49,10 @@ export const mockStreams: StreamRowData[] = [
 type StreamsPageContentProps = {
   state?: StreamsViewState;
   streams?: StreamRowData[];
+  /** Shown in the error panel when state === "error". */
+  errorMessage?: string;
+  /** Called when the user presses "Try again" in the error panel. */
+  onRetry?: () => void;
 };
 
 function StreamListSkeleton() {
@@ -89,6 +94,8 @@ function StreamListSkeleton() {
 export function StreamsPageContent({
   state = "populated",
   streams = mockStreams,
+  errorMessage,
+  onRetry,
 }: StreamsPageContentProps) {
   const isEmpty = state === "empty" || streams.length === 0;
 
@@ -125,6 +132,15 @@ export function StreamsPageContent({
 
         {state === "loading" ? (
           <StreamListSkeleton />
+        ) : state === "error" ? (
+          <PageError
+            heading="Couldn't load your streams"
+            message={
+              errorMessage ??
+              "There was a problem fetching your streams. Check your connection and try again."
+            }
+            onRetry={onRetry}
+          />
         ) : isEmpty ? (
           <EmptyState
             actionLabel={streamListCopy.empty.actionLabel}

--- a/app/streams/[id]/receipt/error.test.tsx
+++ b/app/streams/[id]/receipt/error.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import ReceiptError from "./error";
+
+const mockError = new Error("Test render failure") as Error & { digest?: string };
+
+describe("ReceiptError", () => {
+  it("renders the receipt-specific heading", () => {
+    render(<ReceiptError error={mockError} reset={jest.fn()} />);
+    expect(
+      screen.getByRole("heading", { name: /we couldn't load this receipt/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the reassuring body message", () => {
+    render(<ReceiptError error={mockError} reset={jest.fn()} />);
+    expect(screen.getByText(/your payment data is safe/i)).toBeInTheDocument();
+  });
+
+  it("renders the Try again button and calls reset on click", () => {
+    const reset = jest.fn();
+    render(<ReceiptError error={mockError} reset={reset} />);
+
+    const btn = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(btn);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a Back to streams link pointing to /streams", () => {
+    render(<ReceiptError error={mockError} reset={jest.fn()} />);
+    const link = screen.getByRole("link", { name: /back to streams/i });
+    expect(link).toHaveAttribute("href", "/streams");
+  });
+
+  it("renders the error digest as a support reference when present", () => {
+    const errorWithDigest = Object.assign(new Error("Server error"), {
+      digest: "abc-123-digest",
+    });
+    render(<ReceiptError error={errorWithDigest} reset={jest.fn()} />);
+    expect(screen.getByText(/abc-123-digest/i)).toBeInTheDocument();
+  });
+
+  it("omits the support reference section when digest is absent", () => {
+    render(<ReceiptError error={mockError} reset={jest.fn()} />);
+    expect(screen.queryByText(/support reference/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/streams/[id]/receipt/error.tsx
+++ b/app/streams/[id]/receipt/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { ErrorRecovery } from "../../../components/ErrorRecovery";
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Route-level error boundary for /streams/[id]/receipt.
+ *
+ * Shown when the server component throws during rendering (e.g. data fetch
+ * failure, serialisation error). Uses the shared ErrorRecovery layout so the
+ * visual treatment matches the global error page, while messaging is specific
+ * to the receipt context ("your payment data is safe").
+ */
+export default function ReceiptError({ error, reset }: Props) {
+  return (
+    <ErrorRecovery
+      body="Something went wrong while loading this payment receipt. Your payment data is safe — this is a display issue only. Try refreshing, or go back to your streams list."
+      eyebrow="Receipt unavailable"
+      heading="We couldn't load this receipt"
+      helperNote="If the problem persists, contact support with the reference below."
+      primaryAction={
+        <button
+          className="button button--primary error-page__action"
+          onClick={reset}
+          type="button"
+        >
+          Try again
+        </button>
+      }
+      reference={error.digest}
+      secondaryAction={
+        <Link
+          className="button button--secondary error-page__action"
+          href="/streams"
+        >
+          Back to streams
+        </Link>
+      }
+      variant="server"
+    />
+  );
+}

--- a/app/streams/[id]/receipt/loading.test.tsx
+++ b/app/streams/[id]/receipt/loading.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import ReceiptLoading from "./loading";
+
+describe("ReceiptLoading", () => {
+  it("renders with aria-label for screen readers", () => {
+    render(<ReceiptLoading />);
+    expect(screen.getByLabelText(/loading receipt/i)).toBeInTheDocument();
+  });
+
+  it("sets aria-busy=true on the container", () => {
+    render(<ReceiptLoading />);
+    const container = screen.getByLabelText(/loading receipt/i);
+    expect(container).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("renders toolbar skeleton buttons", () => {
+    const { container } = render(<ReceiptLoading />);
+    const buttons = container.querySelectorAll(".skeleton--button");
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders skeleton fields for the receipt document", () => {
+    const { container } = render(<ReceiptLoading />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    // Should have a healthy number of skeleton elements to match the receipt structure
+    expect(skeletons.length).toBeGreaterThan(8);
+  });
+
+  it("marks the document skeleton as aria-hidden to avoid noisy announcements", () => {
+    render(<ReceiptLoading />);
+    // The article skeleton is presentational; real content is announced via aria-label
+    const article = screen.getByRole("article", { hidden: true });
+    expect(article).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders a divider between skeleton sections", () => {
+    const { container } = render(<ReceiptLoading />);
+    const dividers = container.querySelectorAll(".receipt-divider");
+    expect(dividers.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/app/streams/[id]/receipt/loading.tsx
+++ b/app/streams/[id]/receipt/loading.tsx
@@ -1,0 +1,94 @@
+/**
+ * Streaming loading UI for /streams/[id]/receipt.
+ *
+ * Next.js renders this file automatically while the server component above it
+ * resolves, so users see a skeleton rather than a blank page on slow networks.
+ * The skeleton mirrors the section structure of StreamReceipt to prevent layout
+ * shift when the real document swaps in.
+ */
+
+function SkeletonField() {
+  return (
+    <div style={{ display: "grid", gap: "0.35rem" }}>
+      <div className="skeleton skeleton--label" />
+      <div className="skeleton skeleton--value" />
+    </div>
+  );
+}
+
+export default function ReceiptLoading() {
+  return (
+    <div className="receipt-shell" aria-busy="true" aria-label="Loading receipt">
+      {/* Toolbar skeleton */}
+      <div className="receipt-toolbar no-print">
+        <div className="receipt-note-builder__actions">
+          <div className="skeleton skeleton--button" />
+          <div
+            className="skeleton skeleton--button"
+            style={{ width: "5rem" }}
+          />
+        </div>
+      </div>
+
+      {/* Note-builder skeleton */}
+      <div className="receipt-note-builder no-print" style={{ display: "grid", gap: "0.5rem" }}>
+        <div className="skeleton skeleton--label" />
+        <div
+          className="skeleton"
+          style={{ borderRadius: "0.5rem", height: "6rem" }}
+        />
+      </div>
+
+      {/* Receipt document skeleton */}
+      <article
+        aria-hidden="true"
+        className="receipt-doc"
+        style={{ display: "grid", gap: "1.5rem" }}
+      >
+        {/* Header */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ display: "grid", gap: "0.5rem" }}>
+            <div className="skeleton skeleton--title" style={{ width: "7rem" }} />
+            <div className="skeleton skeleton--text" style={{ width: "12rem" }} />
+          </div>
+          <div className="skeleton skeleton--badge" />
+        </div>
+
+        <div className="receipt-divider" />
+
+        {/* Stream identity */}
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          <div className="skeleton skeleton--title" style={{ width: "9rem" }} />
+          <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+            <div className="skeleton skeleton--value" style={{ width: "11rem" }} />
+            <div className="skeleton skeleton--badge" style={{ width: "4.5rem" }} />
+          </div>
+        </div>
+
+        <div className="receipt-divider" />
+
+        {/* Recipient section */}
+        <div style={{ display: "grid", gap: "1rem" }}>
+          <div className="skeleton skeleton--title" style={{ width: "6rem" }} />
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <SkeletonField />
+            <SkeletonField />
+          </div>
+        </div>
+
+        <div className="receipt-divider" />
+
+        {/* Payment details section */}
+        <div style={{ display: "grid", gap: "1rem" }}>
+          <div className="skeleton skeleton--title" style={{ width: "9rem" }} />
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <SkeletonField />
+            <SkeletonField />
+            <SkeletonField />
+            <SkeletonField />
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/app/streams/page.test.tsx
+++ b/app/streams/page.test.tsx
@@ -79,6 +79,36 @@ describe("StreamsPageContent", () => {
     expect(screen.getByText(/paused on last day; final day prorated/i)).toBeInTheDocument();
   });
 
+  it("renders the error state with heading and contact support link", () => {
+    render(<StreamsPageContent state="error" />);
+
+    expect(
+      screen.getByRole("heading", { name: /couldn't load your streams/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /contact support/i })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders a retry button in the error state when onRetry is provided", () => {
+    const onRetry = jest.fn();
+    render(<StreamsPageContent state="error" onRetry={onRetry} />);
+
+    const retryBtn = screen.getByRole("button", { name: /try again/i });
+    expect(retryBtn).toBeInTheDocument();
+    retryBtn.click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a custom errorMessage in the error panel", () => {
+    render(
+      <StreamsPageContent
+        state="error"
+        errorMessage="The API returned a 503."
+      />,
+    );
+    expect(screen.getByText(/the api returned a 503/i)).toBeInTheDocument();
+  });
+
   it("applies the animation class only to active streams", () => {
     const streams = [
       {


### PR DESCRIPTION
Closes #545

## Summary

- **New `PageError` component** — reusable inline error panel that matches the `EmptyState` visual language using CSS variables (`var(--system-error-*)`) and is theme-aware (dark/light). Uses `role="alert"` + `aria-live="assertive"` for immediate screen-reader announcement.
- **`/streams`** — adds `"error"` to `StreamsViewState`; the error panel accepts `onRetry` + `errorMessage` props so callers can wire up real retry logic when the data layer is connected.
- **`/activity`** — replaces inline styles with `page-shell` / `page-hero` CSS classes (consistent with `/streams`); adds error state with retry; adds `aria-live="polite"` + `aria-busy` on the feed section and an `sr-only` live region so screen readers announce state transitions.
- **`/streams/[id]/receipt/loading.tsx`** — Next.js streaming loading file; renders a receipt-shaped skeleton (toolbar, note-builder, document sections with field placeholders) so the page never shows blank on slow networks.
- **`/streams/[id]/receipt/error.tsx`** — route-level error boundary using the shared `ErrorRecovery` layout with receipt-specific messaging ("your payment data is safe") and a "Back to streams" secondary CTA.

## Reusable components created

| Component | Path | Purpose |
|---|---|---|
| `PageError` | `app/components/PageError.tsx` | Inline error panel for any page section |

## Accessibility

- `role="alert"` + `aria-live="assertive"` on `PageError` → SR announces immediately on mount
- `aria-live="polite"` + `aria-busy` on the Activity feed section → SR defers reading until data arrives
- `sr-only` live region on Activity page → explicit "Loading…" / "Error…" announcements
- `aria-busy="true"` on receipt loading container → SR knows content is pending
- All interactive elements (retry button, links) are keyboard-navigable

## Test results

```
PASS app/components/PageError.test.tsx         (9 tests)
PASS app/streams/page.test.tsx                 (8 tests — 3 new)
PASS app/activity/page.test.tsx                (8 tests — new file)
PASS app/streams/[id]/receipt/loading.test.tsx (6 tests — new file)
PASS app/streams/[id]/receipt/error.test.tsx   (6 tests — new file)

Tests: 37 passed, 0 failed
```

## Test plan

- [x] `PageError` renders heading, message, retry button, support link
- [x] `PageError` hides retry button when `onRetry` is omitted
- [x] `PageError` has `role="alert"` for SR
- [x] `/streams` error state shows panel and wires retry callback
- [x] `/streams` error state accepts custom `errorMessage`
- [x] `/activity` shows loading skeleton initially
- [x] `/activity` transitions to populated state after timer fires
- [x] `/activity` `aria-busy` toggles correctly with page state
- [x] `/activity` cleans up timer on unmount
- [x] Receipt `loading.tsx` has `aria-busy` and `aria-label`
- [x] Receipt `loading.tsx` renders structurally sound skeleton
- [x] Receipt `error.tsx` renders heading, body, retry button, back-link
- [x] Receipt `error.tsx` shows digest as support reference when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)