### PR TITLE
fix: add reduced-motion fallback for live progress animations

### DIFF
--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { StreamProgress } from "./StreamProgress";
+
+/** Installs a matchMedia mock that reports the given reduced-motion preference. */
+function mockMatchMedia(prefersReduced: boolean) {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes("prefers-reduced-motion") ? prefersReduced : false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
+describe("StreamProgress reduced-motion fallback", () => {
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it("animates the fill when reduced motion is not requested", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" accruedAmount={50} totalAmount={100} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar.parentElement).toHaveClass("stream-progress--animated");
+    expect(bar.parentElement).toHaveAttribute("data-reduced-motion", "false");
+
+    const fill = bar.querySelector(".stream-progress__fill") as HTMLElement;
+    expect(fill.style.transition).toBe("width 400ms ease");
+  });
+
+  it("renders a static fill when reduced motion is requested", () => {
+    mockMatchMedia(true);
+    render(<StreamProgress status="active" accruedAmount={50} totalAmount={100} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar.parentElement).toHaveClass("stream-progress--static");
+    expect(bar.parentElement).toHaveAttribute("data-reduced-motion", "true");
+
+    const fill = bar.querySelector(".stream-progress__fill") as HTMLElement;
+    expect(fill.style.transition).toBe("none");
+    // The fill is still positioned to reflect progress — only the motion is removed.
+    expect(fill.style.width).toBe("50%");
+  });
+
+  it("preserves the accessible progress value regardless of motion preference", () => {
+    mockMatchMedia(true);
+    render(<StreamProgress status="active" accruedAmount={25} totalAmount={100} />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "25");
+  });
+});

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -24,7 +24,45 @@
 
 "use client";
 
+import { useEffect, useState } from "react";
 import type { StreamStatus } from "@/app/types/openapi";
+
+// ── Reduced-motion ─────────────────────────────────────────────────────────────
+
+/**
+ * Tracks the user's `prefers-reduced-motion` setting.
+ *
+ * Returns `true` when the user has requested reduced motion. SSR-safe: defaults
+ * to `false` on the server (and before hydration) and updates live if the
+ * preference changes. Used to swap the animated fill transition for a static,
+ * instantly-positioned bar.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(query.matches);
+
+    const onChange = (event: MediaQueryListEvent) => setPrefersReduced(event.matches);
+
+    // addEventListener is the modern API; fall back to addListener for older
+    // engines (e.g. Safari < 14) so the hook degrades gracefully.
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", onChange);
+      return () => query.removeEventListener("change", onChange);
+    }
+
+    query.addListener(onChange);
+    return () => query.removeListener(onChange);
+  }, []);
+
+  return prefersReduced;
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -129,6 +167,7 @@ export function StreamProgress({
 }: StreamProgressProps) {
   const percent = derivePercent({ status, accruedAmount, totalAmount, startedAt, endsAt });
   const label   = deriveLabel(status, percent);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // Map status to BEM modifier for color tokens
   const modifier =
@@ -138,8 +177,16 @@ export function StreamProgress({
     status === "cancelled" ? "cancelled" :
     "draft";
 
+  // When the user prefers reduced motion we render a static bar: the fill is
+  // positioned instantly with no width transition. This is also exposed as a
+  // modifier class so external CSS can opt out of any keyframe animations.
+  const motionModifier = prefersReducedMotion ? "static" : "animated";
+
   return (
-    <div className={`stream-progress ${className}`.trim()}>
+    <div
+      className={`stream-progress stream-progress--${motionModifier} ${className}`.trim()}
+      data-reduced-motion={prefersReducedMotion ? "true" : "false"}
+    >
       {/* Track */}
       <div
         role="progressbar"
@@ -150,10 +197,13 @@ export function StreamProgress({
         aria-label={`Stream progress: ${label}`}
         className={`stream-progress__track stream-progress__track--${modifier}`}
       >
-        {/* Fill */}
+        {/* Fill — transitions width unless reduced motion is requested. */}
         <div
           className={`stream-progress__fill stream-progress__fill--${modifier}`}
-          style={{ width: `${percent}%` }}
+          style={{
+            width: `${percent}%`,
+            transition: prefersReducedMotion ? "none" : "width 400ms ease",
+          }}
         />
       </div>
 


### PR DESCRIPTION
Honours `prefers-reduced-motion` in `StreamProgress`: when the user requests reduced motion the bar updates statically with no width transition.

- Adds an SSR-safe `usePrefersReducedMotion` hook (matchMedia, live updates, `addListener` fallback for older Safari).
- Swaps the fill transition for `none` and exposes a `stream-progress--static` modifier + `data-reduced-motion` attribute so external CSS can opt out of keyframes.
- Progress value/position are preserved — only the motion is removed (WCAG 2.3.3).
- Tests cover animated vs static rendering and aria-value preservation.

Closes #661