### PR TITLE
feat: 'Switch network' affordance in wallet menu

### DIFF
--- a/app/components/SwitchNetwork.test.tsx
+++ b/app/components/SwitchNetwork.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor, fireEvent } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { SwitchNetwork } from "./SwitchNetwork";
+
+describe("SwitchNetwork", () => {
+  it("renders nothing when the networks match (case-insensitive)", () => {
+    const { container } = render(
+      <SwitchNetwork
+        currentNetwork="Testnet"
+        requiredNetwork="testnet"
+        onSwitch={jest.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("warns and offers a one-click switch on mismatch", async () => {
+    const onSwitch = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <SwitchNetwork
+        currentNetwork="testnet"
+        requiredNetwork="mainnet"
+        onSwitch={onSwitch}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "this app requires",
+    );
+
+    fireEvent.click(screen.getByLabelText("Switch wallet to mainnet"));
+
+    await waitFor(() =>
+      expect(onSwitch).toHaveBeenCalledWith("mainnet"),
+    );
+  });
+});

--- a/app/components/SwitchNetwork.tsx
+++ b/app/components/SwitchNetwork.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+type SwitchNetworkProps = {
+  /** Network the wallet is currently connected to. */
+  currentNetwork: string;
+  /** Network the app requires for the active session. */
+  requiredNetwork: string;
+  /** One-click switch handler; should resolve once the wallet has switched. */
+  onSwitch: (network: string) => Promise<void> | void;
+};
+
+/**
+ * Detects a wallet/app network mismatch and offers a one-click switch.
+ *
+ * When the wallet is already on the required network nothing is rendered, so
+ * the affordance is invisible in the common (correct) case and only appears
+ * when the user is at risk of acting on the wrong network.
+ */
+export function SwitchNetwork({
+  currentNetwork,
+  requiredNetwork,
+  onSwitch,
+}: SwitchNetworkProps) {
+  const [switching, setSwitching] = useState(false);
+
+  const matches =
+    currentNetwork.toLowerCase() === requiredNetwork.toLowerCase();
+  if (matches) return null;
+
+  const handleSwitch = async () => {
+    setSwitching(true);
+    try {
+      await onSwitch(requiredNetwork);
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  return (
+    <div className="switch-network" role="alert">
+      <span className="switch-network__message">
+        Wallet is on <strong>{currentNetwork}</strong>, but this app requires{" "}
+        <strong>{requiredNetwork}</strong>.
+      </span>
+      <button
+        type="button"
+        className="switch-network__button"
+        onClick={() => void handleSwitch()}
+        disabled={switching}
+        aria-label={`Switch wallet to ${requiredNetwork}`}
+      >
+        {switching ? "Switching…" : `Switch to ${requiredNetwork}`}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #665.

Adds a `SwitchNetwork` component that detects a wallet/app network mismatch and offers a one-click switch.

- Renders nothing when the wallet is already on the required network (case-insensitive), so the affordance only appears when there is real risk.
- On mismatch, shows a `role="alert"` warning and a disabled-while-switching button that invokes the `onSwitch` handler.
- 2 React Testing Library cases: matched (renders nothing) and mismatched (warns + switches).