### PR TITLE
feat: add paginated stream enumeration view

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,7 +99,7 @@ jobs:
                 e.cve_id === vuln.cwe?.[0] || 
                 e.package === name ||
                 e.advisory_id === vuln.id ||
-                (vunn.via && vuln.via.some(v => v.url?.includes(e.advisory_id)))
+                (vuln.via && vuln.via.some(v => v.url?.includes(e.advisory_id)))
               );
               
               const vulnInfo = {

--- a/app/components/ThemeToggle.test.tsx
+++ b/app/components/ThemeToggle.test.tsx
@@ -4,10 +4,16 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ThemeToggle } from "./ThemeToggle";
-import * as themeNoFlash from "../utils/theme-noflash";
+
+const mockSetTheme = jest.fn();
+jest.mock("../utils/theme-noflash", () => ({
+  ...jest.requireActual("../utils/theme-noflash"),
+  setTheme: (...args: any[]) => mockSetTheme(...args),
+}));
 
 describe("ThemeToggle", () => {
   beforeEach(() => {
+    mockSetTheme.mockClear();
     // Mock localStorage
     const store: Record<string, string> = {};
     const localStorageMock = {
@@ -63,13 +69,12 @@ describe("ThemeToggle", () => {
   });
 
   it("calls setTheme and updates state when selecting dark", () => {
-    const setThemeSpy = jest.spyOn(themeNoFlash, 'setTheme').mockImplementation(() => {});
     render(<ThemeToggle />);
     
     const darkRadio = screen.getByLabelText("Dark");
     fireEvent.click(darkRadio);
     
-    expect(setThemeSpy).toHaveBeenCalledWith("dark");
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
     expect((darkRadio as HTMLInputElement).checked).toBe(true);
   });
   

--- a/app/lib/config/config.test.ts
+++ b/app/lib/config/config.test.ts
@@ -36,6 +36,9 @@ describe('Stellar Network Configuration', () => {
     delete (process.env as any).ANOMALY_SETTLE_THRESHOLD;
     delete (process.env as any).CI;
     delete (process.env as any).GITHUB_ACTIONS;
+    delete (process.env as any).INTERNAL_SERVICE_HMAC_KEYS;
+    delete (process.env as any).INTERNAL_SERVICE_CURRENT_KEY_ID;
+    delete (process.env as any).INTERNAL_SERVICE_CLOCK_SKEW_SECONDS;
   });
 
   describe('Network Profiles', () => {

--- a/app/lib/errors/index.test.ts
+++ b/app/lib/errors/index.test.ts
@@ -79,7 +79,7 @@ describe("errorResponse()", () => {
     }));
 
     // Re-import after resetting modules
-    const { errorResponse: er } = await import("./index");
+    const { errorResponse: er } = await import("./server");
     const res = er(ErrorCode.INTERNAL_SERVER_ERROR, "Oops.");
     const body = (res as unknown as { body: ErrorEnvelope }).body;
     expect(typeof body.error.request_id).toBe("string");
@@ -97,7 +97,7 @@ describe("errorResponse()", () => {
       },
     }));
 
-    const { errorResponse: er } = await import("./index");
+    const { errorResponse: er } = await import("./server");
     const res = er(ErrorCode.NOT_FOUND, "Not found.", 404);
     const body = (res as unknown as { body: ErrorEnvelope }).body;
     expect(body.error.request_id).toBe("req_abc123");

--- a/app/lib/errors/index.ts
+++ b/app/lib/errors/index.ts
@@ -33,6 +33,3 @@ export {
   hasFieldErrors,
   getFirstFieldError,
 } from "./handler";
-
-export { errorResponse, ErrorCode } from "./server";
-export type { ErrorEnvelope } from "./server";

--- a/app/lib/errors/index.ts
+++ b/app/lib/errors/index.ts
@@ -33,3 +33,6 @@ export {
   hasFieldErrors,
   getFirstFieldError,
 } from "./handler";
+
+export { errorResponse, ErrorCode } from "./server";
+export type { ErrorEnvelope } from "./server";

--- a/app/lib/errors/mapper.ts
+++ b/app/lib/errors/mapper.ts
@@ -488,7 +488,7 @@ export function isSorobanError(
   error: unknown
 ): error is Error & { variant: string; meta?: Record<string, unknown>; statusCode?: number } {
   if (!(error instanceof Error)) return false;
-  const e = error as Record<string, unknown>;
+  const e = error as unknown as Record<string, unknown>;
   return (
     typeof e.variant === 'string' &&
     e.variant.length > 0 &&

--- a/app/lib/privacy.ts
+++ b/app/lib/privacy.ts
@@ -4,7 +4,7 @@ import { getStore } from "./db";
 export function redact(data: any): any {
   if (typeof data !== 'object' || data === null) return data;
   const redacted = { ...data };
-  const keysToRedact = ['signature', 'publicKey', 'secret', 'password', 'token', 'email'];
+  const keysToRedact = ['signature', 'publickey', 'secret', 'password', 'token', 'email'];
   for (const key in redacted) {
     if (keysToRedact.includes(key.toLowerCase())) {
       redacted[key] = '[REDACTED]';

--- a/app/lib/webhook-delivery.integration.test.ts
+++ b/app/lib/webhook-delivery.integration.test.ts
@@ -10,7 +10,7 @@ const vi = {
 import { WebhookDeliveryWorker } from '@/app/lib/webhook-delivery-worker';
 import { webhookDeliveryStore } from '@/app/lib/webhook-delivery-store';
 import { WebhookEndpoint, WebhookEvent } from '@/app/lib/webhook-delivery';
-import { logger, withCorrelationContext } from '@/app/lib/logger';
+import { logger, setCorrelationContext } from '@/app/lib/logger';
 
 /**
  * Integration tests with realistic failure scenarios
@@ -19,7 +19,7 @@ describe('Webhook Delivery Integration Tests', () => {
   let worker: WebhookDeliveryWorker;
 
   beforeEach(() => {
-    withCorrelationContext({
+    setCorrelationContext({
       correlation_id: 'integration-test-123',
       request_id: 'req-int-123',
     });

--- a/app/lib/webhook-delivery.test.ts
+++ b/app/lib/webhook-delivery.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@/app/lib/webhook-delivery';
 import { WebhookDeliveryWorker } from '@/app/lib/webhook-delivery-worker';
 import { webhookDeliveryStore } from '@/app/lib/webhook-delivery-store';
-import { logger, withCorrelationContext } from '@/app/lib/logger';
+import { logger, setCorrelationContext } from '@/app/lib/logger';
 
 describe('Webhook Delivery System', () => {
   beforeEach(() => {
@@ -349,10 +349,9 @@ describe('Webhook Delivery System', () => {
     let event: WebhookEvent;
 
     beforeEach(() => {
-      withCorrelationContext({
+      setCorrelationContext({
         correlation_id: 'test-correlation-123',
         request_id: 'req-123',
-        trace_id: 'trace-123',
       });
       worker = new WebhookDeliveryWorker(3);
       endpoint = {

--- a/app/utils/ics.ts
+++ b/app/utils/ics.ts
@@ -31,7 +31,7 @@ export interface VestingEvent {
  * Escapes special characters in ICS text fields according to RFC 5545.
  * Characters that need escaping: \ , ; : and newlines
  */
-function escapeIcsText(text: string): string {
+export function escapeIcsText(text: string): string {
   return text
     .replace(/\\/g, '\\\\')
     .replace(/;/g, '\\;')
@@ -43,7 +43,7 @@ function escapeIcsText(text: string): string {
  * Formats a Date object to ICS datetime format (YYYYMMDDTHHMMSSZ).
  * Uses UTC time to ensure consistency across timezones.
  */
-function formatIcsDate(date: Date): string {
+export function formatIcsDate(date: Date): string {
   return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 }
 
@@ -51,7 +51,7 @@ function formatIcsDate(date: Date): string {
  * Generates a unique UID for an ICS event.
  * Format: <stream-id>-<timestamp>@streampay.io
  */
-function generateEventUid(streamId: string, timestamp: Date): string {
+export function generateEventUid(streamId: string, timestamp: Date): string {
   const timeStr = timestamp.getTime().toString();
   return `${streamId}-${timeStr}@streampay.io`;
 }
@@ -82,13 +82,13 @@ function eventToIcs(event: VestingEvent): string {
  * Parses a stream rate string to extract amount and period.
  * Expected formats: "120 XLM / month", "32 XLM / week", "18 XLM / day"
  */
-function parseRate(rate: string): { amount: string; period: 'day' | 'week' | 'month' } | null {
-  const match = rate.match(/^(\d+(?:\.\d+)?)\s+(\w+)\s*\/\s*(day|week|month)$/i);
+export function parseRate(rate: string): { amount: string; period: 'day' | 'week' | 'month' } | null {
+  const match = rate.match(/^(\d+(?:\.\d+)?)\s*\w+\s*\/\s*(day|week|month)$/i);
   if (!match) return null;
 
   return {
     amount: match[1],
-    period: match[3].toLowerCase() as 'day' | 'week' | 'month',
+    period: match[2].toLowerCase() as 'day' | 'week' | 'month',
   };
 }
 

--- a/contracts/contracts/streampay-stream/src/error.rs
+++ b/contracts/contracts/streampay-stream/src/error.rs
@@ -1,6 +1,6 @@
 //! # Contract error codes
 //!
-//! Every error returned by the StreamPay contract is one of the
+//! Every error returned by the `StreamPay` contract is one of the
 //! discriminants in [`Error`]. The backend maps these codes one-to-one
 //! into the public Problem+JSON error envelope, so:
 //!
@@ -14,7 +14,7 @@
 
 use soroban_sdk::contracterror;
 
-/// Stable StreamPay contract error codes for backend Problem+JSON mapping.
+/// Stable `StreamPay` contract error codes for backend Problem+JSON mapping.
 ///
 /// Discriminants are part of the public contract API and must not be reused.
 #[contracterror]

--- a/contracts/contracts/streampay-stream/src/events.rs
+++ b/contracts/contracts/streampay-stream/src/events.rs
@@ -146,12 +146,12 @@ pub fn amended(
     );
 }
 
-/// Emits the `stream::admin_action` event after an admin performs an action.
-/// Carries the action symbol (e.g., "pause", "resume", "force_cancel") so
+/// Emits the `stream::admin_act` event after an admin performs an action.
+/// Carries the action symbol (e.g., "pause", "resume", "cancel") so
 /// indexers can track admin operations on behalf of senders.
 pub fn admin_action(env: &Env, stream_id: u64, admin: &Address, action: Symbol, timestamp: u64) {
     env.events().publish(
-        (symbol_short!("stream"), symbol_short!("admin_action")),
+        (symbol_short!("stream"), symbol_short!("admin_act")),
         (stream_id, admin.clone(), action, timestamp),
     );
 }

--- a/contracts/contracts/streampay-stream/src/events.rs
+++ b/contracts/contracts/streampay-stream/src/events.rs
@@ -1,26 +1,28 @@
-//! # StreamPay contract events
+//! # `StreamPay` contract events
 //!
 //! All events use a two-topic scheme for indexer filtering:
-//!   topic[0] = symbol_short!("stream")   — identifies the StreamPay contract family
-//!   topic[1] = symbol_short!("<event>")  — identifies the lifecycle transition
+//!   topic[0] = `symbol_short!("stream")` — identifies the `StreamPay` contract family
+//!   topic[1] = `symbol_short!("<event>")` — identifies the lifecycle transition
 //!
 //! ## Event schema (for Horizon indexers and the transactional outbox)
 //!
-//! | Event       | topic[1]      | Data tuple (in order)                                                                                    |
-//! |-------------|---------------|----------------------------------------------------------------------------------------------------------|
-//! | created     | "created"     | (stream_id: u64, sender: Address, recipient: Address, token: Address, total_amount: i128, timestamp: u64) |
-//! | started     | "started"     | (stream_id: u64, start_time: u64, end_time: u64, timestamp: u64)                                         |
-//! | withdrawn   | "withdrawn"   | (stream_id: u64, recipient: Address, amount: i128, timestamp: u64)                                       |
-//! | settled     | "settled"     | (stream_id: u64, recipient: Address, total_amount: i128, timestamp: u64)                                 |
-//! | paused      | "paused"      | (stream_id: u64, sender: Address, pause_time: u64, timestamp: u64)                                       |
-//! | resumed     | "resumed"     | (stream_id: u64, sender: Address, end_time: u64, timestamp: u64)                                         |
-//! | cancelled   | "cancelled"   | (stream_id: u64, cancelled_by: Address, returned_amount: i128, released_amount: i128, timestamp: u64)   |
-//! | amended     | "amended"     | (stream_id: u64, amended_by: Address, new_rate_per_second: i128, new_end_time: u64, timestamp: u64)      |
-//! | admin_action| "admin_action"| (stream_id: u64, admin: Address, action: Symbol, timestamp: u64)                                         |
+//! | Event         | topic[1]        | Data tuple (in order)                                                                                                    |
+//! |---------------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
+//! | created       | "created"       | (`stream_id`: u64, sender: Address, recipient: Address, token: Address, `total_amount`: i128, timestamp: u64)             |
+//! | started       | "started"       | (`stream_id`: u64, `start_time`: u64, `end_time`: u64, timestamp: u64)                                                    |
+//! | withdrawn     | "withdrawn"     | (`stream_id`: u64, recipient: Address, amount: i128, timestamp: u64)                                                      |
+//! | settled       | "settled"       | (`stream_id`: u64, recipient: Address, `total_amount`: i128, timestamp: u64)                                              |
+//! | paused        | "paused"        | (`stream_id`: u64, sender: Address, `pause_time`: u64, timestamp: u64)                                                    |
+//! | resumed       | "resumed"       | (`stream_id`: u64, sender: Address, `end_time`: u64, timestamp: u64)                                                      |
+//! | cancelled     | "cancelled"     | (`stream_id`: u64, `cancelled_by`: Address, `returned_amount`: i128, `released_amount`: i128, timestamp: u64)             |
+//! | amended       | "amended"       | (`stream_id`: u64, `amended_by`: Address, `new_rate_per_second`: i128, `new_end_time`: u64, timestamp: u64)               |
+//! | `admin_action`| "`admin_action`"| (`stream_id`: u64, admin: Address, action: Symbol, timestamp: u64)                                                        |
 //!
 //! All events are emitted AFTER successful state mutation and any token transfer.
 //! Failed calls (returning Err) emit no events.
 //! `settled` is emitted in addition to `withdrawn` when a withdrawal fully drains the stream.
+
+#![allow(deprecated)]
 
 use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
 
@@ -78,6 +80,7 @@ pub fn settled(env: &Env, stream_id: u64, recipient: &Address, total_amount: i12
     );
 }
 
+#[allow(dead_code)]
 pub fn paused(env: &Env, stream_id: u64, sender: &Address, pause_time: u64, timestamp: u64) {
     env.events().publish(
         (symbol_short!("stream"), symbol_short!("paused")),
@@ -85,6 +88,7 @@ pub fn paused(env: &Env, stream_id: u64, sender: &Address, pause_time: u64, time
     );
 }
 
+#[allow(dead_code)]
 pub fn resumed(env: &Env, stream_id: u64, sender: &Address, end_time: u64, timestamp: u64) {
     env.events().publish(
         (symbol_short!("stream"), symbol_short!("resumed")),
@@ -125,7 +129,7 @@ pub fn cancelled(
 }
 
 /// Emits the `stream::amended` event after a stream is successfully amended.
-/// Carries the new rate and end_time so indexers can track schedule changes.
+/// Carries the new rate and `end_time` so indexers can track schedule changes.
 pub fn amended(
     env: &Env,
     stream_id: u64,

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -1,4 +1,4 @@
-//! # StreamPay Stream Contract
+//! # `StreamPay` Stream Contract
 //!
 //! Soroban smart contract that manages linear payment streams on Stellar.
 //! Each stream locks a fixed token amount in escrow and releases it linearly
@@ -29,7 +29,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, 
 pub use storage::{Stream, StreamStatus};
 pub use views::{StreamPage, MAX_PAGE_SIZE};
 
-/// The StreamPay contract entry point registered with the Soroban host.
+/// The `StreamPay` contract entry point registered with the Soroban host.
 #[contract]
 pub struct Contract;
 
@@ -51,6 +51,7 @@ enum DataKey {
     TokenAllowed(Address),
 }
 
+#[allow(clippy::needless_pass_by_value, clippy::must_use_candidate)]
 #[contractimpl]
 impl Contract {
     /// One-time contract initialisation.
@@ -491,7 +492,7 @@ impl Contract {
     /// Returns the stream balance (vested amount) at a given ledger timestamp.
     ///
     /// This is a view function that computes how much of the stream has vested
-    /// based on linear accrual from start_time to end_time. It uses overflow-safe
+    /// based on linear accrual from `start_time` to `end_time`. It uses overflow-safe
     /// checked arithmetic to ensure correctness even with large amounts.
     ///
     /// # Arguments
@@ -502,6 +503,10 @@ impl Contract {
     ///
     /// The vested amount as an i128, always in the range `[0, total_amount]`.
     /// Returns `Err(Error::Overflow)` if arithmetic overflows on extreme inputs.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::Overflow`] if the vested-amount computation overflows.
     pub fn stream_balance(env: Env, stream_id: u64) -> Result<i128, Error> {
         let stream = get_existing_stream(&env, stream_id)?;
         release::vested_amount(&stream, env.ledger().timestamp())
@@ -588,8 +593,13 @@ impl Contract {
     /// Pauses an active stream, freezing accrual while preserving vested funds.
     ///
     /// Only the stream sender may call this. On pause, status is set to Paused
-    /// and pause_time is recorded. Vested amount remains withdrawable but does
+    /// and `pause_time` is recorded. Vested amount remains withdrawable but does
     /// not increase while paused.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::Unauthorized`] if caller is not the stream sender.
+    /// - [`Error::InvalidState`] if the stream is not `Active`.
     pub fn pause(env: Env, stream_id: u64) -> Result<Stream, Error> {
         let mut stream = get_existing_stream(&env, stream_id)?;
         stream.sender.require_auth();
@@ -618,11 +628,17 @@ impl Contract {
         Ok(stream)
     }
 
-    /// Resumes a paused stream, extending end_time to preserve unstreamed time.
+    /// Resumes a paused stream, extending `end_time` to preserve unstreamed time.
     ///
-    /// Only the stream sender may call this. On resume, the end_time is extended
+    /// Only the stream sender may call this. On resume, the `end_time` is extended
     /// by the paused duration so the remaining streamable amount is preserved.
     /// Status is set back to Active.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::Unauthorized`] if caller is not the stream sender.
+    /// - [`Error::InvalidState`] if the stream is not `Paused`.
+    /// - [`Error::InvalidTimeRange`] if time calculation overflows.
     pub fn resume(env: Env, stream_id: u64) -> Result<Stream, Error> {
         let mut stream = get_existing_stream(&env, stream_id)?;
         stream.sender.require_auth();
@@ -894,7 +910,7 @@ impl Contract {
         start_after: Option<u64>,
         limit: u64,
     ) -> views::StreamPage {
-        views::list_streams_by_sender(&env, sender, start_after, limit)
+        views::list_streams_by_sender(&env, &sender, start_after, limit)
     }
 
     /// Returns a paginated list of streams received by a given address.
@@ -916,7 +932,7 @@ impl Contract {
         start_after: Option<u64>,
         limit: u64,
     ) -> views::StreamPage {
-        views::list_streams_by_recipient(&env, recipient, start_after, limit)
+        views::list_streams_by_recipient(&env, &recipient, start_after, limit)
     }
 
     /// Returns a paginated list of streams filtered by status.
@@ -963,7 +979,7 @@ impl Contract {
         start_after: Option<u64>,
         limit: u64,
     ) -> views::StreamPage {
-        views::list_streams_by_recipient_and_status(&env, recipient, status, start_after, limit)
+        views::list_streams_by_recipient_and_status(&env, &recipient, status, start_after, limit)
     }
 
     /// Returns a paginated list of streams filtered by sender and status.
@@ -987,7 +1003,7 @@ impl Contract {
         start_after: Option<u64>,
         limit: u64,
     ) -> views::StreamPage {
-        views::list_streams_by_sender_and_status(&env, sender, status, start_after, limit)
+        views::list_streams_by_sender_and_status(&env, &sender, status, start_after, limit)
     }
 }
 
@@ -1041,7 +1057,7 @@ mod upgrade_test {
         env.mock_all_auths();
 
         let admin = Address::generate(&env);
-        let contract_id = env.register_contract(None, Contract);
+        let contract_id = env.register(Contract, ());
         let client = ContractClient::new(&env, &contract_id);
 
         client.initialize(&admin);

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -22,71 +22,16 @@ mod events;
 mod limits;
 mod release;
 mod storage;
+mod views;
 
 pub use error::Error;
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env};
 pub use storage::{Stream, StreamStatus};
+pub use views::{StreamPage, MAX_PAGE_SIZE};
 
 /// The StreamPay contract entry point registered with the Soroban host.
 #[contract]
 pub struct Contract;
-
-/// Lifecycle state of a payment stream.
-///
-/// Transitions allowed by the current public API:
-/// ```text
-/// Draft ──start_stream──► Active ──withdraw (full)──► Settled
-/// ```
-/// `Paused`, `Ended`, and `Cancelled` are reserved for future entry points.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum StreamStatus {
-    /// Created and funded but not yet activated; accrual has not started.
-    Draft,
-    /// Tokens are flowing linearly to the recipient.
-    Active,
-    /// Reserved — stream-level pause not yet implemented.
-    Paused,
-    /// All `total_amount` tokens have been released to the recipient.
-    Settled,
-    /// Reserved — natural expiry entry point not yet implemented.
-    Ended,
-    /// Reserved — sender-initiated cancellation not yet implemented.
-    Cancelled,
-}
-
-/// On-chain record for a single payment stream.
-///
-/// All token amounts are in the token's base unit (stroops for XLM-based
-/// assets). All timestamps are Unix seconds as reported by the ledger.
-#[derive(Clone, Debug)]
-#[contracttype]
-pub struct Stream {
-    /// Unique monotonic identifier assigned at creation. Starts at 1.
-    pub id: u64,
-    /// Address that created the stream and escrowed `total_amount`.
-    pub sender: Address,
-    /// Address that receives streamed tokens via [`Contract::withdraw`].
-    pub recipient: Address,
-    /// Stellar asset contract address being streamed.
-    pub token: Address,
-    /// Total tokens (base units) locked in escrow at creation. Always > 0.
-    pub total_amount: i128,
-    /// Tokens already transferred to `recipient`. Monotonically non-decreasing.
-    /// Invariant: `released_amount <= total_amount`.
-    pub released_amount: i128,
-    /// Ledger timestamp when accrual begins. Zero for `Draft` streams.
-    pub start_time: u64,
-    /// Ledger timestamp when accrual ends (`start_time + duration`).
-    /// Zero for `Draft` streams.
-    pub end_time: u64,
-    /// Stream length in seconds. Set at creation; never changes.
-    pub duration: u64,
-    /// Ledger timestamp of the last state-mutating operation on this stream.
-    pub last_update: u64,
-    /// Current lifecycle status.
-    pub status: StreamStatus,
-}
 
 /// Ledger storage keys used internally by this contract.
 ///
@@ -906,6 +851,144 @@ impl Contract {
         events::upgraded(&env, new_wasm_hash);
         Ok(())
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Read-only paginated enumeration views
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// Returns a paginated list of all streams, ordered by ascending stream ID.
+    ///
+    /// This is a read-only view that never mutates state or requires auth.
+    /// The global pause flag does not affect this call.
+    ///
+    /// # Parameters
+    ///
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    ///   Pass `None` to start from the beginning (stream ID 1).
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams. If `next_cursor` is `Some(id)`,
+    /// there are more streams; pass `id` as `start_after` to the next call.
+    pub fn list_streams(env: Env, start_after: Option<u64>, limit: u64) -> views::StreamPage {
+        views::list_streams(&env, start_after, limit)
+    }
+
+    /// Returns a paginated list of streams sent by a given address.
+    ///
+    /// This is a read-only view that never mutates state or requires auth.
+    ///
+    /// # Parameters
+    ///
+    /// - `sender` — Filter: only return streams where `stream.sender == sender`.
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams sent by `sender`.
+    pub fn list_streams_by_sender(
+        env: Env,
+        sender: Address,
+        start_after: Option<u64>,
+        limit: u64,
+    ) -> views::StreamPage {
+        views::list_streams_by_sender(&env, sender, start_after, limit)
+    }
+
+    /// Returns a paginated list of streams received by a given address.
+    ///
+    /// This is a read-only view that never mutates state or requires auth.
+    ///
+    /// # Parameters
+    ///
+    /// - `recipient` — Filter: only return streams where `stream.recipient == recipient`.
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams received by `recipient`.
+    pub fn list_streams_by_recipient(
+        env: Env,
+        recipient: Address,
+        start_after: Option<u64>,
+        limit: u64,
+    ) -> views::StreamPage {
+        views::list_streams_by_recipient(&env, recipient, start_after, limit)
+    }
+
+    /// Returns a paginated list of streams filtered by status.
+    ///
+    /// This is a read-only view that never mutates state or requires auth.
+    ///
+    /// # Parameters
+    ///
+    /// - `status` — Filter: only return streams where `stream.status == status`.
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams in the given status.
+    pub fn list_streams_by_status(
+        env: Env,
+        status: StreamStatus,
+        start_after: Option<u64>,
+        limit: u64,
+    ) -> views::StreamPage {
+        views::list_streams_by_status(&env, status, start_after, limit)
+    }
+
+    /// Returns a paginated list of streams filtered by recipient and status.
+    ///
+    /// This is a read-only view commonly used by frontends to show a user's
+    /// active/paused/settled streams.
+    ///
+    /// # Parameters
+    ///
+    /// - `recipient` — Filter: only return streams where `stream.recipient == recipient`.
+    /// - `status` — Filter: only return streams where `stream.status == status`.
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams matching both filters.
+    pub fn list_streams_recipient_status(
+        env: Env,
+        recipient: Address,
+        status: StreamStatus,
+        start_after: Option<u64>,
+        limit: u64,
+    ) -> views::StreamPage {
+        views::list_streams_by_recipient_and_status(&env, recipient, status, start_after, limit)
+    }
+
+    /// Returns a paginated list of streams filtered by sender and status.
+    ///
+    /// This is a read-only view that never mutates state or requires auth.
+    ///
+    /// # Parameters
+    ///
+    /// - `sender` — Filter: only return streams where `stream.sender == sender`.
+    /// - `status` — Filter: only return streams where `stream.status == status`.
+    /// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+    /// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+    ///
+    /// # Returns
+    ///
+    /// A [`StreamPage`] with up to `limit` streams matching both filters.
+    pub fn list_streams_sender_status(
+        env: Env,
+        sender: Address,
+        status: StreamStatus,
+        start_after: Option<u64>,
+        limit: u64,
+    ) -> views::StreamPage {
+        views::list_streams_by_sender_and_status(&env, sender, status, start_after, limit)
+    }
 }
 
 fn get_existing_stream(env: &Env, stream_id: u64) -> Result<Stream, Error> {
@@ -943,6 +1026,9 @@ mod test;
 
 #[cfg(test)]
 mod prop_test;
+
+#[cfg(test)]
+mod views_integration_test;
 
 #[cfg(test)]
 mod upgrade_test {

--- a/contracts/contracts/streampay-stream/src/prop_test.rs
+++ b/contracts/contracts/streampay-stream/src/prop_test.rs
@@ -1,4 +1,4 @@
-//! Property-based tests for the StreamPay contract.
+//! Property-based tests for the `StreamPay` contract.
 //!
 //! The property suite in this module was previously broken by an
 //! SDK API churn (changes to `register_stellar_asset_contract_v2`,

--- a/contracts/contracts/streampay-stream/src/release.rs
+++ b/contracts/contracts/streampay-stream/src/release.rs
@@ -48,9 +48,9 @@ pub fn vested_amount(stream: &Stream, now: u64) -> Result<i128, Error> {
     // All casts from u64 to i128 are safe because u64::MAX < i128::MAX.
     stream
         .total_amount
-        .checked_mul(elapsed as i128) // total_amount ∈ [0, i128::MAX], elapsed cast is lossless
+        .checked_mul(i128::from(elapsed)) // total_amount ∈ [0, i128::MAX], elapsed cast is lossless
         .ok_or(Error::Overflow)? // propagate overflow
-        .checked_div(stream.duration as i128) // duration > 0 at this point, cast is lossless
+        .checked_div(i128::from(stream.duration)) // duration > 0 at this point, cast is lossless
         .ok_or(Error::Overflow) // propagate overflow (shouldn't happen for division by non-zero)
 }
 
@@ -234,7 +234,7 @@ mod tests {
             (1, 0, 1, 1, 1),                // minimal duration, at end
         ];
 
-        for case in cases.iter() {
+        for case in &cases {
             let stream = test_stream(case.0, 0, case.1, case.2);
             let result = vested_amount(&stream, case.3);
             assert_eq!(
@@ -263,7 +263,7 @@ mod tests {
             (1000, 0, 1000, 2000, 3000, 1000),  // past end, nothing released
         ];
 
-        for case in cases.iter() {
+        for case in &cases {
             let stream = test_stream(case.0, case.1, case.2, case.3);
             let result = withdrawable(&stream, case.4);
             assert_eq!(

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -1,6 +1,6 @@
 //! # Contract storage layout
 //!
-//! All persistent state for the StreamPay contract is keyed by
+//! All persistent state for the `StreamPay` contract is keyed by
 //! [`DataKey`]. There are two storage tiers in use:
 //!
 //! - **Instance storage** holds singletons: `Admin`, `Paused`, the
@@ -16,7 +16,7 @@
 
 use soroban_sdk::{contracttype, Address, Env};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum StreamStatus {
     Draft,

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -295,3 +295,31 @@ pub fn get_stream(env: &Env, stream_id: u64) -> Option<Stream> {
     }
     stream
 }
+
+/// Peeks at the next stream ID without incrementing the counter.
+///
+/// This is used by pagination views to determine the upper bound for
+/// stream enumeration. It does not extend TTL since it's a read-only
+/// operation that doesn't need to keep the counter alive.
+///
+/// # Returns
+/// The next stream ID that would be assigned. If no streams have been
+/// created, returns `1`.
+///
+/// # Errors
+/// This helper does not return errors.
+pub fn peek_next_stream_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::StreamCount)
+        .unwrap_or(1u64)
+}
+
+/// Test helper to set the next stream ID counter.
+///
+/// This is only available in test builds and is used by the views
+/// module tests to set up specific test scenarios.
+#[cfg(test)]
+pub fn set_next_stream_id_for_test(env: &Env, id: u64) {
+    env.storage().instance().set(&DataKey::StreamCount, &id);
+}

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -275,8 +275,7 @@ fn init_with_token_allowlist_emits_no_events() {
     let events = data.env.events().all();
     assert!(
         events.is_empty(),
-        "init_with_token_allowlist should emit zero events, got: {:?}",
-        events
+        "init_with_token_allowlist should emit zero events, got: {events:?}",
     );
 }
 
@@ -651,7 +650,7 @@ fn cancel_stream_emits_cancelled_event() {
     assert!(!events.is_empty(), "cancel_stream should emit events");
 
     // The last event should be the cancelled event
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -673,9 +672,9 @@ fn cancel_stream_requires_auth() {
 
     // Mock auths off and try to cancel as a different address
     data.env.mock_auths(&[]);
-    let impostor = Address::generate(&data.env);
+    let _impostor = Address::generate(&data.env);
 
-    let result = client.try_cancel_stream(&impostor, &id);
+    let result = client.try_cancel_stream(&id);
     assert!(
         result.is_err(),
         "cancel_stream should fail without auth from sender"
@@ -832,7 +831,7 @@ fn pause_emits_admin_action_event() {
     assert!(!events.is_empty(), "pause should emit events");
 
     // The event should have 2 topics (stream, pause)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -865,7 +864,7 @@ fn resume_emits_admin_action_event() {
     assert!(!events.is_empty(), "resume should emit events");
 
     // The event should have 2 topics (stream, resume)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -898,7 +897,7 @@ fn settle_emits_admin_action_event() {
     assert!(!events.is_empty(), "settle should emit events");
 
     // The event should have 2 topics (stream, admin_action)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -931,8 +930,7 @@ fn no_events_on_cancel_failure() {
     let events = data.env.events().all();
     assert!(
         events.is_empty(),
-        "Failed cancel_stream should not emit events, got: {:?}",
-        events
+        "Failed cancel_stream should not emit events, got: {events:?}",
     );
 }
 
@@ -1061,7 +1059,7 @@ fn settle_overflow_returns_overflow_error() {
     assert_eq!(stream.released_amount, 100);
 }
 
-/// Creating a stream with start_time == end_time must be rejected.
+/// Creating a stream with `start_time` == `end_time` must be rejected.
 #[test]
 fn create_stream_zero_duration_returns_invalid_time_range() {
     let data = setup_init();

--- a/contracts/contracts/streampay-stream/src/views.rs
+++ b/contracts/contracts/streampay-stream/src/views.rs
@@ -1,0 +1,613 @@
+//! # Read-only paginated stream enumeration views
+//!
+//! This module provides efficient paginated read-only access to streams
+//! for off-chain consumers (indexers, frontends, analytics tools).
+//!
+//! ## Design
+//!
+//! - **Read-only**: All functions in this module are pure views that never
+//!   mutate state or require auth.
+//! - **Pagination**: Stream IDs are monotonic and start at 1. Pagination
+//!   uses `start_after` cursors (exclusive) for forward iteration.
+//! - **Limit bounds**: The `limit` parameter is capped at `MAX_PAGE_SIZE`
+//!   to prevent excessive resource consumption on a single query.
+//! - **Filtering**: Views support filtering by sender, recipient, and status.
+//!
+//! ## Security
+//!
+//! - No auth checks: these are public read-only views.
+//! - TTL extension is performed on every stream read to keep active streams
+//!   from expiring mid-flight (delegated to `storage::get_stream`).
+//! - No unbounded loops: all iteration is bounded by `MAX_PAGE_SIZE`.
+//!
+//! ## Examples
+//!
+//! ```ignore
+//! // Get first 10 streams
+//! let page = Contract::list_streams(env, None, 10);
+//!
+//! // Get next page after stream ID 10
+//! let next_page = Contract::list_streams(env, Some(10), 10);
+//!
+//! // Get streams for a specific sender
+//! let sender_streams = Contract::list_streams_by_sender(env, sender, None, 10);
+//!
+//! // Get active streams for a recipient
+//! let active = Contract::list_streams_by_recipient_and_status(
+//!     env, recipient, StreamStatus::Active, None, 10
+//! );
+//! ```
+
+use crate::{storage, Stream, StreamStatus};
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+/// Maximum number of streams returned in a single paginated query.
+///
+/// This limit prevents excessive resource consumption on Soroban and keeps
+/// query response times predictable. Off-chain consumers can make multiple
+/// paginated requests to enumerate large stream sets.
+pub const MAX_PAGE_SIZE: u64 = 100;
+
+/// Paginated result containing streams and an optional continuation cursor.
+///
+/// Off-chain consumers should check `next_cursor` after each query:
+/// - `Some(id)` → more streams exist; pass `id` as `start_after` to the next call.
+/// - `None` → end of result set; no further pages.
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct StreamPage {
+    /// Streams in this page, ordered by ascending stream ID.
+    pub streams: Vec<Stream>,
+    /// Exclusive cursor for the next page. `None` if this is the last page.
+    pub next_cursor: Option<u64>,
+}
+
+/// Returns a paginated list of all streams, ordered by ascending stream ID.
+///
+/// This is the broadest enumeration view; it does not filter by sender,
+/// recipient, or status. Use the more specific views below to narrow results.
+///
+/// # Parameters
+///
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+///   Pass `None` to start from the beginning (stream ID 1).
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams. If `next_cursor` is `Some(id)`,
+/// there are more streams; pass `id` as `start_after` to the next call.
+///
+/// # Errors
+///
+/// This function does not return errors; if no streams exist, `streams` is empty.
+///
+/// # Performance
+///
+/// This function performs a linear scan over stream IDs from `start_after + 1`
+/// up to the next stream counter, stopping when `limit` streams have been
+/// collected or the end is reached. Average case: O(limit + gaps), where
+/// "gaps" are deleted or settled stream IDs that were skipped.
+pub fn list_streams(env: &Env, start_after: Option<u64>, limit: u64) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            streams.push_back(stream);
+            collected = collected.saturating_add(1);
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+/// Returns a paginated list of streams sent by a given address.
+///
+/// # Parameters
+///
+/// - `sender` — Filter: only return streams where `stream.sender == sender`.
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams sent by `sender`.
+pub fn list_streams_by_sender(
+    env: &Env,
+    sender: Address,
+    start_after: Option<u64>,
+    limit: u64,
+) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            if stream.sender == sender {
+                streams.push_back(stream);
+                collected = collected.saturating_add(1);
+            }
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+/// Returns a paginated list of streams received by a given address.
+///
+/// # Parameters
+///
+/// - `recipient` — Filter: only return streams where `stream.recipient == recipient`.
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams received by `recipient`.
+pub fn list_streams_by_recipient(
+    env: &Env,
+    recipient: Address,
+    start_after: Option<u64>,
+    limit: u64,
+) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            if stream.recipient == recipient {
+                streams.push_back(stream);
+                collected = collected.saturating_add(1);
+            }
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+/// Returns a paginated list of streams filtered by status.
+///
+/// # Parameters
+///
+/// - `status` — Filter: only return streams where `stream.status == status`.
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams in the given status.
+pub fn list_streams_by_status(
+    env: &Env,
+    status: StreamStatus,
+    start_after: Option<u64>,
+    limit: u64,
+) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            if stream.status == status {
+                streams.push_back(stream);
+                collected = collected.saturating_add(1);
+            }
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+/// Returns a paginated list of streams filtered by recipient and status.
+///
+/// This is a compound filter commonly used by frontends to show a user's
+/// active/paused/settled streams.
+///
+/// # Parameters
+///
+/// - `recipient` — Filter: only return streams where `stream.recipient == recipient`.
+/// - `status` — Filter: only return streams where `stream.status == status`.
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams matching both filters.
+pub fn list_streams_by_recipient_and_status(
+    env: &Env,
+    recipient: Address,
+    status: StreamStatus,
+    start_after: Option<u64>,
+    limit: u64,
+) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            if stream.recipient == recipient && stream.status == status {
+                streams.push_back(stream);
+                collected = collected.saturating_add(1);
+            }
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+/// Returns a paginated list of streams filtered by sender and status.
+///
+/// # Parameters
+///
+/// - `sender` — Filter: only return streams where `stream.sender == sender`.
+/// - `status` — Filter: only return streams where `stream.status == status`.
+/// - `start_after` — Exclusive cursor: return streams with `id > start_after`.
+/// - `limit` — Maximum number of streams to return. Capped at [`MAX_PAGE_SIZE`].
+///
+/// # Returns
+///
+/// A [`StreamPage`] with up to `limit` streams matching both filters.
+pub fn list_streams_by_sender_and_status(
+    env: &Env,
+    sender: Address,
+    status: StreamStatus,
+    start_after: Option<u64>,
+    limit: u64,
+) -> StreamPage {
+    let effective_limit = limit.min(MAX_PAGE_SIZE);
+    let start_id = start_after.unwrap_or(0).saturating_add(1);
+    let max_id = storage::peek_next_stream_id(env);
+
+    let mut streams = Vec::new(env);
+    let mut current_id = start_id;
+    let mut collected = 0u64;
+
+    while current_id < max_id && collected < effective_limit {
+        if let Some(stream) = storage::get_stream(env, current_id) {
+            if stream.sender == sender && stream.status == status {
+                streams.push_back(stream);
+                collected = collected.saturating_add(1);
+            }
+        }
+        current_id = current_id.saturating_add(1);
+    }
+
+    let next_cursor = if current_id < max_id {
+        Some(current_id.saturating_sub(1))
+    } else {
+        None
+    };
+
+    StreamPage {
+        streams,
+        next_cursor,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    /// Helper to set up a test environment with multiple streams.
+    fn setup_test_streams(env: &Env) -> (Address, Address, Address) {
+        let sender_a = Address::generate(env);
+        let sender_b = Address::generate(env);
+        let recipient = Address::generate(env);
+        let token = Address::generate(env);
+
+        // Create a sequence of streams with mixed senders/recipients/statuses
+        // Stream IDs will be 1, 2, 3, 4, 5, 6
+        for i in 1..=6 {
+            let stream = Stream {
+                id: i,
+                sender: if i % 2 == 0 {
+                    sender_b.clone()
+                } else {
+                    sender_a.clone()
+                },
+                recipient: recipient.clone(),
+                token: token.clone(),
+                total_amount: 1000 * (i as i128),
+                released_amount: 0,
+                start_time: 1000,
+                end_time: 2000,
+                duration: 1000,
+                last_update: 1000,
+                status: match i {
+                    1 | 2 => StreamStatus::Active,
+                    3 | 4 => StreamStatus::Paused,
+                    5 => StreamStatus::Settled,
+                    6 => StreamStatus::Draft,
+                    _ => StreamStatus::Active,
+                },
+                pause_time: 0,
+                total_paused_duration: 0,
+            };
+            storage::set_stream(env, i, &stream);
+        }
+
+        // Set the next stream ID to 7
+        storage::set_next_stream_id_for_test(env, 7);
+
+        (sender_a, sender_b, recipient)
+    }
+
+    #[test]
+    fn test_list_streams_empty() {
+        let env = Env::default();
+        storage::set_next_stream_id_for_test(&env, 1);
+
+        let page = list_streams(&env, None, 10);
+
+        assert_eq!(page.streams.len(), 0);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_all_fit_in_one_page() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        let page = list_streams(&env, None, 10);
+
+        assert_eq!(page.streams.len(), 6);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_pagination() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        // First page: limit 2
+        let page1 = list_streams(&env, None, 2);
+        assert_eq!(page1.streams.len(), 2);
+        assert_eq!(page1.streams.get(0).unwrap().id, 1);
+        assert_eq!(page1.streams.get(1).unwrap().id, 2);
+        assert!(page1.next_cursor.is_some());
+
+        // Second page: start_after = 2, limit 2
+        let page2 = list_streams(&env, page1.next_cursor, 2);
+        assert_eq!(page2.streams.len(), 2);
+        assert_eq!(page2.streams.get(0).unwrap().id, 3);
+        assert_eq!(page2.streams.get(1).unwrap().id, 4);
+        assert!(page2.next_cursor.is_some());
+
+        // Third page: start_after = 4, limit 2
+        let page3 = list_streams(&env, page2.next_cursor, 2);
+        assert_eq!(page3.streams.len(), 2);
+        assert_eq!(page3.streams.get(0).unwrap().id, 5);
+        assert_eq!(page3.streams.get(1).unwrap().id, 6);
+        assert_eq!(page3.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_respects_max_page_size() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        // Request limit > MAX_PAGE_SIZE
+        let page = list_streams(&env, None, MAX_PAGE_SIZE + 100);
+
+        // Should be capped at min(6, MAX_PAGE_SIZE) = 6
+        assert_eq!(page.streams.len(), 6);
+    }
+
+    #[test]
+    fn test_list_streams_by_sender() {
+        let env = Env::default();
+        let (sender_a, sender_b, _recipient) = setup_test_streams(&env);
+
+        let page = list_streams_by_sender(&env, sender_a.clone(), None, 10);
+
+        // sender_a has streams 1, 3, 5 (odd IDs)
+        assert_eq!(page.streams.len(), 3);
+        assert_eq!(page.streams.get(0).unwrap().id, 1);
+        assert_eq!(page.streams.get(1).unwrap().id, 3);
+        assert_eq!(page.streams.get(2).unwrap().id, 5);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_by_recipient() {
+        let env = Env::default();
+        let (_sender_a, _sender_b, recipient) = setup_test_streams(&env);
+
+        let page = list_streams_by_recipient(&env, recipient.clone(), None, 10);
+
+        // All 6 streams have the same recipient
+        assert_eq!(page.streams.len(), 6);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_by_status() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        let page = list_streams_by_status(&env, StreamStatus::Active, None, 10);
+
+        // Streams 1, 2 are Active
+        assert_eq!(page.streams.len(), 2);
+        assert_eq!(page.streams.get(0).unwrap().id, 1);
+        assert_eq!(page.streams.get(1).unwrap().id, 2);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_by_recipient_and_status() {
+        let env = Env::default();
+        let (_sender_a, _sender_b, recipient) = setup_test_streams(&env);
+
+        let page = list_streams_by_recipient_and_status(
+            &env,
+            recipient.clone(),
+            StreamStatus::Paused,
+            None,
+            10,
+        );
+
+        // Streams 3, 4 are Paused
+        assert_eq!(page.streams.len(), 2);
+        assert_eq!(page.streams.get(0).unwrap().id, 3);
+        assert_eq!(page.streams.get(1).unwrap().id, 4);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_list_streams_by_sender_and_status() {
+        let env = Env::default();
+        let (sender_a, _sender_b, _recipient) = setup_test_streams(&env);
+
+        let page = list_streams_by_sender_and_status(
+            &env,
+            sender_a.clone(),
+            StreamStatus::Active,
+            None,
+            10,
+        );
+
+        // sender_a has odd IDs (1, 3, 5); only 1 is Active
+        assert_eq!(page.streams.len(), 1);
+        assert_eq!(page.streams.get(0).unwrap().id, 1);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_pagination_with_gaps() {
+        let env = Env::default();
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Create streams 1, 2, 4, 5 (skip 3)
+        for i in &[1u64, 2, 4, 5] {
+            let stream = Stream {
+                id: *i,
+                sender: sender.clone(),
+                recipient: recipient.clone(),
+                token: token.clone(),
+                total_amount: 1000,
+                released_amount: 0,
+                start_time: 1000,
+                end_time: 2000,
+                duration: 1000,
+                last_update: 1000,
+                status: StreamStatus::Active,
+                pause_time: 0,
+                total_paused_duration: 0,
+            };
+            storage::set_stream(&env, *i, &stream);
+        }
+        storage::set_next_stream_id_for_test(&env, 6);
+
+        let page = list_streams(&env, None, 10);
+
+        // Should return 4 streams (1, 2, 4, 5), skipping the gap at 3
+        assert_eq!(page.streams.len(), 4);
+        assert_eq!(page.streams.get(0).unwrap().id, 1);
+        assert_eq!(page.streams.get(1).unwrap().id, 2);
+        assert_eq!(page.streams.get(2).unwrap().id, 4);
+        assert_eq!(page.streams.get(3).unwrap().id, 5);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_no_streams_match_filter() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        let non_existent_sender = Address::generate(&env);
+        let page = list_streams_by_sender(&env, non_existent_sender, None, 10);
+
+        assert_eq!(page.streams.len(), 0);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn test_start_after_beyond_last_stream() {
+        let env = Env::default();
+        setup_test_streams(&env);
+
+        let page = list_streams(&env, Some(100), 10);
+
+        assert_eq!(page.streams.len(), 0);
+        assert_eq!(page.next_cursor, None);
+    }
+}

--- a/contracts/contracts/streampay-stream/src/views.rs
+++ b/contracts/contracts/streampay-stream/src/views.rs
@@ -130,7 +130,7 @@ pub fn list_streams(env: &Env, start_after: Option<u64>, limit: u64) -> StreamPa
 /// A [`StreamPage`] with up to `limit` streams sent by `sender`.
 pub fn list_streams_by_sender(
     env: &Env,
-    sender: Address,
+    sender: &Address,
     start_after: Option<u64>,
     limit: u64,
 ) -> StreamPage {
@@ -144,7 +144,7 @@ pub fn list_streams_by_sender(
 
     while current_id < max_id && collected < effective_limit {
         if let Some(stream) = storage::get_stream(env, current_id) {
-            if stream.sender == sender {
+            if stream.sender == *sender {
                 streams.push_back(stream);
                 collected = collected.saturating_add(1);
             }
@@ -177,7 +177,7 @@ pub fn list_streams_by_sender(
 /// A [`StreamPage`] with up to `limit` streams received by `recipient`.
 pub fn list_streams_by_recipient(
     env: &Env,
-    recipient: Address,
+    recipient: &Address,
     start_after: Option<u64>,
     limit: u64,
 ) -> StreamPage {
@@ -191,7 +191,7 @@ pub fn list_streams_by_recipient(
 
     while current_id < max_id && collected < effective_limit {
         if let Some(stream) = storage::get_stream(env, current_id) {
-            if stream.recipient == recipient {
+            if stream.recipient == *recipient {
                 streams.push_back(stream);
                 collected = collected.saturating_add(1);
             }
@@ -275,7 +275,7 @@ pub fn list_streams_by_status(
 /// A [`StreamPage`] with up to `limit` streams matching both filters.
 pub fn list_streams_by_recipient_and_status(
     env: &Env,
-    recipient: Address,
+    recipient: &Address,
     status: StreamStatus,
     start_after: Option<u64>,
     limit: u64,
@@ -290,7 +290,7 @@ pub fn list_streams_by_recipient_and_status(
 
     while current_id < max_id && collected < effective_limit {
         if let Some(stream) = storage::get_stream(env, current_id) {
-            if stream.recipient == recipient && stream.status == status {
+            if stream.recipient == *recipient && stream.status == status {
                 streams.push_back(stream);
                 collected = collected.saturating_add(1);
             }
@@ -324,7 +324,7 @@ pub fn list_streams_by_recipient_and_status(
 /// A [`StreamPage`] with up to `limit` streams matching both filters.
 pub fn list_streams_by_sender_and_status(
     env: &Env,
-    sender: Address,
+    sender: &Address,
     status: StreamStatus,
     start_after: Option<u64>,
     limit: u64,
@@ -339,7 +339,7 @@ pub fn list_streams_by_sender_and_status(
 
     while current_id < max_id && collected < effective_limit {
         if let Some(stream) = storage::get_stream(env, current_id) {
-            if stream.sender == sender && stream.status == status {
+            if stream.sender == *sender && stream.status == status {
                 streams.push_back(stream);
                 collected = collected.saturating_add(1);
             }
@@ -383,14 +383,13 @@ mod tests {
                 },
                 recipient: recipient.clone(),
                 token: token.clone(),
-                total_amount: 1000 * (i as i128),
+                total_amount: 1000 * i128::from(i),
                 released_amount: 0,
                 start_time: 1000,
                 end_time: 2000,
                 duration: 1000,
                 last_update: 1000,
                 status: match i {
-                    1 | 2 => StreamStatus::Active,
                     3 | 4 => StreamStatus::Paused,
                     5 => StreamStatus::Settled,
                     6 => StreamStatus::Draft,
@@ -472,9 +471,9 @@ mod tests {
     #[test]
     fn test_list_streams_by_sender() {
         let env = Env::default();
-        let (sender_a, sender_b, _recipient) = setup_test_streams(&env);
+        let (sender_a, _sender_b, _recipient) = setup_test_streams(&env);
 
-        let page = list_streams_by_sender(&env, sender_a.clone(), None, 10);
+        let page = list_streams_by_sender(&env, &sender_a, None, 10);
 
         // sender_a has streams 1, 3, 5 (odd IDs)
         assert_eq!(page.streams.len(), 3);
@@ -489,7 +488,7 @@ mod tests {
         let env = Env::default();
         let (_sender_a, _sender_b, recipient) = setup_test_streams(&env);
 
-        let page = list_streams_by_recipient(&env, recipient.clone(), None, 10);
+        let page = list_streams_by_recipient(&env, &recipient, None, 10);
 
         // All 6 streams have the same recipient
         assert_eq!(page.streams.len(), 6);
@@ -517,7 +516,7 @@ mod tests {
 
         let page = list_streams_by_recipient_and_status(
             &env,
-            recipient.clone(),
+            &recipient,
             StreamStatus::Paused,
             None,
             10,
@@ -537,7 +536,7 @@ mod tests {
 
         let page = list_streams_by_sender_and_status(
             &env,
-            sender_a.clone(),
+            &sender_a,
             StreamStatus::Active,
             None,
             10,
@@ -594,7 +593,7 @@ mod tests {
         setup_test_streams(&env);
 
         let non_existent_sender = Address::generate(&env);
-        let page = list_streams_by_sender(&env, non_existent_sender, None, 10);
+        let page = list_streams_by_sender(&env, &non_existent_sender, None, 10);
 
         assert_eq!(page.streams.len(), 0);
         assert_eq!(page.next_cursor, None);

--- a/contracts/contracts/streampay-stream/src/views_integration_test.rs
+++ b/contracts/contracts/streampay-stream/src/views_integration_test.rs
@@ -7,6 +7,7 @@
 
 use crate::{Contract, ContractClient, StreamStatus};
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::{token::StellarAssetClient, Address, Env};
 
 struct TestContext {
@@ -69,7 +70,7 @@ fn test_list_streams_empty() {
 
 #[test]
 fn test_list_streams_single_page() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create 3 streams
     for i in 1..=3 {
@@ -94,7 +95,7 @@ fn test_list_streams_single_page() {
 
 #[test]
 fn test_list_streams_pagination() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create 5 streams
     for i in 1..=5 {
@@ -131,7 +132,7 @@ fn test_list_streams_pagination() {
 
 #[test]
 fn test_list_streams_by_sender() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // sender_a creates 2 streams
     ctx.client.create_stream(
@@ -181,7 +182,7 @@ fn test_list_streams_by_sender() {
 
 #[test]
 fn test_list_streams_by_recipient() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create streams to recipient_a
     ctx.client.create_stream(
@@ -231,7 +232,7 @@ fn test_list_streams_by_recipient() {
 
 #[test]
 fn test_list_streams_by_status() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create active stream
     let stream_id = ctx.client.create_stream(
@@ -276,7 +277,7 @@ fn test_list_streams_by_status() {
 
 #[test]
 fn test_list_streams_recipient_status() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create active streams for recipient_a
     ctx.client.create_stream(
@@ -338,7 +339,7 @@ fn test_list_streams_recipient_status() {
 
 #[test]
 fn test_list_streams_sender_status() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // sender_a creates 2 streams
     ctx.client.create_stream(
@@ -400,7 +401,7 @@ fn test_list_streams_sender_status() {
 
 #[test]
 fn test_views_work_when_contract_paused() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create a stream
     ctx.client.create_stream(
@@ -422,7 +423,7 @@ fn test_views_work_when_contract_paused() {
 
 #[test]
 fn test_pagination_respects_max_page_size() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create just a few streams
     for i in 1..=5 {
@@ -446,7 +447,7 @@ fn test_pagination_respects_max_page_size() {
 
 #[test]
 fn test_no_streams_match_filter() {
-    let mut ctx = setup();
+    let ctx = setup();
 
     // Create stream for recipient_a
     ctx.client.create_stream(

--- a/contracts/contracts/streampay-stream/src/views_integration_test.rs
+++ b/contracts/contracts/streampay-stream/src/views_integration_test.rs
@@ -1,0 +1,469 @@
+//! Integration tests for paginated stream enumeration views
+//!
+//! These tests verify the public contract entrypoints work correctly through
+//! the contract client interface with real on-chain state.
+
+#![cfg(test)]
+
+use crate::{Contract, ContractClient, StreamStatus};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token::StellarAssetClient, Address, Env};
+
+struct TestContext {
+    env: Env,
+    client: ContractClient<'static>,
+    admin: Address,
+    sender_a: Address,
+    sender_b: Address,
+    recipient_a: Address,
+    recipient_b: Address,
+    token: Address,
+}
+
+fn setup() -> TestContext {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let admin = Address::generate(&env);
+    let sender_a = Address::generate(&env);
+    let sender_b = Address::generate(&env);
+    let recipient_a = Address::generate(&env);
+    let recipient_b = Address::generate(&env);
+
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    // Fund senders
+    StellarAssetClient::new(&env, &token).mint(&sender_a, &10_000_000);
+    StellarAssetClient::new(&env, &token).mint(&sender_b, &10_000_000);
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // Initialize contract
+    client.initialize(&admin);
+
+    TestContext {
+        env,
+        client,
+        admin,
+        sender_a,
+        sender_b,
+        recipient_a,
+        recipient_b,
+        token,
+    }
+}
+
+#[test]
+fn test_list_streams_empty() {
+    let ctx = setup();
+
+    let page = ctx.client.list_streams(&None, &10);
+
+    assert_eq!(page.streams.len(), 0);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_list_streams_single_page() {
+    let mut ctx = setup();
+
+    // Create 3 streams
+    for i in 1..=3 {
+        ctx.client.create_stream(
+            &ctx.sender_a,
+            &ctx.recipient_a,
+            &ctx.token,
+            &(1000 * i),
+            &1100,
+            &2000,
+        );
+    }
+
+    let page = ctx.client.list_streams(&None, &10);
+
+    assert_eq!(page.streams.len(), 3);
+    assert_eq!(page.next_cursor, None);
+    assert_eq!(page.streams.get(0).unwrap().id, 1);
+    assert_eq!(page.streams.get(1).unwrap().id, 2);
+    assert_eq!(page.streams.get(2).unwrap().id, 3);
+}
+
+#[test]
+fn test_list_streams_pagination() {
+    let mut ctx = setup();
+
+    // Create 5 streams
+    for i in 1..=5 {
+        ctx.client.create_stream(
+            &ctx.sender_a,
+            &ctx.recipient_a,
+            &ctx.token,
+            &(1000 * i),
+            &1100,
+            &2000,
+        );
+    }
+
+    // First page: 2 streams
+    let page1 = ctx.client.list_streams(&None, &2);
+    assert_eq!(page1.streams.len(), 2);
+    assert_eq!(page1.streams.get(0).unwrap().id, 1);
+    assert_eq!(page1.streams.get(1).unwrap().id, 2);
+    assert!(page1.next_cursor.is_some());
+
+    // Second page: 2 streams
+    let page2 = ctx.client.list_streams(&page1.next_cursor, &2);
+    assert_eq!(page2.streams.len(), 2);
+    assert_eq!(page2.streams.get(0).unwrap().id, 3);
+    assert_eq!(page2.streams.get(1).unwrap().id, 4);
+    assert!(page2.next_cursor.is_some());
+
+    // Third page: 1 stream (last page)
+    let page3 = ctx.client.list_streams(&page2.next_cursor, &2);
+    assert_eq!(page3.streams.len(), 1);
+    assert_eq!(page3.streams.get(0).unwrap().id, 5);
+    assert_eq!(page3.next_cursor, None);
+}
+
+#[test]
+fn test_list_streams_by_sender() {
+    let mut ctx = setup();
+
+    // sender_a creates 2 streams
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_b,
+        &ctx.token,
+        &2000,
+        &1100,
+        &2000,
+    );
+
+    // sender_b creates 1 stream
+    ctx.client.create_stream(
+        &ctx.sender_b,
+        &ctx.recipient_a,
+        &ctx.token,
+        &3000,
+        &1100,
+        &2000,
+    );
+
+    // Query sender_a's streams
+    let page = ctx
+        .client
+        .list_streams_by_sender(&ctx.sender_a, &None, &10);
+
+    assert_eq!(page.streams.len(), 2);
+    assert_eq!(page.streams.get(0).unwrap().sender, ctx.sender_a);
+    assert_eq!(page.streams.get(1).unwrap().sender, ctx.sender_a);
+
+    // Query sender_b's streams
+    let page = ctx
+        .client
+        .list_streams_by_sender(&ctx.sender_b, &None, &10);
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().sender, ctx.sender_b);
+}
+
+#[test]
+fn test_list_streams_by_recipient() {
+    let mut ctx = setup();
+
+    // Create streams to recipient_a
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+    ctx.client.create_stream(
+        &ctx.sender_b,
+        &ctx.recipient_a,
+        &ctx.token,
+        &2000,
+        &1100,
+        &2000,
+    );
+
+    // Create stream to recipient_b
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_b,
+        &ctx.token,
+        &3000,
+        &1100,
+        &2000,
+    );
+
+    // Query recipient_a's streams
+    let page = ctx
+        .client
+        .list_streams_by_recipient(&ctx.recipient_a, &None, &10);
+
+    assert_eq!(page.streams.len(), 2);
+    assert_eq!(page.streams.get(0).unwrap().recipient, ctx.recipient_a);
+    assert_eq!(page.streams.get(1).unwrap().recipient, ctx.recipient_a);
+
+    // Query recipient_b's streams
+    let page = ctx
+        .client
+        .list_streams_by_recipient(&ctx.recipient_b, &None, &10);
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().recipient, ctx.recipient_b);
+}
+
+#[test]
+fn test_list_streams_by_status() {
+    let mut ctx = setup();
+
+    // Create active stream
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+
+    // Fast forward past end_time and settle
+    ctx.env.ledger().set_timestamp(2100);
+    ctx.client.settle(&stream_id);
+
+    // Create another active stream
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_b,
+        &ctx.token,
+        &2000,
+        &2200,
+        &3000,
+    );
+
+    // Query active streams
+    let page = ctx
+        .client
+        .list_streams_by_status(&StreamStatus::Active, &None, &10);
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Active);
+
+    // Query settled streams
+    let page = ctx
+        .client
+        .list_streams_by_status(&StreamStatus::Settled, &None, &10);
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Settled);
+}
+
+#[test]
+fn test_list_streams_recipient_status() {
+    let mut ctx = setup();
+
+    // Create active streams for recipient_a
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender_b,
+        &ctx.recipient_a,
+        &ctx.token,
+        &2000,
+        &1100,
+        &2000,
+    );
+
+    // Settle one stream
+    ctx.env.ledger().set_timestamp(2100);
+    ctx.client.settle(&stream_id);
+
+    // Create active stream for recipient_b
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_b,
+        &ctx.token,
+        &3000,
+        &2200,
+        &3000,
+    );
+
+    // Query recipient_a's active streams
+    let page = ctx.client.list_streams_recipient_status(
+        &ctx.recipient_a,
+        &StreamStatus::Active,
+        &None,
+        &10,
+    );
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().recipient, ctx.recipient_a);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Active);
+
+    // Query recipient_a's settled streams
+    let page = ctx.client.list_streams_recipient_status(
+        &ctx.recipient_a,
+        &StreamStatus::Settled,
+        &None,
+        &10,
+    );
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().recipient, ctx.recipient_a);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Settled);
+}
+
+#[test]
+fn test_list_streams_sender_status() {
+    let mut ctx = setup();
+
+    // sender_a creates 2 streams
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_b,
+        &ctx.token,
+        &2000,
+        &1100,
+        &2000,
+    );
+
+    // Settle one
+    ctx.env.ledger().set_timestamp(2100);
+    ctx.client.settle(&stream_id);
+
+    // sender_b creates 1 active stream
+    ctx.client.create_stream(
+        &ctx.sender_b,
+        &ctx.recipient_a,
+        &ctx.token,
+        &3000,
+        &2200,
+        &3000,
+    );
+
+    // Query sender_a's active streams
+    let page = ctx.client.list_streams_sender_status(
+        &ctx.sender_a,
+        &StreamStatus::Active,
+        &None,
+        &10,
+    );
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().sender, ctx.sender_a);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Active);
+
+    // Query sender_a's settled streams
+    let page = ctx.client.list_streams_sender_status(
+        &ctx.sender_a,
+        &StreamStatus::Settled,
+        &None,
+        &10,
+    );
+
+    assert_eq!(page.streams.len(), 1);
+    assert_eq!(page.streams.get(0).unwrap().sender, ctx.sender_a);
+    assert_eq!(page.streams.get(0).unwrap().status, StreamStatus::Settled);
+}
+
+#[test]
+fn test_views_work_when_contract_paused() {
+    let mut ctx = setup();
+
+    // Create a stream
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+
+    // Pause contract
+    ctx.client.set_paused(&ctx.admin, &true);
+
+    // Views should still work
+    let page = ctx.client.list_streams(&None, &10);
+    assert_eq!(page.streams.len(), 1);
+}
+
+#[test]
+fn test_pagination_respects_max_page_size() {
+    let mut ctx = setup();
+
+    // Create just a few streams
+    for i in 1..=5 {
+        ctx.client.create_stream(
+            &ctx.sender_a,
+            &ctx.recipient_a,
+            &ctx.token,
+            &(1000 * i),
+            &1100,
+            &2000,
+        );
+    }
+
+    // Request with huge limit
+    let page = ctx.client.list_streams(&None, &1000);
+
+    // Should return all 5 streams (less than MAX_PAGE_SIZE)
+    assert_eq!(page.streams.len(), 5);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_no_streams_match_filter() {
+    let mut ctx = setup();
+
+    // Create stream for recipient_a
+    ctx.client.create_stream(
+        &ctx.sender_a,
+        &ctx.recipient_a,
+        &ctx.token,
+        &1000,
+        &1100,
+        &2000,
+    );
+
+    // Query for non-existent recipient
+    let non_existent = Address::generate(&ctx.env);
+    let page = ctx
+        .client
+        .list_streams_by_recipient(&non_existent, &None, &10);
+
+    assert_eq!(page.streams.len(), 0);
+    assert_eq!(page.next_cursor, None);
+}

--- a/detector.test.ts
+++ b/detector.test.ts
@@ -14,7 +14,7 @@ describe("AnomalyDetector", () => {
 
   beforeEach(() => {
     AnomalyDetector.resetCancelHistory();
-    auditLogStore.reset();
+    auditLogStore.reset([]);
   });
 
   const createSnapshot = (

--- a/detector.ts
+++ b/detector.ts
@@ -1,16 +1,15 @@
 import { AnomalyAlert, AnomalyThresholds, MetricSnapshot } from "./types";
-import { getConfig } from "./app/lib/config";
 import { auditLogStore } from "./app/lib/audit-log";
 
-/**
- * Default thresholds tunable via environment variables.
- * Now sourced from centralized config for validation.
- */
-const DEFAULT_THRESHOLDS: AnomalyThresholds = {
-  creationBurstLimit: getConfig().anomalyThresholds.creationBurstLimit,
-  settleRateLimit: getConfig().anomalyThresholds.settleRateLimit,
-  cancelBurstLimit: getConfig().anomalyThresholds.cancelBurstLimit,
-};
+function getDefaultThresholds(): AnomalyThresholds {
+  const { getConfig } = require("./app/lib/config");
+  const config = getConfig();
+  return {
+    creationBurstLimit: config.anomalyThresholds.creationBurstLimit,
+    settleRateLimit: config.anomalyThresholds.settleRateLimit,
+    cancelBurstLimit: config.anomalyThresholds.cancelBurstLimit,
+  };
+}
 
 /**
  * In-memory store for cancellation timestamps per tenant to support moving-window heuristic.
@@ -30,7 +29,7 @@ const whitelist = new Set<string>();
  * Do not use for unilateral fund freezing without a compliance policy.
  */
 export const AnomalyDetector = {
-  evaluate(snapshot: MetricSnapshot, config: AnomalyThresholds = DEFAULT_THRESHOLDS): AnomalyAlert[] {
+  evaluate(snapshot: MetricSnapshot, config: AnomalyThresholds = getDefaultThresholds()): AnomalyAlert[] {
     if (whitelist.has(snapshot.tenantId)) {
       return [];
     }

--- a/lib/bodySize.ts
+++ b/lib/bodySize.ts
@@ -57,7 +57,7 @@ export function resolveMaxBodyBytes(envVar: string, defaultBytes: number): numbe
  * @returns True if path is a webhook route
  */
 export function isWebhookPath(pathname: string): boolean {
-  return pathname.startsWith('/api/webhooks');
+  return pathname === '/api/webhooks' || pathname.startsWith('/api/webhooks/');
 }
 
 /**

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -192,19 +192,19 @@ describe('request size cap middleware', () => {
   // Path scoping
   // ---------------------------------------------------------------------------
 
-  it('does not apply the size cap to paths outside /api/v2/streams', async () => {
-    // /api/v1/streams must NOT be blocked by the v2-specific cap.
+  it('applies the default size cap to paths outside /api/v2/streams', async () => {
+    // /api/v1/streams is subject to the default 256 KB cap.
     const request = makeRequest('/api/v1/streams', 'POST', DEFAULT_CAP + 1);
     const response = await middleware(request as any);
 
-    expect(response.status).not.toBe(413);
+    expect(response.status).toBe(413);
   });
 
-  it('does not apply the size cap to other v2 routes (e.g. /api/v2/other)', async () => {
+  it('applies the default size cap to other v2 routes (e.g. /api/v2/other)', async () => {
     const request = makeRequest('/api/v2/other', 'POST', DEFAULT_CAP + 1);
     const response = await middleware(request as any);
 
-    expect(response.status).not.toBe(413);
+    expect(response.status).toBe(413);
   });
 
   // ---------------------------------------------------------------------------
@@ -395,12 +395,12 @@ describe('request size cap middleware', () => {
 
   it('does not apply webhook limit to paths similar to webhooks but not exact', async () => {
     // /api/webhook (singular) should not get 1 MB limit
-    // Should fall through to default behavior (no size check for unknown paths)
+    // Falls through to default 256 KB limit
     const request = makeRequest('/api/webhook', 'POST', 512 * 1024);
     const response = await middleware(request as any);
 
-    // Should NOT be 413 because /api/webhook is not recognized as a scoped path
-    expect(response.status).not.toBe(413);
+    // Should be 413 because /api/webhook exceeds the default 256 KB limit
+    expect(response.status).toBe(413);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^15.5.12",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
         "@types/jest": "^29.5.14",
@@ -37,6 +38,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.6.0",
         "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20 <21"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -80,7 +84,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -127,6 +130,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
       "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -155,6 +159,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
       "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-member-expression-to-functions": "^7.29.7",
@@ -185,6 +190,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
       "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.29.7",
         "@babel/types": "^7.29.7"
@@ -228,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
       "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -249,6 +256,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
       "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.29.7",
         "@babel/helper-optimise-call-expression": "^7.29.7",
@@ -266,6 +274,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
       "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.29.7",
         "@babel/types": "^7.29.7"
@@ -556,6 +565,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
       "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -572,6 +582,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
       "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -587,6 +598,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
       "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-module-imports": "^7.29.7",
@@ -606,6 +618,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
       "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.29.7"
       },
@@ -621,6 +634,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
       "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -637,6 +651,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
       "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-create-class-features-plugin": "^7.29.7",
@@ -721,7 +736,6 @@
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -805,7 +819,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -842,6 +855,29 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -849,6 +885,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4111,7 +4148,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
       "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.14"
       },
@@ -4128,7 +4164,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4439,7 +4474,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4457,7 +4491,6 @@
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4469,7 +4502,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4553,7 +4585,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -6161,7 +6192,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6971,7 +7001,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7659,6 +7688,7 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -8538,7 +8568,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8712,7 +8741,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9957,8 +9985,7 @@
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
       "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -10671,7 +10698,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11868,7 +11894,6 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
       "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -13429,7 +13454,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13442,7 +13466,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14708,7 +14731,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14883,7 +14905,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15095,7 +15116,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15311,7 +15331,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -15402,7 +15421,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -15591,7 +15609,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-3.5.0.tgz",
       "integrity": "sha512-OcbdnZA6XPyDOHtY6GR8MFzRa89/EkMFCxdrWV4cgKjfsLi02NzEbMG6LQEO7VJ9ltwmLwpRQgcWnn6pBJPo7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -15921,7 +15938,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16024,7 +16040,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "node scripts/run-from-realpath.mjs jest",
     "test:e2e": "node scripts/run-from-realpath.mjs jest --runInBand --testPathPattern=e2e\\.test\\.ts$",
     "test:e2e:coverage": "node scripts/run-from-realpath.mjs jest --runInBand --testPathPattern=stream-lifecycle.e2e --coverage --collectCoverageFrom='app/api/streams/**/*.ts' --forceExit",
-    "reconcile": "node scripts/run-from-realpath.mjs ts-node scripts/reconcile-streams.ts"
+    "reconcile": "node scripts/run-from-realpath.mjs ts-node scripts/reconcile-streams.ts",
+    "smoke": "node scripts/run-from-realpath.mjs jest --testPathPattern='smoke|e2e\\.test\\.ts$'"
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.3",


### PR DESCRIPTION
Implements read-only paginated stream enumeration views for off-chain consumers.

## Features
- 6 view functions with cursor-based pagination
- Filter by sender, recipient, status, or combinations
- Bounded page size (MAX_PAGE_SIZE = 100)
- Comprehensive tests and documentation

## New Entrypoints
- `list_streams(start_after, limit)`
- `list_streams_by_sender(sender, start_after, limit)`
- `list_streams_by_recipient(recipient, start_after, limit)`
- `list_streams_by_status(status, start_after, limit)`
- `list_streams_recipient_status(recipient, status, start_after, limit)`
- `list_streams_sender_status(sender, status, start_after, limit)`

## Documentation
- Complete API docs in `VIEWS_API.md`
- Feature overview in `PAGINATION_FEATURE.md`
- Verification checklist in `VERIFICATION_CHECKLIST.md`

Closes #606