### PR TITLE
feat: toast severity icons with SR text

### DIFF
--- a/app/components/ToastProvider.test.tsx
+++ b/app/components/ToastProvider.test.tsx
@@ -107,6 +107,20 @@ describe("ToastProvider", () => {
     expect(screen.getByText("Heads up").closest("[data-severity='info']")).toBeTruthy();
   });
 
+  it("announces the severity to screen readers alongside the icon", () => {
+    renderToastHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: /show success/i }));
+    fireEvent.click(screen.getByRole("button", { name: /show error/i }));
+    fireEvent.click(screen.getByRole("button", { name: /show warning/i }));
+    fireEvent.click(screen.getByRole("button", { name: /show info/i }));
+
+    expect(screen.getByText("Success:")).toBeInTheDocument();
+    expect(screen.getByText("Error:")).toBeInTheDocument();
+    expect(screen.getByText("Warning:")).toBeInTheDocument();
+    expect(screen.getByText("Information:")).toBeInTheDocument();
+  });
+
   it("dismisses a toast manually and via action click", () => {
     renderToastHarness();
 

--- a/app/components/ToastProvider.tsx
+++ b/app/components/ToastProvider.tsx
@@ -58,52 +58,40 @@ function normalizeToastInput(input: ToastInput | string): ToastInput {
   return input;
 }
 
+/** Human-readable severity labels announced to assistive tech. */
+const SEVERITY_LABELS: Record<ToastSeverity, string> = {
+  success: "Success",
+  warning: "Warning",
+  info: "Information",
+  error: "Error",
+};
+
+/** SVG path for each severity's distinct icon. */
+const SEVERITY_ICON_PATHS: Record<ToastSeverity, string> = {
+  success:
+    "M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z",
+  warning:
+    "M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z",
+  info:
+    "M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z",
+  error:
+    "M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z",
+};
+
 function SeverityIcon({ severity }: { severity: ToastSeverity }) {
   const className = `toast-queue__icon toast-queue__icon--${severity}`;
 
-  switch (severity) {
-    case "success":
-      return (
-        <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
-      );
-    case "warning":
-      return (
-        <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path
-            fillRule="evenodd"
-            d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-            clipRule="evenodd"
-          />
-        </svg>
-      );
-    case "info":
-      return (
-        <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path
-            fillRule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-            clipRule="evenodd"
-          />
-        </svg>
-      );
-    case "error":
-    default:
-      return (
-        <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-            clipRule="evenodd"
-          />
-        </svg>
-      );
-  }
+  // The icon is decorative (aria-hidden); the visually-hidden label carries
+  // the severity meaning to screen-reader users, since colour and shape alone
+  // are not accessible.
+  return (
+    <>
+      <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d={SEVERITY_ICON_PATHS[severity]} clipRule="evenodd" />
+      </svg>
+      <span className="sr-only">{`${SEVERITY_LABELS[severity]}:`}</span>
+    </>
+  );
 }
 
 interface ToastCardProps {


### PR DESCRIPTION
Closes #670.

Toast severity icons were distinct but purely decorative (`aria-hidden`), leaving screen-reader users without the severity context. This refactors `SeverityIcon` to keep the distinct per-severity icon and add a visually-hidden label (Success/Warning/Information/Error) so the meaning is announced. Adds a focused test covering all four severities.