### PR TITLE
feat: sticky page header on stream detail

### DIFF
--- a/app/components/StickyStreamHeader.test.tsx
+++ b/app/components/StickyStreamHeader.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { StickyStreamHeader } from "./StickyStreamHeader";
+
+describe("StickyStreamHeader", () => {
+  it("renders the stream summary with a sticky position", () => {
+    render(
+      <StickyStreamHeader
+        streamId="s-1"
+        status="active"
+        amount="42.00"
+        recipient="GABCDEF1234567890XYZ"
+      />,
+    );
+
+    const header = screen.getByLabelText("Stream s-1 summary");
+    expect(header).toHaveStyle({ position: "sticky", top: "0px" });
+    expect(header).toHaveTextContent("42.00 XLM");
+    expect(screen.getByLabelText("Stream status: active")).toBeInTheDocument();
+  });
+
+  it("shortens long recipient addresses but keeps the full value as a title", () => {
+    render(
+      <StickyStreamHeader
+        streamId="s-2"
+        status="paused"
+        amount="1.00"
+        recipient="GABCDEF1234567890XYZ"
+      />,
+    );
+
+    expect(screen.getByText("to GABC…0XYZ")).toBeInTheDocument();
+    expect(screen.getByTitle("GABCDEF1234567890XYZ")).toBeInTheDocument();
+  });
+});

--- a/app/components/StickyStreamHeader.tsx
+++ b/app/components/StickyStreamHeader.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+type StickyStreamHeaderProps = {
+  streamId: string;
+  status: string;
+  amount: string;
+  assetCode?: string;
+  recipient: string;
+};
+
+/** Masks the middle of an address for a compact header summary. */
+function shortAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+/**
+ * A compact, sticky summary bar for the stream detail page that stays pinned to
+ * the top while the user scrolls, keeping the stream's key facts (amount,
+ * status, recipient) in view.
+ */
+export function StickyStreamHeader({
+  streamId,
+  status,
+  amount,
+  assetCode = "XLM",
+  recipient,
+}: StickyStreamHeaderProps) {
+  return (
+    <header
+      className="sticky-stream-header"
+      aria-label={`Stream ${streamId} summary`}
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 10,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "1rem",
+        padding: "0.75rem 1rem",
+        backdropFilter: "blur(8px)",
+        borderBottom: "1px solid var(--border, #e5e7eb)",
+      }}
+    >
+      <span className="sticky-stream-header__amount">
+        {amount} {assetCode}
+      </span>
+      <span
+        className={`sticky-stream-header__status status-badge--${status}`}
+        aria-label={`Stream status: ${status}`}
+      >
+        {status}
+      </span>
+      <span className="sticky-stream-header__recipient" title={recipient}>
+        to {shortAddress(recipient)}
+      </span>
+    </header>
+  );
+}


### PR DESCRIPTION
Closes #668.

Adds a `StickyStreamHeader` summary bar for the stream detail page that stays pinned (`position: sticky; top: 0`) while scrolling, keeping the amount, status, and recipient in view.

- Compact summary with an accessible status label and a shortened recipient that retains the full address as a `title`.
- Drop-in component for `app/streams/[id]/page.tsx`.
- 2 React Testing Library cases: sticky positioning + summary content, and recipient shortening.