### PR TITLE
fix: polish modal close affordance — escape + click outside

### DIFF
--- a/app/components/Modal.test.tsx
+++ b/app/components/Modal.test.tsx
@@ -53,12 +53,41 @@ describe("Modal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /open modal/i }));
     expect(screen.getByRole("heading", { name: /confirm action/i })).toBeInTheDocument();
-    fireEvent.click(getOverlay());
-    fireEvent.animationEnd(getOverlay());
+    const overlay = getOverlay();
+    // A genuine backdrop click: press and release both land on the overlay.
+    fireEvent.mouseDown(overlay);
+    fireEvent.click(overlay);
+    fireEvent.animationEnd(overlay);
 
     await waitFor(() => {
       expect(screen.queryByRole("heading", { name: /confirm action/i })).not.toBeInTheDocument();
     });
+  });
+
+  it("does NOT close when a drag starts inside the dialog and ends on the backdrop", () => {
+    render(<ModalHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open modal/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm action/i });
+    const overlay = getOverlay();
+
+    // Press begins inside the dialog (e.g. selecting text), release on backdrop.
+    fireEvent.mouseDown(dialog);
+    fireEvent.click(overlay);
+
+    expect(screen.getByRole("heading", { name: /confirm action/i })).toBeInTheDocument();
+  });
+
+  it("does NOT close when interacting with content inside the dialog", () => {
+    render(<ModalHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open modal/i }));
+    const finalAction = screen.getByRole("button", { name: /final action/i });
+
+    fireEvent.mouseDown(finalAction);
+    fireEvent.click(finalAction);
+
+    expect(screen.getByRole("heading", { name: /confirm action/i })).toBeInTheDocument();
   });
 
   it("renders children only while open", () => {

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -2,6 +2,7 @@
 
 import React, {
   KeyboardEvent,
+  MouseEvent,
   PropsWithChildren,
   useEffect,
   useId,
@@ -24,6 +25,11 @@ export const Modal: React.FC<PropsWithChildren<ModalProps>> = ({
   const [shouldRender, setShouldRender] = useState(isOpen);
   const dialogRef = useRef<HTMLDivElement>(null);
   const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+  // Tracks whether the current pointer interaction *started* on the overlay.
+  // Without this, a text-selection drag that begins inside the dialog and ends
+  // on the backdrop would incorrectly close the modal. We only treat it as an
+  // outside-click when both press and release happen on the overlay itself.
+  const pointerDownOnOverlayRef = useRef(false);
   const titleId = useId();
 
   useEffect(() => {
@@ -54,6 +60,21 @@ export const Modal: React.FC<PropsWithChildren<ModalProps>> = ({
 
   const handleAnimationEnd = () => {
     if (!isOpen) setShouldRender(false);
+  };
+
+  // Record where the pointer press began so we can distinguish a genuine
+  // backdrop click from a drag that merely ended on the backdrop.
+  const handleOverlayPointerDown = (event: MouseEvent<HTMLDivElement>) => {
+    pointerDownOnOverlayRef.current = event.target === event.currentTarget;
+  };
+
+  // Close only when the click both started and ended on the overlay.
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    const startedOnOverlay = pointerDownOnOverlayRef.current;
+    pointerDownOnOverlayRef.current = false;
+    if (startedOnOverlay && event.target === event.currentTarget) {
+      onClose();
+    }
   };
 
   // Keep keyboard focus inside the active dialog per WAI-ARIA dialog guidance.
@@ -123,7 +144,9 @@ export const Modal: React.FC<PropsWithChildren<ModalProps>> = ({
 
   return (
     <div
-      onClick={onClose}
+      data-modal-overlay="true"
+      onMouseDown={handleOverlayPointerDown}
+      onClick={handleOverlayClick}
       onAnimationEnd={handleAnimationEnd}
       style={{
         position: "fixed",


### PR DESCRIPTION
Hardens and standardizes the shared `Modal` close behaviour.

- Escape-to-close is preserved.
- Click-outside now only closes when the pointer press **and** release both land on the overlay. A text-selection drag that starts inside the dialog and ends on the backdrop no longer closes the modal (a common accidental-dismiss bug).
- Adds a `data-modal-overlay` hook for consistent targeting/testing across the app.
- Tests cover genuine backdrop click, the inside-to-backdrop drag case, and content interaction.

Closes #662