### PR TITLE
feat: cancel stream refund preview

### DIFF
--- a/app/components/CancelStreamModal.test.tsx
+++ b/app/components/CancelStreamModal.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { CancelStreamModal } from "./CancelStreamModal";
+import type { CancelInput } from "../lib/cancel-stream";
+
+const ONE_TOKEN = 10_000_000n; // 1.0 in stroops
+
+const split: CancelInput = {
+  totalAmount: 100n * ONE_TOKEN,
+  releasedAmount: 0n,
+  vestedAmount: 40n * ONE_TOKEN,
+  token: "XLM",
+  senderAddress: "GSENDER",
+  recipientAddress: "GRECIPIENT",
+};
+
+describe("CancelStreamModal", () => {
+  it("previews the exact refund split before confirming", () => {
+    render(
+      <CancelStreamModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        stream={{ status: "active" }}
+        split={split}
+        tokenLabel="XLM"
+      />,
+    );
+
+    // 40 vested ⇒ recipient keeps 40, sender refunded 60.
+    expect(screen.getByTestId("recipient-payout")).toHaveTextContent("40 XLM");
+    expect(screen.getByTestId("sender-refund")).toHaveTextContent("60 XLM");
+  });
+
+  it("invokes onConfirm when confirming a cancellable stream", async () => {
+    const onConfirm = jest.fn();
+    render(
+      <CancelStreamModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        stream={{ status: "active" }}
+        split={split}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm cancellation/i }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("blocks cancellation and disables confirm for terminal streams", () => {
+    render(
+      <CancelStreamModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        stream={{ status: "cancelled" }}
+        split={split}
+      />,
+    );
+
+    expect(screen.getByTestId("cancel-blocked")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /confirm cancellation/i }),
+    ).toBeDisabled();
+  });
+});

--- a/app/components/CancelStreamModal.tsx
+++ b/app/components/CancelStreamModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Modal } from "./Modal";
+import { STROOPS_SCALE } from "../lib/amount";
+import { computeCancellationSplit, type CancelInput } from "../lib/cancel-stream";
+import type { Stream } from "../types/openapi";
+
+type CancelStreamModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
+  /** Minimal stream context: only the status is needed for the cancel guard. */
+  stream: Pick<Stream, "status">;
+  /** Escrow amounts (raw i128 units) used to compute the refund split. */
+  split: CancelInput;
+  tokenLabel?: string;
+};
+
+/** Format a raw i128 (stroops) amount as a trimmed decimal string. */
+function formatRaw(raw: bigint): string {
+  const whole = raw / STROOPS_SCALE;
+  const fraction = (raw % STROOPS_SCALE).toString().padStart(7, "0").replace(/0+$/, "");
+  return fraction.length === 0 ? whole.toString() : `${whole.toString()}.${fraction}`;
+}
+
+/**
+ * Cancel-stream confirmation modal with an exact refund preview.
+ *
+ * Before allowing the (irreversible) cancellation, it shows the precise split
+ * the recipient keeps vs. the amount refunded to the sender, computed by the
+ * shared `computeCancellationSplit` logic. If the stream cannot be cancelled
+ * (terminal/draft state, or a broken escrow invariant) the confirm action is
+ * disabled and the reason is shown instead of a preview.
+ */
+export function CancelStreamModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  stream,
+  split,
+  tokenLabel = "tokens",
+}: CancelStreamModalProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const result = useMemo(
+    () => computeCancellationSplit(stream, split),
+    [stream, split],
+  );
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Cancel stream">
+      <div className="cancel-stream">
+        <p className="cancel-stream__warning" role="alert">
+          Cancelling stops all future payouts. This action cannot be undone.
+        </p>
+
+        {result.ok ? (
+          <>
+            <p className="cancel-stream__intro">Review the exact refund split before confirming:</p>
+            <dl className="cancel-stream__split">
+              <div>
+                <dt>Recipient keeps</dt>
+                <dd data-testid="recipient-payout">
+                  {formatRaw(result.split.recipientPayout)} {tokenLabel}
+                </dd>
+              </div>
+              <div>
+                <dt>Refunded to you</dt>
+                <dd data-testid="sender-refund">
+                  {formatRaw(result.split.senderRefund)} {tokenLabel}
+                </dd>
+              </div>
+            </dl>
+          </>
+        ) : (
+          <p className="cancel-stream__blocked" role="alert" data-testid="cancel-blocked">
+            {result.message}
+          </p>
+        )}
+
+        <div className="cancel-stream__footer">
+          <button className="button button--secondary" onClick={onClose} type="button">
+            Keep stream
+          </button>
+          <button
+            className="button button--danger"
+            disabled={!result.ok || isSubmitting}
+            onClick={handleConfirm}
+            type="button"
+          >
+            {isSubmitting ? "Cancelling..." : "Confirm cancellation"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Closes #669.

Adds `CancelStreamModal`, a confirmation dialog that shows the exact refund split (amount the recipient keeps vs. amount refunded to the sender) before allowing an irreversible cancel. The split reuses the shared `computeCancellationSplit` logic; if the stream is in a terminal/draft state the confirm action is disabled and the reason is shown. Includes focused tests.