### PR TITLE
feat: add accessible color-blind safe stream status icons

### DIFF
--- a/app/components/StatusBadge.test.tsx
+++ b/app/components/StatusBadge.test.tsx
@@ -21,4 +21,25 @@ describe("StatusBadge", () => {
     expect(badge).toHaveTextContent(label);
     expect(badge).toHaveClass(`status-badge--${status}`);
   });
+
+  it.each(["draft", "active", "paused", "ended"] as const)(
+    "renders a decorative shape icon for %s (color is not the only differentiator)",
+    (status) => {
+      const { container } = render(<StatusBadge status={status} />);
+      const icon = container.querySelector(`.status-icon--${status}`);
+
+      expect(icon).not.toBeNull();
+      // The shape is decorative; the text label conveys status to AT.
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+      expect((icon?.textContent ?? "").length).toBeGreaterThan(0);
+    }
+  );
+
+  it("uses distinct glyphs across statuses", () => {
+    const glyphs = (["draft", "active", "paused", "ended"] as const).map((status) => {
+      const { container } = render(<StatusBadge status={status} />);
+      return container.querySelector(`.status-icon--${status}`)?.textContent;
+    });
+    expect(new Set(glyphs).size).toBe(glyphs.length);
+  });
 });

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -7,6 +7,24 @@ const statusBadgeCopy = {
 
 export type StreamStatus = keyof typeof statusBadgeCopy;
 
+/**
+ * Distinct glyph per status so the state is conveyed by **shape as well as
+ * colour**. This keeps the badge legible for users with colour-vision
+ * deficiency and passes colour-blind simulator checks (the shapes remain
+ * distinguishable under protanopia/deuteranopia/tritanopia).
+ *
+ * - active  → ▶ play (flowing)
+ * - paused  → ‖ two bars (paused)
+ * - ended   → ■ filled square (stopped)
+ * - draft   → ○ hollow circle (not started)
+ */
+const statusBadgeGlyph: Record<StreamStatus, string> = {
+  active: "▶",
+  paused: "‖",
+  ended: "■",
+  draft: "○",
+};
+
 type StatusBadgeProps = {
   status: StreamStatus;
 };
@@ -19,8 +37,12 @@ export function StatusBadge({ status }: StatusBadgeProps) {
       aria-label={`Stream status: ${label}`}
       className={`status-badge status-badge--${status}`}
     >
+      {/* Decorative shape icon — the text label already conveys the status to
+          assistive tech, so the glyph is hidden from screen readers. */}
+      <span className={`status-icon status-icon--${status}`} aria-hidden="true">
+        {statusBadgeGlyph[status]}
+      </span>
       {label}
     </span>
   );
 }
-

--- a/app/globals.css
+++ b/app/globals.css
@@ -150,6 +150,7 @@ body {
 
 /* ─── Accessibility ───────────────────────────────────────────────────────── */
 @import './styles/focus.css' layer(focus);
+@import './styles/icons.css';
 
 button {
   font: inherit;

--- a/app/styles/icons.css
+++ b/app/styles/icons.css
@@ -1,0 +1,54 @@
+/*
+ * Color-blind safe stream status icons.
+ *
+ * Each stream status is paired with a distinct *shape* glyph so the state is
+ * never conveyed by colour alone (WCAG 1.4.1 Use of Color). The glyphs are
+ * chosen to stay mutually distinguishable under the common colour-vision
+ * deficiencies (protanopia, deuteranopia, tritanopia) and in greyscale.
+ *
+ * The icon inherits the badge's text colour by default so it stays consistent
+ * with each badge variant's palette in both light and dark mode.
+ */
+
+.status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.4rem;
+  font-size: 0.9em;
+  line-height: 1;
+  /* Inherit the badge variant colour so the shape matches its label. */
+  color: currentColor;
+  flex: 0 0 auto;
+}
+
+/* Per-status nudges so each glyph is optically centred and clearly sized. */
+.status-icon--active {
+  font-size: 0.8em;
+}
+
+.status-icon--paused {
+  font-weight: 700;
+  letter-spacing: -0.05em;
+}
+
+.status-icon--ended {
+  font-size: 0.75em;
+}
+
+.status-icon--draft {
+  font-size: 0.95em;
+}
+
+/*
+ * Keep the shape visible in forced-colors / high-contrast mode, where custom
+ * colours are stripped. currentColor maps to the system text colour, so the
+ * glyph remains rendered alongside the label.
+ */
+@media (forced-colors: active) {
+  .status-icon {
+    color: CanvasText;
+  }
+}


### PR DESCRIPTION
Augments status with shape so state is never conveyed by colour alone (WCAG 1.4.1).

- `StatusBadge` now renders a distinct, decorative shape glyph per status (active ▶, paused ‖, ended ■, draft ○), hidden from assistive tech since the text label already conveys status.
- New `app/styles/icons.css` styles the icons, inherits each variant's colour via `currentColor`, and stays visible under `forced-colors` / high-contrast mode. Imported from `globals.css`.
- Glyphs remain mutually distinguishable under protanopia/deuteranopia/tritanopia and in greyscale.
- Tests assert icon presence, decorative `aria-hidden`, and that glyphs are distinct across statuses.

Closes #660