### PR TITLE
feat: add recently used recipient rail in create-stream

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2420,3 +2420,74 @@ a:hover {
   font-size: var(--text-base);
   margin-bottom: var(--space-1);
 }
+
+/* ─── Recent Recipients Rail (Create-Stream) ──────────────────────────── */
+.recent-recipients {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.recent-recipients__label {
+  color: var(--muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.recent-recipients__rail {
+  -webkit-overflow-scrolling: touch;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  overflow-x: auto;
+  padding: 0 0 0.25rem;
+  scrollbar-width: none;
+}
+
+.recent-recipients__rail::-webkit-scrollbar {
+  display: none;
+}
+
+.recent-recipients__item {
+  flex-shrink: 0;
+}
+
+.recent-recipients__pill {
+  background: var(--panel-elevated);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted-light);
+  cursor: pointer;
+  font-family: ui-monospace, 'Cascadia Code', monospace;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.75rem;
+  transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
+  white-space: nowrap;
+}
+
+.recent-recipients__pill:hover {
+  background: var(--panel);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.recent-recipients__pill:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (min-width: 40rem) {
+  .recent-recipients__rail {
+    flex-wrap: wrap;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recent-recipients__pill {
+    transition: none !important;
+  }
+}

--- a/app/state/recentRecipients.ts
+++ b/app/state/recentRecipients.ts
@@ -1,0 +1,40 @@
+const RECENT_RECIPIENTS_KEY = "streampay_recent_recipients";
+const MAX_RECENT = 6;
+
+export interface RecentRecipient {
+  address: string;
+  addedAt: number;
+}
+
+export function getRecentRecipients(): RecentRecipient[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(RECENT_RECIPIENTS_KEY);
+    return raw ? (JSON.parse(raw) as RecentRecipient[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Prepends `address` to the recent-recipients list, deduplicating and capping
+ * at MAX_RECENT entries. No-ops for empty/whitespace-only addresses.
+ */
+export function addRecentRecipient(address: string): void {
+  if (typeof window === "undefined") return;
+  const trimmed = address.trim();
+  if (!trimmed) return;
+
+  const deduped = getRecentRecipients().filter((r) => r.address !== trimmed);
+  const updated: RecentRecipient[] = [
+    { address: trimmed, addedAt: Date.now() },
+    ...deduped,
+  ].slice(0, MAX_RECENT);
+
+  localStorage.setItem(RECENT_RECIPIENTS_KEY, JSON.stringify(updated));
+}
+
+export function clearRecentRecipients(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(RECENT_RECIPIENTS_KEY);
+}

--- a/app/streams/new/components/RecentRecipients.test.tsx
+++ b/app/streams/new/components/RecentRecipients.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { RecentRecipients } from "./RecentRecipients";
+import {
+  addRecentRecipient,
+  clearRecentRecipients,
+  getRecentRecipients,
+} from "../../../state/recentRecipients";
+
+const ADDR_A = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G";
+const ADDR_B = "GBDE4S2PHRXBLPJFQVLZJ6VFBNEXDBKGKNXQY5FAFKPV7XTMHHFP2SU";
+const ADDR_C = "GC5M3NBSIFDIBZGBSMABKW7ZAQEYLQR6YIXMKBDGQCKIQE5KW7ZK7K3";
+const ADDR_D = "GD2GBFGQOFKSJAL5FXIJHQFPAJDP7GQFXHTDQYKFFNPIBZRPZJKFHTB";
+const ADDR_E = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZQE3DCSSGNL4GQXHOPKC";
+const ADDR_F = "GBXGQJWVLKZX6HIWB3R4R5JXQFQBSKNYZTZM6FXQZN6ER6SDKZFM6O";
+const ADDR_G = "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7PNKEG3QAE6FAJQZF4KBPWF4";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  clearRecentRecipients();
+});
+
+describe("recentRecipients state module", () => {
+  it("returns empty array when localStorage is empty", () => {
+    expect(getRecentRecipients()).toEqual([]);
+  });
+
+  it("adds a recipient and retrieves it", () => {
+    addRecentRecipient(ADDR_A);
+    const result = getRecentRecipients();
+    expect(result).toHaveLength(1);
+    expect(result[0].address).toBe(ADDR_A);
+    expect(result[0].addedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("prepends new entries so the most recent is first", () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+    const result = getRecentRecipients();
+    expect(result[0].address).toBe(ADDR_B);
+    expect(result[1].address).toBe(ADDR_A);
+  });
+
+  it("deduplicates: re-adding an existing address moves it to front", () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+    addRecentRecipient(ADDR_A);
+    const result = getRecentRecipients();
+    expect(result).toHaveLength(2);
+    expect(result[0].address).toBe(ADDR_A);
+    expect(result[1].address).toBe(ADDR_B);
+  });
+
+  it("caps the list at 6 entries", () => {
+    [ADDR_A, ADDR_B, ADDR_C, ADDR_D, ADDR_E, ADDR_F, ADDR_G].forEach(
+      addRecentRecipient
+    );
+    const result = getRecentRecipients();
+    expect(result).toHaveLength(6);
+    expect(result[0].address).toBe(ADDR_G);
+  });
+
+  it("ignores empty and whitespace-only addresses", () => {
+    addRecentRecipient("");
+    addRecentRecipient("   ");
+    expect(getRecentRecipients()).toHaveLength(0);
+  });
+
+  it("trims whitespace from addresses before storing", () => {
+    addRecentRecipient(`  ${ADDR_A}  `);
+    const result = getRecentRecipients();
+    expect(result[0].address).toBe(ADDR_A);
+  });
+
+  it("clearRecentRecipients removes all entries", () => {
+    addRecentRecipient(ADDR_A);
+    clearRecentRecipients();
+    expect(getRecentRecipients()).toHaveLength(0);
+  });
+});
+
+describe("RecentRecipients component", () => {
+  it("renders nothing when there are no recent recipients", () => {
+    const { container } = render(
+      <RecentRecipients onSelect={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a pill for each recent recipient", async () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+  });
+
+  it("displays truncated addresses in pill labels", async () => {
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    const pill = screen.getByRole("button");
+    expect(pill.textContent).toMatch(/^GAHJJJ…AKZK7G$/);
+  });
+
+  it("exposes the full address in aria-label for screen readers", async () => {
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: `Use recent recipient ${ADDR_A}`,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("exposes the full address as title tooltip", async () => {
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getByRole("button")).toHaveAttribute("title", ADDR_A);
+  });
+
+  it("calls onSelect with the full address when a pill is clicked", async () => {
+    const onSelect = jest.fn();
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={onSelect} />);
+    });
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(ADDR_A);
+  });
+
+  it("renders pills in most-recent-first order", async () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAttribute(
+      "aria-label",
+      `Use recent recipient ${ADDR_B}`
+    );
+    expect(buttons[1]).toHaveAttribute(
+      "aria-label",
+      `Use recent recipient ${ADDR_A}`
+    );
+  });
+
+  it("renders at most 6 pills even when more addresses are stored", async () => {
+    [ADDR_A, ADDR_B, ADDR_C, ADDR_D, ADDR_E, ADDR_F, ADDR_G].forEach(
+      addRecentRecipient
+    );
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getAllByRole("button")).toHaveLength(6);
+  });
+
+  it("renders the 'Recent' label when recipients exist", async () => {
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+  });
+
+  it("all pills are type=button to avoid accidental form submission", async () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    screen.getAllByRole("button").forEach((btn) => {
+      expect(btn).toHaveAttribute("type", "button");
+    });
+  });
+
+  it("applies an extra className to the wrapper when provided", async () => {
+    addRecentRecipient(ADDR_A);
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <RecentRecipients onSelect={jest.fn()} className="my-extra-class" />
+      ));
+    });
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("recent-recipients");
+    expect(wrapper).toHaveClass("my-extra-class");
+  });
+
+  it("has aria-label on the wrapper for landmark context", async () => {
+    addRecentRecipient(ADDR_A);
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<RecentRecipients onSelect={jest.fn()} />));
+    });
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveAttribute(
+      "aria-label",
+      "Recently used recipients"
+    );
+  });
+
+  it("renders a list element for the rail", async () => {
+    addRecentRecipient(ADDR_A);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getByRole("list")).toBeInTheDocument();
+  });
+
+  it("each pill item is a list item inside the rail", async () => {
+    addRecentRecipient(ADDR_A);
+    addRecentRecipient(ADDR_B);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("short addresses are not truncated", async () => {
+    const shortAddr = "GABC123";
+    addRecentRecipient(shortAddr);
+
+    await act(async () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+    });
+
+    expect(screen.getByRole("button").textContent).toBe(shortAddr);
+  });
+});

--- a/app/streams/new/components/RecentRecipients.tsx
+++ b/app/streams/new/components/RecentRecipients.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  getRecentRecipients,
+  RecentRecipient,
+} from "../../../state/recentRecipients";
+
+export interface RecentRecipientsProps {
+  /** Called with the full address when the user clicks a recent-recipient pill. */
+  onSelect: (address: string) => void;
+  /** Optional additional CSS class for the wrapper element. */
+  className?: string;
+}
+
+/** Returns the first `chars` + "…" + last `chars` characters of `address`. */
+function truncateAddress(address: string, chars = 6): string {
+  if (address.length <= chars * 2 + 3) return address;
+  return `${address.slice(0, chars)}…${address.slice(-chars)}`;
+}
+
+/**
+ * RecentRecipients — quick-pick rail showing the last 6 addresses used in the
+ * create-stream form.  Reads from localStorage on mount and renders nothing
+ * when the list is empty (e.g. first-time users).
+ *
+ * Accessibility
+ * - Landmark-free; the outer `<div>` has an `aria-label` describing the region.
+ * - Each pill is a `<button type="button">` with a full-address `aria-label`
+ *   so screen readers announce the untruncated value.
+ * - Focus ring is provided by the `.recent-recipients__pill:focus-visible` rule
+ *   in globals.css (WCAG 2.1 AA compliant, 2 px accent-colour outline).
+ *
+ * @example
+ * <RecentRecipients onSelect={(addr) => setRecipient(addr)} />
+ */
+export function RecentRecipients({
+  onSelect,
+  className = "",
+}: RecentRecipientsProps) {
+  const [recipients, setRecipients] = useState<RecentRecipient[]>([]);
+
+  useEffect(() => {
+    setRecipients(getRecentRecipients());
+  }, []);
+
+  if (recipients.length === 0) return null;
+
+  return (
+    <div
+      className={`recent-recipients${className ? ` ${className}` : ""}`}
+      aria-label="Recently used recipients"
+    >
+      <p className="recent-recipients__label" aria-hidden="true">
+        Recent
+      </p>
+      <ul role="list" className="recent-recipients__rail">
+        {recipients.map((r) => (
+          <li key={r.address} className="recent-recipients__item">
+            <button
+              type="button"
+              className="recent-recipients__pill"
+              onClick={() => onSelect(r.address)}
+              aria-label={`Use recent recipient ${r.address}`}
+              title={r.address}
+            >
+              {truncateAddress(r.address)}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/streams/new/page.tsx
+++ b/app/streams/new/page.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import { GasOnRecipientToggle } from '../../components/GasOnRecipientToggle';
+import { RecentRecipients } from './components/RecentRecipients';
+import { addRecentRecipient } from '../../state/recentRecipients';
 
 /**
  * New Stream page (single-recipient).
@@ -24,6 +26,7 @@ export default function NewStreamPage() {
     setIsSubmitting(true);
     // TODO: call stream creation API with { recipient, amount, token, gasOnRecipient }
     await new Promise((resolve) => setTimeout(resolve, 800));
+    addRecentRecipient(recipient);
     setIsSubmitting(false);
     setSuccess(true);
   };
@@ -78,6 +81,10 @@ export default function NewStreamPage() {
             >
               Recipient address
             </label>
+            <RecentRecipients
+              onSelect={setRecipient}
+              className="recent-recipients--inline"
+            />
             <input
               id="recipient"
               type="text"
@@ -85,7 +92,7 @@ export default function NewStreamPage() {
               value={recipient}
               onChange={(e) => setRecipient(e.target.value)}
               placeholder="GABC..."
-              style={fieldStyle}
+              style={{ ...fieldStyle, marginTop: '0.5rem' }}
             />
           </div>
 


### PR DESCRIPTION
Closes #556

---

## Summary

- Adds `app/state/recentRecipients.ts` — localStorage state module that stores the last 6 unique recipient addresses used in the create-stream form, with deduplication and automatic capping
- Adds `app/streams/new/components/RecentRecipients.tsx` — horizontal quick-pick pill rail rendered above the recipient input; renders nothing for first-time users (empty state)
- Extends `app/globals.css` with `.recent-recipients` BEM block using design tokens, dark/light theme support, `prefers-reduced-motion`, and a responsive wrap breakpoint
- Updates `app/streams/new/page.tsx` to render the rail and persist each address on successful stream creation

## Test plan

- [x] 23 unit tests added in `RecentRecipients.test.tsx`
  - State module: empty read, add, prepend-order, deduplication, 6-entry cap, empty/whitespace guard, trim, clear
  - Component: null render when empty, pill count, truncated display, full-address aria-label, title tooltip, onSelect callback, order, max-6 pills, "Recent" label, `type="button"` guard, custom className, wrapper aria-label, list/listitem roles, short-address passthrough
- [x] All 23 tests pass (`PASS app/streams/new/components/RecentRecipients.test.tsx`)
- [x] No regressions in existing suites (pre-existing failures are unrelated to this change)

## Accessibility

- WCAG 2.1 AA: 2 px accent-colour focus ring via `focus-visible`, full addresses in `aria-label` and `title`, `role="list"` on the rail
- `prefers-reduced-motion`: transitions disabled when user prefers reduced motion