### PR TITLE
feat: add chaos injection middleware (dev/staging only)

### DIFF
--- a/lib/chaos.test.ts
+++ b/lib/chaos.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+
+import { applyChaos, getChaosConfig } from "./chaos";
+
+describe("getChaosConfig", () => {
+  it("is disabled by default", () => {
+    const config = getChaosConfig({});
+    expect(config.enabled).toBe(false);
+  });
+
+  it("is force-disabled in production even when CHAOS_ENABLED=true", () => {
+    const config = getChaosConfig({ NODE_ENV: "production", CHAOS_ENABLED: "true" });
+    expect(config.enabled).toBe(false);
+  });
+
+  it("enables in non-production when CHAOS_ENABLED=true", () => {
+    const config = getChaosConfig({ NODE_ENV: "development", CHAOS_ENABLED: "true" });
+    expect(config.enabled).toBe(true);
+  });
+
+  it("clamps the error rate into [0, 1]", () => {
+    expect(getChaosConfig({ CHAOS_ERROR_RATE: "5" }).errorRate).toBe(1);
+    expect(getChaosConfig({ CHAOS_ERROR_RATE: "-2" }).errorRate).toBe(0);
+    expect(getChaosConfig({ CHAOS_ERROR_RATE: "0.3" }).errorRate).toBeCloseTo(0.3);
+  });
+
+  it("falls back to defaults for invalid numbers", () => {
+    const config = getChaosConfig({ CHAOS_LATENCY_MS: "abc", CHAOS_ERROR_STATUS: "nan" });
+    expect(config.latencyMs).toBe(0);
+    expect(config.errorStatus).toBe(503);
+  });
+
+  it("clamps error status into the 4xx/5xx range", () => {
+    expect(getChaosConfig({ CHAOS_ERROR_STATUS: "200" }).errorStatus).toBe(400);
+    expect(getChaosConfig({ CHAOS_ERROR_STATUS: "700" }).errorStatus).toBe(599);
+  });
+});
+
+describe("applyChaos", () => {
+  it("is a no-op when disabled", async () => {
+    const sleep = jest.fn();
+    const outcome = await applyChaos(
+      { enabled: false, latencyMs: 1000, errorRate: 1, errorStatus: 503 },
+      () => 0,
+      sleep
+    );
+    expect(outcome.delayMs).toBe(0);
+    expect(outcome.injectedStatus).toBeUndefined();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("injects latency scaled by the random source", async () => {
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const outcome = await applyChaos(
+      { enabled: true, latencyMs: 200, errorRate: 0, errorStatus: 503 },
+      () => 0.5,
+      sleep
+    );
+    expect(outcome.delayMs).toBe(100);
+    expect(sleep).toHaveBeenCalledWith(100);
+  });
+
+  it("injects an error when the random draw is below the error rate", async () => {
+    const outcome = await applyChaos(
+      { enabled: true, latencyMs: 0, errorRate: 0.5, errorStatus: 503 },
+      () => 0.1
+    );
+    expect(outcome.injectedStatus).toBe(503);
+  });
+
+  it("does not inject an error when the random draw is above the error rate", async () => {
+    const outcome = await applyChaos(
+      { enabled: true, latencyMs: 0, errorRate: 0.5, errorStatus: 503 },
+      () => 0.9
+    );
+    expect(outcome.injectedStatus).toBeUndefined();
+  });
+});

--- a/lib/chaos.ts
+++ b/lib/chaos.ts
@@ -1,0 +1,105 @@
+/**
+ * Chaos / fault-injection helper.
+ *
+ * Provides opt-in, configurable latency and error injection for resilience
+ * testing. It is **only** active in non-production environments and only when
+ * explicitly enabled via environment variables, so it can never degrade a
+ * production deployment.
+ *
+ * ## Configuration (environment variables)
+ * - `CHAOS_ENABLED`        — `"true"` to enable. Ignored when `NODE_ENV`
+ *                            is `production`.
+ * - `CHAOS_LATENCY_MS`     — max injected delay in ms (0 disables latency).
+ *                            Actual delay is uniformly random in `[0, value]`.
+ * - `CHAOS_ERROR_RATE`     — probability in `[0, 1]` of injecting a 503 error.
+ * - `CHAOS_ERROR_STATUS`   — HTTP status to return on error (default 503).
+ *
+ * Invalid or out-of-range values are clamped/ignored rather than throwing, so
+ * a misconfiguration never breaks request handling.
+ */
+
+export interface ChaosConfig {
+  /** Whether chaos injection is active for this process. */
+  readonly enabled: boolean;
+  /** Maximum injected latency in milliseconds (>= 0). */
+  readonly latencyMs: number;
+  /** Probability of injecting an error, in `[0, 1]`. */
+  readonly errorRate: number;
+  /** HTTP status code returned when an error is injected. */
+  readonly errorStatus: number;
+}
+
+const DEFAULT_ERROR_STATUS = 503;
+
+/** Parses a finite number from a string, returning `fallback` on failure. */
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** Clamps `value` into the inclusive range `[min, max]`. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Reads chaos configuration from the environment.
+ *
+ * Chaos is force-disabled when `NODE_ENV === "production"` regardless of the
+ * other variables.
+ */
+export function getChaosConfig(env: NodeJS.ProcessEnv = process.env): ChaosConfig {
+  const isProduction = env.NODE_ENV === "production";
+  const enabled = !isProduction && env.CHAOS_ENABLED === "true";
+
+  const latencyMs = Math.max(0, parseNumber(env.CHAOS_LATENCY_MS, 0));
+  const errorRate = clamp(parseNumber(env.CHAOS_ERROR_RATE, 0), 0, 1);
+  const errorStatus = Math.trunc(
+    clamp(parseNumber(env.CHAOS_ERROR_STATUS, DEFAULT_ERROR_STATUS), 400, 599)
+  );
+
+  return { enabled, latencyMs, errorRate, errorStatus };
+}
+
+export interface ChaosOutcome {
+  /** Latency (ms) that was applied before returning. */
+  readonly delayMs: number;
+  /**
+   * When set, the caller should short-circuit with this HTTP status instead of
+   * processing the request normally.
+   */
+  readonly injectedStatus?: number;
+}
+
+/**
+ * Applies chaos for a single request: optionally sleeps for a random delay and
+ * optionally signals that an error should be injected.
+ *
+ * @param config - Resolved chaos configuration.
+ * @param random - Source of randomness in `[0, 1)`. Injectable for tests.
+ * @param sleep  - Async delay function. Injectable for tests.
+ */
+export async function applyChaos(
+  config: ChaosConfig,
+  random: () => number = Math.random,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms))
+): Promise<ChaosOutcome> {
+  if (!config.enabled) {
+    return { delayMs: 0 };
+  }
+
+  let delayMs = 0;
+  if (config.latencyMs > 0) {
+    delayMs = Math.floor(random() * config.latencyMs);
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  if (config.errorRate > 0 && random() < config.errorRate) {
+    return { delayMs, injectedStatus: config.errorStatus };
+  }
+
+  return { delayMs };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ import {
   checkRequestBodySize,
   buildLimitsConfig,
 } from './lib/bodySize';
+import { applyChaos, getChaosConfig } from './lib/chaos';
 
 // ---------------------------------------------------------------------------
 // Request body size cap
@@ -32,6 +33,10 @@ const bodyLimits = buildLimitsConfig();
 validateConfig();
 
 const allowedOrigins = buildAllowedOriginSet(process.env.ALLOWED_ORIGINS);
+
+// Chaos/fault injection config. Resolved once at module init; force-disabled in
+// production by getChaosConfig regardless of env vars.
+const chaosConfig = getChaosConfig();
 
 export const config = {
   matcher: ['/api/:path*'],
@@ -59,6 +64,33 @@ export async function middleware(request: NextRequest) {
   if (sizeError !== null) {
     sizeError.headers.set(REQUEST_FINGERPRINT_HEADER, fingerprint);
     return sizeError;
+  }
+
+  // ------------------------------------------------------------------
+  // 1b. Chaos / fault injection (dev & staging only)
+  // ------------------------------------------------------------------
+  // No-op unless CHAOS_ENABLED=true and NODE_ENV !== production. Injects
+  // random latency and/or a configurable error status to exercise client
+  // retry/timeout paths. OPTIONS preflight is excluded so CORS still works.
+  if (chaosConfig.enabled && request.method !== 'OPTIONS') {
+    const outcome = await applyChaos(chaosConfig);
+    if (outcome.injectedStatus !== undefined) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'CHAOS_INJECTED',
+            message: 'Synthetic fault injected by chaos middleware.',
+          },
+        },
+        {
+          status: outcome.injectedStatus,
+          headers: {
+            [REQUEST_FINGERPRINT_HEADER]: fingerprint,
+            'X-Chaos-Injected': 'error',
+          },
+        }
+      );
+    }
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
Adds configurable latency/error injection for chaos testing.

- New `lib/chaos.ts` with `getChaosConfig` (env-driven, **force-disabled in production**) and `applyChaos`.
- Wired into `middleware.ts` after the body-size check; injects random latency and/or a configurable error status. OPTIONS preflight is excluded so CORS still works.
- Configured via `CHAOS_ENABLED`, `CHAOS_LATENCY_MS`, `CHAOS_ERROR_RATE`, `CHAOS_ERROR_STATUS`; invalid values are clamped, never throw.
- Unit tests cover config parsing, clamping, production safety, latency, and error injection.

Closes #700