### PR TITLE
feat: wallet balance polling display

### DIFF
--- a/app/components/WalletBalance.test.tsx
+++ b/app/components/WalletBalance.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor, fireEvent } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { WalletBalance } from "./WalletBalance";
+
+describe("WalletBalance", () => {
+  it("renders the resolved balance with the asset code", async () => {
+    const fetchBalance = jest.fn().mockResolvedValue("100.50");
+
+    render(<WalletBalance fetchBalance={fetchBalance} assetCode="XLM" />);
+
+    expect(await screen.findByText("100.50 XLM")).toBeInTheDocument();
+    expect(fetchBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error message when the balance cannot be fetched", async () => {
+    const fetchBalance = jest.fn().mockRejectedValue(new Error("network"));
+
+    render(<WalletBalance fetchBalance={fetchBalance} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Balance unavailable",
+    );
+  });
+
+  it("re-fetches when the manual refresh button is pressed", async () => {
+    const fetchBalance = jest
+      .fn()
+      .mockResolvedValueOnce("1.00")
+      .mockResolvedValueOnce("2.00");
+
+    render(<WalletBalance fetchBalance={fetchBalance} assetCode="XLM" />);
+    await screen.findByText("1.00 XLM");
+
+    fireEvent.click(screen.getByLabelText("Refresh balance now"));
+
+    await waitFor(() => expect(screen.getByText("2.00 XLM")).toBeInTheDocument());
+    expect(fetchBalance).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/WalletBalance.tsx
+++ b/app/components/WalletBalance.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type WalletBalanceProps = {
+  /** Resolver for the current balance, e.g. an on-chain query. */
+  fetchBalance: () => Promise<string>;
+  /** Asset code shown next to the amount. */
+  assetCode?: string;
+  /** Poll interval in milliseconds (defaults to 15s). */
+  pollIntervalMs?: number;
+};
+
+type Status = "loading" | "idle" | "error";
+
+/**
+ * Displays a wallet balance that refreshes on an interval, with a live
+ * "refreshing" indicator and a manual refresh control. The polling timer is
+ * cleared on unmount so it never leaks or updates an unmounted component.
+ */
+export function WalletBalance({
+  fetchBalance,
+  assetCode = "XLM",
+  pollIntervalMs = 15_000,
+}: WalletBalanceProps) {
+  const [balance, setBalance] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>("loading");
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    setStatus("loading");
+    try {
+      const next = await fetchBalance();
+      if (!mounted.current) return;
+      setBalance(next);
+      setStatus("idle");
+    } catch {
+      if (!mounted.current) return;
+      setStatus("error");
+    }
+  }, [fetchBalance]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+    const id = setInterval(() => void refresh(), pollIntervalMs);
+    return () => {
+      mounted.current = false;
+      clearInterval(id);
+    };
+  }, [refresh, pollIntervalMs]);
+
+  return (
+    <div className="wallet-balance" aria-live="polite">
+      <span className="wallet-balance__amount">
+        {balance === null ? "—" : `${balance} ${assetCode}`}
+      </span>
+      {status === "loading" && (
+        <span
+          className="wallet-balance__indicator"
+          role="status"
+          aria-label="Refreshing balance"
+        >
+          ⟳
+        </span>
+      )}
+      {status === "error" && (
+        <span className="wallet-balance__error" role="alert">
+          Balance unavailable
+        </span>
+      )}
+      <button
+        type="button"
+        className="wallet-balance__refresh"
+        onClick={() => void refresh()}
+        aria-label="Refresh balance now"
+      >
+        Refresh
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #664.

Adds a self-contained `WalletBalance` component that polls a balance resolver on an interval and surfaces a live refreshing indicator plus a manual refresh control.

- Refreshes on mount and every `pollIntervalMs` (default 15s); the interval is cleared on unmount and guarded against state updates after unmount.
- `aria-live` region, `role="status"` refreshing indicator, and `role="alert"` error state for accessibility.
- 3 React Testing Library cases: initial render, error path, and manual refresh.