### PR TITLE
feat: expand ContractError taxonomy

### DIFF
--- a/contracts/contracts/streampay-stream/src/error.rs
+++ b/contracts/contracts/streampay-stream/src/error.rs
@@ -43,4 +43,8 @@ pub enum Error {
     Overflow = 10,
     /// 11: Sender has exceeded the maximum number of active streams.
     StreamLimitExceeded = 11,
+    /// 12: Stream sender and recipient are the same address.
+    SelfStream = 12,
+    /// 13: Contract has already been initialised.
+    AlreadyInitialized = 13,
 }

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -120,13 +120,13 @@ impl Contract {
     /// `set_token_allowed`. Sets the global pause flag to `false`.
     ///
     /// # Errors
-    /// - [`Error::InvalidState`] if the contract has already been initialised.
+    /// - [`Error::AlreadyInitialized`] if the contract has already been initialised.
     ///
     /// # Auth
     /// Requires authorisation from `admin`.
     pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
         if storage::has_admin(&env) {
-            return Err(Error::InvalidState);
+            return Err(Error::AlreadyInitialized);
         }
 
         admin.require_auth();
@@ -178,7 +178,7 @@ impl Contract {
     ///
     /// # Errors
     ///
-    /// - `Error::InvalidState` if the contract has already been
+    /// - `Error::AlreadyInitialized` if the contract has already been
     ///   initialised. The allowlist is *not* partially written.
     ///
     /// # Auth
@@ -202,7 +202,7 @@ impl Contract {
         // writes so that a previously-initialised contract cannot have
         // its allowlist silently mutated.
         if storage::has_admin(&env) {
-            return Err(Error::InvalidState);
+            return Err(Error::AlreadyInitialized);
         }
 
         // Authorise the caller up-front. Soroban rolls back all
@@ -362,7 +362,7 @@ impl Contract {
     /// # Errors
     /// - [`Error::ContractPaused`] if the global pause flag is set.
     /// - [`Error::InvalidAmount`] if `total_amount <= 0`.
-    /// - [`Error::InvalidState`] if `sender == recipient`.
+    /// - [`Error::SelfStream`] if `sender == recipient`.
     /// - [`Error::TokenNotAllowed`] if the token has been blocked by the admin.
     /// - [`Error::InvalidTimeRange`] if `end_time <= start_time` or `start_time < now`.
     ///
@@ -386,7 +386,7 @@ impl Contract {
         }
 
         if sender == recipient {
-            return Err(Error::InvalidState);
+            return Err(Error::SelfStream);
         }
 
         if storage::is_token_blocked(&env, &token) {

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -9,7 +9,7 @@
 //!   as unpaused, AND marks every token in `tokens` as `allowed = true`
 //!   - all in one transaction.
 //! - Re-initialisation (via either path) is rejected with
-//!   `Error::InvalidState` and leaves no partial state.
+//!   `Error::AlreadyInitialized` and leaves no partial state.
 //!
 //! The full allowlist/stream lifecycle is exercised elsewhere; this
 //! module only verifies the deployment-time surface area.
@@ -107,7 +107,28 @@ fn initialize_twice_returns_invalid_state() {
 
     let result = client.try_initialize(&data.admin);
     let err = result.expect_err("second initialize should fail");
-    assert_eq!(err, Ok(Error::InvalidState));
+    assert_eq!(err, Ok(Error::AlreadyInitialized));
+}
+
+#[test]
+fn create_stream_with_self_recipient_returns_self_stream() {
+    // Streaming to yourself is meaningless and now has its own semantic
+    // error code rather than the generic `InvalidState`.
+    let data = setup_init();
+    let client = contract_client(&data.env);
+
+    client.initialize(&data.admin);
+
+    let result = client.try_create_stream(
+        &data.sender,
+        &data.sender,
+        &data.tokens[0],
+        &100i128,
+        &1_100u64,
+        &1_200u64,
+    );
+    let err = result.expect_err("sender == recipient should fail");
+    assert_eq!(err, Ok(Error::SelfStream));
 }
 
 #[test]
@@ -217,7 +238,7 @@ fn init_with_token_allowlist_twice_returns_invalid_state() {
     let result =
         client.try_init_with_token_allowlist(&data.admin, &to_sdk_vec(&data.env, &data.tokens));
     let err = result.expect_err("second init_with_token_allowlist should fail");
-    assert_eq!(err, Ok(Error::InvalidState));
+    assert_eq!(err, Ok(Error::AlreadyInitialized));
 }
 
 #[test]
@@ -232,7 +253,7 @@ fn init_with_token_allowlist_after_initialize_returns_invalid_state() {
     let result =
         client.try_init_with_token_allowlist(&data.admin, &to_sdk_vec(&data.env, &data.tokens));
     let err = result.expect_err("init_with_token_allowlist after initialize should fail");
-    assert_eq!(err, Ok(Error::InvalidState));
+    assert_eq!(err, Ok(Error::AlreadyInitialized));
 }
 
 #[test]
@@ -244,7 +265,7 @@ fn initialize_after_init_with_token_allowlist_returns_invalid_state() {
 
     let result = client.try_initialize(&data.admin);
     let err = result.expect_err("initialize after init_with_token_allowlist should fail");
-    assert_eq!(err, Ok(Error::InvalidState));
+    assert_eq!(err, Ok(Error::AlreadyInitialized));
 }
 
 #[test]


### PR DESCRIPTION
Closes #709.

Adds two semantic `Error` variants with new stable codes (existing 1-11 untouched): `SelfStream` (12) for `sender == recipient` and `AlreadyInitialized` (13) for double initialisation, both previously overloaded onto the generic `InvalidState`. Wires them into `create_stream` and the two init paths, updates the affected assertions/docs, and adds a self-stream test.