### PR TITLE
feat: add idempotency cleanup job

### DIFF
--- a/app/api/internal/cleanup/idempotency/route.test.ts
+++ b/app/api/internal/cleanup/idempotency/route.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment node */
+
+import { POST } from "./route";
+import { resetConfigCache } from "@/app/lib/config";
+import { getStore, resetDb } from "@/app/lib/db";
+import { createInternalServiceRequestHeaders } from "@/app/lib/internal-service-auth";
+
+const URL = "http://localhost/api/internal/cleanup/idempotency";
+
+const keys = { current: "a".repeat(32), next: "b".repeat(32) };
+
+function authedRequest(body: string): Request {
+  const headers = createInternalServiceRequestHeaders({
+    body,
+    keyId: "current",
+    method: "POST",
+    secret: keys.current,
+    serviceName: "cleanup-worker",
+    url: URL,
+  });
+  return new Request(URL, { method: "POST", headers, body });
+}
+
+function seedIdempotency(now: number) {
+  const store = getStore().idempotencyStore;
+  store.set("fresh", { fingerprint: "f1", expiresAt: now + 60_000, status: 200, body: {} });
+  store.set("stale-1", { fingerprint: "f2", expiresAt: now - 1, status: 200, body: {} });
+  store.set("stale-2", { fingerprint: "f3", expiresAt: now - 10_000, status: 200, body: {} });
+  store.set("malformed", { fingerprint: "f4" }); // no expiresAt → treated as stale
+}
+
+describe("POST /api/internal/cleanup/idempotency", () => {
+  beforeEach(() => {
+    resetConfigCache();
+    resetDb();
+    process.env.STELLAR_NETWORK = "testnet";
+    process.env.JWT_SECRET = "test-secret-at-least-32-characters-long";
+    process.env.ALLOWED_ORIGINS = "http://localhost:3000";
+    process.env.INTERNAL_SERVICE_HMAC_KEYS = JSON.stringify(keys);
+    process.env.INTERNAL_SERVICE_CURRENT_KEY_ID = "current";
+    process.env.INTERNAL_SERVICE_CLOCK_SKEW_SECONDS = "300";
+  });
+
+  it("conceals the route when unauthenticated", async () => {
+    const res = await POST(new Request(URL, { method: "POST" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("removes expired and malformed idempotency keys", async () => {
+    const now = Date.now();
+    seedIdempotency(now);
+
+    const res = await POST(authedRequest(""));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.scanned).toBe(4);
+    expect(body.expired).toBe(3);
+    expect(body.removed).toBe(3);
+    expect(body.remaining).toBe(1);
+    expect(body.dryRun).toBe(false);
+
+    const store = getStore().idempotencyStore;
+    expect(store.has("fresh")).toBe(true);
+    expect(store.has("stale-1")).toBe(false);
+    expect(store.has("malformed")).toBe(false);
+  });
+
+  it("supports dryRun without deleting anything", async () => {
+    const now = Date.now();
+    seedIdempotency(now);
+
+    const payload = JSON.stringify({ dryRun: true });
+    const res = await POST(authedRequest(payload));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.expired).toBe(3);
+    expect(body.removed).toBe(0);
+    expect(body.dryRun).toBe(true);
+    expect(getStore().idempotencyStore.size).toBe(4);
+  });
+
+  it("rejects a non-boolean dryRun", async () => {
+    const res = await POST(authedRequest(JSON.stringify({ dryRun: "yes" })));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_REQUEST");
+  });
+
+  it("rejects an invalid JSON body", async () => {
+    const res = await POST(authedRequest("{not json"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/internal/cleanup/idempotency/route.ts
+++ b/app/api/internal/cleanup/idempotency/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { getStore } from "@/app/lib/db";
+import { requireInternalServiceAuth } from "@/app/lib/internal-service-auth";
+import { logger } from "@/app/lib/logger";
+
+/**
+ * POST /api/internal/cleanup/idempotency
+ *
+ * Periodic maintenance job that evicts **expired** idempotency keys from the
+ * persistence layer. The application uses lazy eviction (expired keys are only
+ * removed when read), so long-lived keys that are never replayed accumulate
+ * indefinitely. This job sweeps them proactively and is intended to be invoked
+ * by an internal scheduler (cron / ops automation).
+ *
+ * ## Authentication
+ * Requires a signed internal-service request (see
+ * {@link requireInternalServiceAuth}). Only the `ops-automation` and
+ * `cleanup-worker` services are permitted. Auth failures are concealed as
+ * 404 so the route is not discoverable by unauthenticated callers.
+ *
+ * ## Request body (optional JSON)
+ * - `dryRun` (boolean) — when `true`, report how many keys *would* be removed
+ *   without deleting anything. Defaults to `false`.
+ *
+ * ## Response
+ * ```json
+ * { "scanned": 120, "expired": 7, "removed": 7, "remaining": 113, "dryRun": false }
+ * ```
+ */
+
+interface IdempotencyEnvelope {
+  readonly expiresAt?: unknown;
+}
+
+/** Returns the numeric `expiresAt` of a stored entry, or `null` if malformed. */
+function readExpiry(value: unknown): number | null {
+  if (value && typeof value === "object" && "expiresAt" in value) {
+    const expiresAt = (value as IdempotencyEnvelope).expiresAt;
+    if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+      return expiresAt;
+    }
+  }
+  return null;
+}
+
+function errorResponse(code: string, message: string, status: number) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const identity = await requireInternalServiceAuth(request, {
+    allowedServices: ["ops-automation", "cleanup-worker"],
+    concealFailure: true,
+  });
+
+  if (identity instanceof NextResponse) {
+    return identity;
+  }
+
+  let dryRun = false;
+  try {
+    const raw = await request.clone().text();
+    if (raw.length > 0) {
+      const parsed = JSON.parse(raw) as { dryRun?: unknown };
+      if (parsed.dryRun !== undefined) {
+        if (typeof parsed.dryRun !== "boolean") {
+          return errorResponse("INVALID_REQUEST", "`dryRun` must be a boolean.", 400);
+        }
+        dryRun = parsed.dryRun;
+      }
+    }
+  } catch {
+    return errorResponse("INVALID_REQUEST", "Request body must be valid JSON.", 400);
+  }
+
+  const store = getStore().idempotencyStore;
+  const now = Date.now();
+
+  // Snapshot keys first so we never delete while iterating the live map.
+  const expiredKeys: string[] = [];
+  let scanned = 0;
+  for (const [key, value] of store.entries()) {
+    scanned += 1;
+    const expiresAt = readExpiry(value);
+    // Malformed entries (no usable expiry) are treated as stale and removed.
+    if (expiresAt === null || expiresAt < now) {
+      expiredKeys.push(key);
+    }
+  }
+
+  let removed = 0;
+  if (!dryRun) {
+    for (const key of expiredKeys) {
+      if (store.delete(key)) removed += 1;
+    }
+  }
+
+  const remaining = store.size;
+  logger.info("Idempotency cleanup completed", {
+    scanned,
+    expired: expiredKeys.length,
+    removed,
+    remaining,
+    dryRun,
+  });
+
+  return NextResponse.json({
+    scanned,
+    expired: expiredKeys.length,
+    removed: dryRun ? 0 : removed,
+    remaining,
+    dryRun,
+  });
+}


### PR DESCRIPTION
Adds `POST /api/internal/cleanup/idempotency`, an internal-service-authenticated maintenance job that proactively evicts expired (and malformed) idempotency keys from the persistence layer.

- Signed internal-service auth (`ops-automation`, `cleanup-worker`); failures concealed as 404.
- Supports `{ "dryRun": true }` to report counts without deleting.
- Snapshots keys before deleting to avoid mutating during iteration; structured logging with counts.
- Returns `{ scanned, expired, removed, remaining, dryRun }`.
- Unit tests cover auth concealment, deletion, dry-run, and validation.

Closes #702