### PR TITLE
feat: accessible mobile bottom nav with badges

### DIFF
--- a/app/components/BottomNav.test.tsx
+++ b/app/components/BottomNav.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { usePathname } from "next/navigation";
+import { BottomNav, type BottomNavItem } from "./BottomNav";
+
+const items: BottomNavItem[] = [
+  { href: "/streams", label: "Streams", badgeCount: 3 },
+  { href: "/activity", label: "Activity" },
+  { href: "/settings", label: "Settings", badgeCount: 12 },
+];
+
+describe("BottomNav", () => {
+  beforeEach(() => {
+    (usePathname as jest.Mock).mockReturnValue("/streams");
+  });
+
+  it("renders an accessible primary navigation with every item", () => {
+    render(<BottomNav items={items} />);
+    const nav = screen.getByRole("navigation", { name: "Primary" });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByText("Streams")).toBeInTheDocument();
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("marks the active route with aria-current", () => {
+    render(<BottomNav items={items} />);
+    const active = screen.getByText("Streams").closest("a");
+    expect(active).toHaveAttribute("aria-current", "page");
+    const inactive = screen.getByText("Activity").closest("a");
+    expect(inactive).not.toHaveAttribute("aria-current");
+  });
+
+  it("shows a badge with screen-reader text for pending actions", () => {
+    render(<BottomNav items={items} />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("3 pending")).toBeInTheDocument();
+  });
+
+  it("caps large badge counts but announces the exact number", () => {
+    render(<BottomNav items={items} maxBadgeCount={9} />);
+    expect(screen.getByText("9+")).toBeInTheDocument();
+    expect(screen.getByText("12 pending")).toBeInTheDocument();
+  });
+
+  it("omits the badge when there are no pending actions", () => {
+    render(<BottomNav items={items} />);
+    const activity = screen.getByText("Activity").closest("a");
+    expect(activity?.querySelector(".bottom-nav__badge")).toBeNull();
+  });
+});

--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export type BottomNavItem = {
+  /** Route the item links to. */
+  href: string;
+  /** Visible, human-readable label. */
+  label: string;
+  /** Count of pending actions; renders a badge when greater than zero. */
+  badgeCount?: number;
+};
+
+type BottomNavProps = {
+  items: BottomNavItem[];
+  /** Counts above this are rendered as "N+". */
+  maxBadgeCount?: number;
+};
+
+/** True when `pathname` is `href` or a descendant route of it. */
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * Accessible mobile bottom navigation.
+ *
+ * Renders a fixed bottom bar of primary destinations. Each item can show a
+ * badge with the number of pending actions; the count is also announced to
+ * assistive tech via visually-hidden text so screen-reader users are not left
+ * out. The active route is marked with `aria-current="page"`.
+ */
+export function BottomNav({ items, maxBadgeCount = 9 }: BottomNavProps) {
+  const pathname = usePathname() ?? "/";
+
+  return (
+    <nav className="bottom-nav" aria-label="Primary">
+      <ul className="bottom-nav__list">
+        {items.map((item) => {
+          const active = isActive(pathname, item.href);
+          const count = item.badgeCount ?? 0;
+          const hasBadge = count > 0;
+          const badgeLabel = count > maxBadgeCount ? `${maxBadgeCount}+` : String(count);
+
+          return (
+            <li className="bottom-nav__item" key={item.href}>
+              <Link
+                href={item.href}
+                className={`bottom-nav__link${active ? " bottom-nav__link--active" : ""}`}
+                aria-current={active ? "page" : undefined}
+              >
+                <span className="bottom-nav__label">{item.label}</span>
+
+                {hasBadge && (
+                  <span className="bottom-nav__badge" aria-hidden="true">
+                    {badgeLabel}
+                  </span>
+                )}
+                {hasBadge && (
+                  <span className="sr-only">{`${count} pending`}</span>
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2420,3 +2420,74 @@ a:hover {
   font-size: var(--text-base);
   margin-bottom: var(--space-1);
 }
+
+/* ==========================================================================
+   STREAMPAY — MOBILE BOTTOM NAVIGATION (#672)
+   Fixed bottom bar shown on small screens with per-item pending-action badges.
+   Uses design tokens so it follows light/dark mode automatically.
+   ========================================================================== */
+
+.bottom-nav {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 40;
+  background: var(--background);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+/* Mobile-first: visible on small screens, hidden from large breakpoints up. */
+@media (min-width: 768px) {
+  .bottom-nav {
+    display: none;
+  }
+}
+
+.bottom-nav__list {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bottom-nav__item {
+  flex: 1 1 0;
+}
+
+.bottom-nav__link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 56px;
+  padding: var(--space-2, 0.5rem);
+  color: var(--muted);
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bottom-nav__link--active {
+  color: var(--accent);
+}
+
+.bottom-nav__link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.bottom-nav__badge {
+  position: absolute;
+  top: 6px;
+  inset-inline-start: 50%;
+  transform: translateX(0.5rem);
+  min-width: 1.1rem;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-on);
+  font-size: 0.7rem;
+  line-height: 1.1rem;
+  text-align: center;
+}


### PR DESCRIPTION
Closes #672.

Adds a `BottomNav` component: a mobile-only fixed bottom bar of primary destinations with per-item pending-action badges. Badges are announced to screen readers via visually-hidden text, large counts collapse to "N+", and the active route gets `aria-current="page"`. Includes token-based responsive styles (light/dark aware) and focused tests.