### PR TITLE
feat: anonymous read-only receipt share

### DIFF
--- a/app/lib/anon-receipt.test.ts
+++ b/app/lib/anon-receipt.test.ts
@@ -1,0 +1,58 @@
+import type { Stream } from "../types/openapi";
+import { maskAddress, toAnonymousReceipt } from "./anon-receipt";
+
+const baseStream: Stream = {
+  id: "stream-123",
+  recipient: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+  rate: "100",
+  schedule: "monthly",
+  status: "active",
+  email: "alice@example.com",
+  label: "Salary",
+  memo: "March payout",
+  partnerId: "partner-9",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-02-01T00:00:00.000Z",
+  token: "XLM",
+  senderAddress: "GZYXWVUTSRQPONMLKJIHGFEDCBA765432",
+};
+
+describe("anon-receipt", () => {
+  describe("maskAddress", () => {
+    it("masks a full address to prefix/suffix", () => {
+      expect(maskAddress("GABCDEFGHIJKLMNOP")).toBe("GABC…MNOP");
+    });
+
+    it("collapses short or missing values", () => {
+      expect(maskAddress("GABC1234")).toBe("•••");
+      expect(maskAddress("")).toBe("•••");
+      expect(maskAddress(undefined)).toBe("•••");
+    });
+  });
+
+  describe("toAnonymousReceipt", () => {
+    it("strips all PII fields", () => {
+      const receipt = toAnonymousReceipt(baseStream) as Record<string, unknown>;
+      expect(receipt).not.toHaveProperty("email");
+      expect(receipt).not.toHaveProperty("label");
+      expect(receipt).not.toHaveProperty("memo");
+      expect(receipt).not.toHaveProperty("partnerId");
+      expect(receipt).not.toHaveProperty("recipient");
+      expect(receipt).not.toHaveProperty("senderAddress");
+    });
+
+    it("masks recipient and sender addresses", () => {
+      const receipt = toAnonymousReceipt(baseStream);
+      expect(receipt.recipientMasked).toBe("GABC…4567");
+      expect(receipt.senderMasked).toBe("GZYX…5432");
+    });
+
+    it("marks the receipt as read-only and omits sender when absent", () => {
+      const { senderAddress, ...noSender } = baseStream;
+      void senderAddress;
+      const receipt = toAnonymousReceipt(noSender as Stream);
+      expect(receipt.readonly).toBe(true);
+      expect(receipt.senderMasked).toBeUndefined();
+    });
+  });
+});

--- a/app/lib/anon-receipt.ts
+++ b/app/lib/anon-receipt.ts
@@ -1,0 +1,60 @@
+/**
+ * Anonymous read-only receipt sharing.
+ *
+ * Produces a redacted, read-only projection of a stream receipt that is
+ * safe to share publicly: wallet addresses are masked to short prefixes
+ * and all PII (email, label, memo, partner id) is stripped. The result
+ * carries no `nextAction`, signalling that the view is read-only.
+ */
+
+import type { Stream } from "../types/openapi";
+
+/** A redacted, read-only receipt with no recoverable addresses or PII. */
+export type AnonymousReceipt = {
+  id: string;
+  recipientMasked: string;
+  senderMasked?: string;
+  rate: string;
+  schedule: string;
+  status: Stream["status"];
+  token: string;
+  createdAt: string;
+  updatedAt: string;
+  readonly: true;
+};
+
+/**
+ * Mask a Stellar address to a short, non-reversible prefix/suffix form,
+ * e.g. "GABC…WXYZ". Short or empty values collapse to a generic mask.
+ */
+export function maskAddress(address: string | undefined | null): string {
+  if (typeof address !== "string") return "•••";
+  const trimmed = address.trim();
+  if (trimmed.length <= 9) return trimmed ? "•••" : "•••";
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
+}
+
+/**
+ * Build a shareable, read-only receipt from a full stream. Drops every
+ * PII field and replaces addresses with masked prefixes so the receipt
+ * can be shared without exposing the parties involved.
+ */
+export function toAnonymousReceipt(stream: Stream): AnonymousReceipt {
+  const receipt: AnonymousReceipt = {
+    id: stream.id,
+    recipientMasked: maskAddress(stream.recipient),
+    rate: stream.rate,
+    schedule: stream.schedule,
+    status: stream.status,
+    token: stream.token,
+    createdAt: stream.createdAt,
+    updatedAt: stream.updatedAt,
+    readonly: true,
+  };
+
+  if (stream.senderAddress) {
+    receipt.senderMasked = maskAddress(stream.senderAddress);
+  }
+
+  return receipt;
+}


### PR DESCRIPTION
Closes #713.

Adds an `anon-receipt` module that projects a stream into a redacted, read-only receipt safe for public sharing. Wallet addresses are masked to short prefixes and all PII (email, label, memo, partnerId) is stripped; the result is flagged read-only. Includes unit tests covering masking and PII removal.