### PR TITLE
feat: add /api/metrics route protected by token

### DIFF
--- a/app/api/metrics/route.test.ts
+++ b/app/api/metrics/route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for GET /api/metrics — token-gated Prometheus metrics endpoint.
+ */
+
+import { GET } from "./route";
+import { recordRequest, recordThrottle, resetMetrics } from "@/app/lib/rate-limit-metrics";
+
+const TOKEN = "test-metrics-token-123";
+
+function makeRequest(authorization?: string): Request {
+  const headers: Record<string, string> = {};
+  if (authorization !== undefined) headers.authorization = authorization;
+  return new Request("http://localhost/api/metrics", { method: "GET", headers });
+}
+
+describe("GET /api/metrics", () => {
+  const originalToken = process.env.METRICS_AUTH_TOKEN;
+
+  beforeEach(() => {
+    resetMetrics();
+    process.env.METRICS_AUTH_TOKEN = TOKEN;
+  });
+
+  afterAll(() => {
+    if (originalToken === undefined) delete process.env.METRICS_AUTH_TOKEN;
+    else process.env.METRICS_AUTH_TOKEN = originalToken;
+  });
+
+  it("returns 503 when no token is configured", async () => {
+    delete process.env.METRICS_AUTH_TOKEN;
+    const res = await GET(makeRequest(`Bearer ${TOKEN}`));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe("METRICS_DISABLED");
+  });
+
+  it("returns 401 when the Authorization header is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe("Bearer");
+  });
+
+  it("returns 401 when the Authorization header is malformed", async () => {
+    const res = await GET(makeRequest("Token abc"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the token is incorrect", async () => {
+    const res = await GET(makeRequest("Bearer wrong-token"));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns Prometheus metrics for a valid token", async () => {
+    recordRequest("/api/streams");
+    recordRequest("/api/streams");
+    recordThrottle("/api/streams", "perMinute", "wallet", "GABC");
+
+    const res = await GET(makeRequest(`Bearer ${TOKEN}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+
+    const text = await res.text();
+    expect(text).toContain("# TYPE streampay_requests_total counter");
+    expect(text).toContain('streampay_requests_total{route="/api/streams"} 2');
+    expect(text).toContain(
+      'streampay_rate_limit_throttled_total{route="/api/streams",limit_type="perMinute"} 1'
+    );
+    expect(text).toContain("streampay_metrics_up 1");
+  });
+
+  it("accepts a case-insensitive bearer scheme", async () => {
+    const res = await GET(makeRequest(`bearer ${TOKEN}`));
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/app/lib/logger";
+import { getMetrics } from "@/app/lib/rate-limit-metrics";
+
+/**
+ * GET /api/metrics
+ *
+ * Exposes application metrics in Prometheus text exposition format.
+ *
+ * ## Authentication
+ * The endpoint is gated by a static bearer token supplied via the
+ * `METRICS_AUTH_TOKEN` environment variable. Callers must present it as
+ * `Authorization: Bearer <token>`. If the variable is unset the route is
+ * disabled (returns 503) so metrics are never exposed accidentally.
+ *
+ * The token comparison is constant-time to avoid leaking its length or
+ * contents through timing side-channels.
+ *
+ * ## Response
+ * - `200 text/plain; version=0.0.4` — Prometheus metrics on success.
+ * - `401` — missing or malformed `Authorization` header.
+ * - `403` — token present but incorrect.
+ * - `503` — endpoint disabled (no token configured).
+ */
+
+const PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+/**
+ * Constant-time string comparison. Returns `true` only when both inputs are
+ * identical. The loop always runs over the longer of the two lengths so the
+ * timing does not depend on where the first mismatch occurs.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  const len = Math.max(a.length, b.length);
+  let mismatch = a.length ^ b.length;
+  for (let i = 0; i < len; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+/** Escapes a Prometheus label value per the text exposition format spec. */
+function escapeLabel(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+/**
+ * Renders the in-memory counters as Prometheus metrics. Each metric carries a
+ * `# HELP` and `# TYPE` line followed by one sample per label set.
+ */
+function renderPrometheus(): string {
+  const metrics = getMetrics();
+  const lines: string[] = [];
+
+  lines.push("# HELP streampay_requests_total Total requests observed per route.");
+  lines.push("# TYPE streampay_requests_total counter");
+  for (const [route, count] of Object.entries(metrics.total)) {
+    lines.push(`streampay_requests_total{route="${escapeLabel(route)}"} ${count}`);
+  }
+
+  lines.push("# HELP streampay_rate_limit_throttled_total Throttled requests per route and limit type.");
+  lines.push("# TYPE streampay_rate_limit_throttled_total counter");
+  for (const [key, count] of Object.entries(metrics.throttled)) {
+    const sep = key.lastIndexOf(":");
+    const route = sep >= 0 ? key.slice(0, sep) : key;
+    const limitType = sep >= 0 ? key.slice(sep + 1) : "unknown";
+    lines.push(
+      `streampay_rate_limit_throttled_total{route="${escapeLabel(route)}",limit_type="${escapeLabel(limitType)}"} ${count}`
+    );
+  }
+
+  // Always-present gauge so scrapers can confirm the endpoint is healthy even
+  // when no traffic has been recorded yet.
+  lines.push("# HELP streampay_metrics_up Whether the metrics endpoint is serving.");
+  lines.push("# TYPE streampay_metrics_up gauge");
+  lines.push("streampay_metrics_up 1");
+
+  return `${lines.join("\n")}\n`;
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const expected = process.env.METRICS_AUTH_TOKEN;
+
+  if (!expected) {
+    logger.warn("Metrics endpoint requested but METRICS_AUTH_TOKEN is not configured");
+    return NextResponse.json(
+      { error: { code: "METRICS_DISABLED", message: "Metrics endpoint is not configured." } },
+      { status: 503 }
+    );
+  }
+
+  const header = request.headers.get("authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Missing or malformed Authorization header." } },
+      { status: 401, headers: { "WWW-Authenticate": "Bearer" } }
+    );
+  }
+
+  if (!timingSafeEqual(match[1], expected)) {
+    logger.warn("Metrics endpoint rejected an invalid token");
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Invalid metrics token." } },
+      { status: 403 }
+    );
+  }
+
+  const body = renderPrometheus();
+  return new NextResponse(body, {
+    status: 200,
+    headers: { "Content-Type": PROM_CONTENT_TYPE, "Cache-Control": "no-store" },
+  });
+}


### PR DESCRIPTION
Adds a token-gated Prometheus metrics endpoint at `/api/metrics`.

- Gated by `METRICS_AUTH_TOKEN` env var via `Authorization: Bearer` (constant-time compare).
- Returns 503 when unconfigured, 401 on missing/malformed header, 403 on bad token.
- Emits `streampay_requests_total`, `streampay_rate_limit_throttled_total`, and a `streampay_metrics_up` gauge in Prometheus text format.
- Unit tests cover all auth paths and metric rendering.

Closes #699