### PR TITLE
feat: expose remaining per-sender stream capacity

### DIFF
--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -317,6 +317,12 @@ impl Contract {
         limits::get_sender_stream_count(&env, &sender)
     }
 
+    /// Returns how many more streams `sender` may create before reaching the
+    /// configured per-sender limit (`0` once the limit is reached).
+    pub fn remaining_sender_capacity(env: Env, sender: Address) -> u64 {
+        limits::remaining_sender_capacity(&env, &sender)
+    }
+
     /// Creates a funded stream and escrows `total_amount` from `sender`.
     ///
     /// **Token transfer**: `total_amount` is transferred from `sender` to the

--- a/contracts/contracts/streampay-stream/src/limits.rs
+++ b/contracts/contracts/streampay-stream/src/limits.rs
@@ -102,3 +102,15 @@ pub fn check_sender_limit(env: &Env, sender: &Address) -> Result<(), Error> {
     }
     Ok(())
 }
+
+/// Returns how many additional streams `sender` may still create before
+/// hitting the configured per-sender limit.
+///
+/// Returns `0` once the sender is at or above the limit, so callers can
+/// surface remaining capacity in a UI without performing their own
+/// overflow-safe subtraction.
+pub fn remaining_sender_capacity(env: &Env, sender: &Address) -> u64 {
+    let limit = get_max_streams_per_sender(env);
+    let current = get_sender_stream_count(env, sender);
+    limit.saturating_sub(current)
+}

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -399,6 +399,50 @@ fn create_stream_beyond_limit_returns_stream_limit_exceeded() {
 }
 
 #[test]
+fn remaining_capacity_tracks_active_streams() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+
+    client.initialize(&data.admin);
+
+    // Full capacity before any stream exists.
+    assert_eq!(client.remaining_sender_capacity(&data.sender), 10);
+
+    client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &100i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    // One stream consumed ⇒ nine remaining.
+    assert_eq!(client.remaining_sender_capacity(&data.sender), 9);
+}
+
+#[test]
+fn remaining_capacity_is_zero_at_limit() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+
+    client.initialize(&data.admin);
+
+    for i in 0..10 {
+        client.create_stream(
+            &data.sender,
+            &data.recipient,
+            &data.tokens[i % 3],
+            &100i128,
+            &(1_100u64 + i as u64 * 100),
+            &(1_200u64 + i as u64 * 100),
+        );
+    }
+
+    assert_eq!(client.remaining_sender_capacity(&data.sender), 0);
+}
+
+#[test]
 fn settle_stream_decrements_sender_count() {
     let data = setup_init();
     let client = contract_client(&data.env);


### PR DESCRIPTION
Closes #711.

Builds on the per-sender max-active-streams limit by adding a read-only `remaining_sender_capacity` helper (overflow-safe `saturating_sub`) and exposing it as a contract entrypoint, so clients can show how many more streams a sender may create. Adds unit tests covering the empty, partial, and at-limit cases.