### PR TITLE
test: add invalid resume state coverage

### DIFF
--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -870,6 +870,28 @@ fn resume_emits_admin_action_event() {
 }
 
 #[test]
+fn resume_without_pause_returns_invalid_state() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+
+    client.initialize(&data.admin);
+
+    let id = client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &1000i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    let result = client.try_resume(&id);
+
+    let err = result.expect_err("resume should fail for active stream");
+    assert_eq!(err, Ok(Error::InvalidState));
+}
+
+#[test]
 fn settle_emits_admin_action_event() {
     let data = setup_init();
     let client = contract_client(&data.env);


### PR DESCRIPTION
## Summary

- Add a regression test to verify `resume()` returns `Error::InvalidState` when called on a stream that is not paused.
- Improve state-machine test coverage for the resume entrypoint.
- No production logic changes.

## Testing

- [x] cargo test


Closes #624 