### PR TITLE
feat: per-recipient receipt customisation

### DIFF
--- a/app/lib/receipt-theme.test.ts
+++ b/app/lib/receipt-theme.test.ts
@@ -1,0 +1,72 @@
+import {
+  DEFAULT_ACCENT_COLOR,
+  MAX_MESSAGE_LENGTH,
+  isSafeLogoUrl,
+  isValidAccentColor,
+  normalizeReceiptTheme,
+} from "./receipt-theme";
+
+describe("receipt-theme", () => {
+  describe("isValidAccentColor", () => {
+    it("accepts 3- and 6-digit hex colours", () => {
+      expect(isValidAccentColor("#fff")).toBe(true);
+      expect(isValidAccentColor("#1f6feb")).toBe(true);
+    });
+
+    it("rejects malformed colours", () => {
+      expect(isValidAccentColor("red")).toBe(false);
+      expect(isValidAccentColor("#1234")).toBe(false);
+      expect(isValidAccentColor(null)).toBe(false);
+      expect(isValidAccentColor(undefined)).toBe(false);
+    });
+  });
+
+  describe("isSafeLogoUrl", () => {
+    it("accepts https URLs only", () => {
+      expect(isSafeLogoUrl("https://cdn.example.com/logo.png")).toBe(true);
+    });
+
+    it("rejects unsafe or non-https URLs", () => {
+      expect(isSafeLogoUrl("http://example.com/logo.png")).toBe(false);
+      expect(isSafeLogoUrl("javascript:alert(1)")).toBe(false);
+      expect(isSafeLogoUrl("data:image/png;base64,AAAA")).toBe(false);
+      expect(isSafeLogoUrl("not a url")).toBe(false);
+      expect(isSafeLogoUrl("")).toBe(false);
+    });
+  });
+
+  describe("normalizeReceiptTheme", () => {
+    it("falls back to defaults for empty input", () => {
+      const theme = normalizeReceiptTheme();
+      expect(theme.accentColor).toBe(DEFAULT_ACCENT_COLOR);
+      expect(theme.logoUrl).toBeUndefined();
+      expect(theme.message).toBeUndefined();
+    });
+
+    it("keeps valid customisation and lowercases the colour", () => {
+      const theme = normalizeReceiptTheme({
+        logoUrl: "https://cdn.example.com/logo.png",
+        accentColor: "#AABBCC",
+        message: "  Thanks!  ",
+      });
+      expect(theme.logoUrl).toBe("https://cdn.example.com/logo.png");
+      expect(theme.accentColor).toBe("#aabbcc");
+      expect(theme.message).toBe("Thanks!");
+    });
+
+    it("drops unsafe logo URLs and invalid colours", () => {
+      const theme = normalizeReceiptTheme({
+        logoUrl: "http://insecure/logo.png",
+        accentColor: "purple",
+      });
+      expect(theme.logoUrl).toBeUndefined();
+      expect(theme.accentColor).toBe(DEFAULT_ACCENT_COLOR);
+    });
+
+    it("truncates overly long messages with an ellipsis", () => {
+      const theme = normalizeReceiptTheme({ message: "a".repeat(200) });
+      expect(theme.message).toHaveLength(MAX_MESSAGE_LENGTH);
+      expect(theme.message?.endsWith("…")).toBe(true);
+    });
+  });
+});

--- a/app/lib/receipt-theme.ts
+++ b/app/lib/receipt-theme.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-recipient receipt customisation.
+ *
+ * Lets a recipient brand the receipt they receive with their own logo,
+ * accent colour and a short thank-you message. The theme is fully
+ * validated and normalised here so that UI components can render it
+ * without re-checking untrusted input.
+ */
+
+/** Raw, possibly-untrusted customisation supplied by a recipient. */
+export type ReceiptThemeInput = {
+  /** Absolute https URL of a logo image. */
+  logoUrl?: string | null;
+  /** Hex accent colour, e.g. "#1f6feb". */
+  accentColor?: string | null;
+  /** Short message shown on the receipt, e.g. "Thanks for your support!". */
+  message?: string | null;
+};
+
+/** Validated, render-ready receipt theme. */
+export type ReceiptTheme = {
+  logoUrl?: string;
+  accentColor: string;
+  message?: string;
+};
+
+/** Default StreamPay brand accent used when a recipient sets none. */
+export const DEFAULT_ACCENT_COLOR = "#1f6feb";
+
+/** Messages longer than this are truncated to keep receipts tidy. */
+export const MAX_MESSAGE_LENGTH = 140;
+
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/** True for a syntactically valid 3- or 6-digit hex colour. */
+export function isValidAccentColor(value: string | null | undefined): boolean {
+  return typeof value === "string" && HEX_COLOR.test(value.trim());
+}
+
+/** True only for absolute https URLs (blocks http, data:, javascript:, …). */
+export function isSafeLogoUrl(value: string | null | undefined): boolean {
+  if (typeof value !== "string" || value.trim() === "") return false;
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalise untrusted recipient input into a render-ready theme.
+ * Invalid logo URLs and colours fall back to safe defaults, and the
+ * message is trimmed and length-capped.
+ */
+export function normalizeReceiptTheme(input: ReceiptThemeInput = {}): ReceiptTheme {
+  const theme: ReceiptTheme = {
+    accentColor: isValidAccentColor(input.accentColor)
+      ? input.accentColor!.trim().toLowerCase()
+      : DEFAULT_ACCENT_COLOR,
+  };
+
+  if (isSafeLogoUrl(input.logoUrl)) {
+    theme.logoUrl = input.logoUrl!.trim();
+  }
+
+  const message = typeof input.message === "string" ? input.message.trim() : "";
+  if (message) {
+    theme.message =
+      message.length > MAX_MESSAGE_LENGTH
+        ? `${message.slice(0, MAX_MESSAGE_LENGTH - 1).trimEnd()}…`
+        : message;
+  }
+
+  return theme;
+}


### PR DESCRIPTION
Closes #714.

Adds a `receipt-theme` module that lets recipients brand their receipts with a logo, accent colour and a short message. Untrusted input is validated and normalised (https-only logos, hex-only accent colours, length-capped messages) so UI components can render the theme safely. Includes focused unit tests.