### PR TITLE
feat: emit structured paused/resumed lifecycle events

### DIFF
--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -660,8 +660,11 @@ impl Contract {
         stream.pause_time = now;
 
         storage::set_stream(&env, stream_id, &stream);
-        
-        // Emit admin_action event for pause
+
+        // Dedicated structured lifecycle event for off-chain indexers that
+        // filter on the `stream::paused` topic, in addition to the generic
+        // admin_action audit event below.
+        events::paused(&env, stream_id, &stream.sender, stream.pause_time, now);
         events::admin_action(
             &env,
             stream_id,
@@ -708,8 +711,11 @@ impl Contract {
         stream.pause_time = 0;
 
         storage::set_stream(&env, stream_id, &stream);
-        
-        // Emit admin_action event for resume
+
+        // Dedicated structured lifecycle event for off-chain indexers that
+        // filter on the `stream::resumed` topic, in addition to the generic
+        // admin_action audit event below.
+        events::resumed(&env, stream_id, &stream.sender, stream.end_time, now);
         events::admin_action(
             &env,
             stream_id,


### PR DESCRIPTION
Closes #710.

The `pause`/`resume` entrypoints previously emitted only a generic `admin_action` event, so off-chain indexers filtering on the documented `stream::paused` / `stream::resumed` topics received nothing. This wires the already-defined dedicated lifecycle events into those paths (kept alongside the audit event), giving indexers the per-lifecycle events the event schema promises.