### PR TITLE
feat: polish CreateStream wizard preview step

### DIFF
--- a/app/components/StreamPreview.test.tsx
+++ b/app/components/StreamPreview.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { StreamPreview, computeTotal, type StreamPreviewData } from "./StreamPreview";
+
+const BASE: StreamPreviewData = {
+  recipient: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+  rate: "10",
+  schedule: "day",
+  durationIntervals: 7,
+  token: "XLM",
+  gasOnRecipient: false,
+};
+
+describe("computeTotal", () => {
+  it("multiplies rate by duration", () => {
+    expect(computeTotal("10", 7)).toBe("70");
+  });
+
+  it("respects Stellar 7-dp precision and trims trailing zeros", () => {
+    expect(computeTotal("0.1", 3)).toBe("0.3");
+  });
+
+  it("returns a dash for invalid or non-positive rates", () => {
+    expect(computeTotal("abc", 7)).toBe("—");
+    expect(computeTotal("0", 7)).toBe("—");
+    expect(computeTotal("10", 0)).toBe("—");
+  });
+});
+
+describe("StreamPreview", () => {
+  it("renders a labelled review region with the computed total", () => {
+    render(<StreamPreview data={BASE} />);
+    expect(screen.getByRole("group", { name: /review your stream/i })).toBeInTheDocument();
+    expect(screen.getByText(/70 XLM/)).toBeInTheDocument();
+  });
+
+  it("shortens the recipient address but keeps the full value in the title", () => {
+    render(<StreamPreview data={BASE} />);
+    const dd = screen.getByText(/GABCDE…UVW/);
+    expect(dd).toHaveAttribute("title", BASE.recipient);
+  });
+
+  it("pluralises the duration correctly", () => {
+    const { rerender } = render(<StreamPreview data={{ ...BASE, durationIntervals: 1 }} />);
+    expect(screen.getByText("1 day")).toBeInTheDocument();
+
+    rerender(<StreamPreview data={{ ...BASE, durationIntervals: 7 }} />);
+    expect(screen.getByText("7 days")).toBeInTheDocument();
+  });
+
+  it("shows who pays gas", () => {
+    const { rerender } = render(<StreamPreview data={{ ...BASE, gasOnRecipient: true }} />);
+    expect(screen.getByText(/recipient/i)).toBeInTheDocument();
+
+    rerender(<StreamPreview data={{ ...BASE, gasOnRecipient: false }} />);
+    expect(screen.getByText(/you \(sender\)/i)).toBeInTheDocument();
+  });
+});

--- a/app/components/StreamPreview.tsx
+++ b/app/components/StreamPreview.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import React from "react";
+
+/**
+ * StreamPreview
+ *
+ * Read-only summary card shown on the final step of the CreateStream wizard.
+ * It presents the configured stream parameters side-by-side with computed
+ * totals so the creator can review everything before confirming.
+ *
+ * ## Accessibility (WCAG 2.1 AA)
+ * - Rendered as a labelled region (`role="group"` + `aria-labelledby`).
+ * - Field/value pairs use a description list (`<dl>`) for correct semantics.
+ * - The computed total is announced via an `aria-live="polite"` region so it
+ *   updates audibly if the upstream values change.
+ *
+ * ## Theming
+ * Uses design tokens so it is consistent in light and dark mode; the layout is
+ * responsive (single column on small screens, two columns on wider ones).
+ */
+
+export interface StreamPreviewData {
+  recipient: string;
+  /** Per-interval rate in display units. */
+  rate: string;
+  /** Schedule cadence, e.g. "day", "week". */
+  schedule: string;
+  /** Number of intervals the stream runs for. */
+  durationIntervals: number;
+  /** Token symbol, e.g. "XLM" or "USDC". */
+  token: string;
+  /** Whether the recipient bears the gas fee. */
+  gasOnRecipient?: boolean;
+}
+
+export interface StreamPreviewProps {
+  data: StreamPreviewData;
+  className?: string;
+}
+
+/**
+ * Computes the total streamed amount as `rate * durationIntervals`.
+ * Returns a formatted string with up to 7 decimal places (Stellar precision),
+ * or `"—"` when the rate is not a valid positive number.
+ */
+export function computeTotal(rate: string, durationIntervals: number): string {
+  const numericRate = Number(rate);
+  if (!Number.isFinite(numericRate) || numericRate <= 0 || durationIntervals <= 0) {
+    return "—";
+  }
+  const total = numericRate * durationIntervals;
+  // Trim trailing zeros while respecting Stellar's 7-dp precision.
+  return Number(total.toFixed(7)).toString();
+}
+
+/** Truncates a long Stellar address to `GABC…WXYZ` for compact display. */
+function shortenAddress(address: string): string {
+  const trimmed = address.trim();
+  if (trimmed.length <= 12) return trimmed;
+  return `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}`;
+}
+
+export function StreamPreview({ data, className = "" }: StreamPreviewProps) {
+  const total = computeTotal(data.rate, data.durationIntervals);
+  const headingId = "stream-preview-heading";
+
+  return (
+    <section
+      className={`stream-preview ${className}`.trim()}
+      role="group"
+      aria-labelledby={headingId}
+    >
+      <h3 id={headingId} className="stream-preview__title">
+        Review your stream
+      </h3>
+
+      <div className="stream-preview__grid">
+        <dl className="stream-preview__list">
+          <div className="stream-preview__row">
+            <dt>Recipient</dt>
+            <dd title={data.recipient}>{shortenAddress(data.recipient) || "—"}</dd>
+          </div>
+          <div className="stream-preview__row">
+            <dt>Rate</dt>
+            <dd>
+              {data.rate || "—"} {data.token} / {data.schedule}
+            </dd>
+          </div>
+          <div className="stream-preview__row">
+            <dt>Duration</dt>
+            <dd>
+              {data.durationIntervals} {data.schedule}
+              {data.durationIntervals === 1 ? "" : "s"}
+            </dd>
+          </div>
+          <div className="stream-preview__row">
+            <dt>Gas paid by</dt>
+            <dd>{data.gasOnRecipient ? "Recipient" : "You (sender)"}</dd>
+          </div>
+        </dl>
+
+        <aside className="stream-preview__totals" aria-live="polite">
+          <span className="stream-preview__totals-label">Total to stream</span>
+          <span className="stream-preview__totals-value">
+            {total} {data.token}
+          </span>
+        </aside>
+      </div>
+
+      <style jsx>{`
+        .stream-preview {
+          padding: 1.25rem;
+          background: var(--panel, var(--card-surface));
+          border: 1px solid var(--border, var(--card-border));
+          border-radius: 1rem;
+        }
+        .stream-preview__title {
+          margin: 0 0 1rem;
+          font-size: 1.05rem;
+        }
+        .stream-preview__grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 1rem;
+          align-items: start;
+        }
+        @media (min-width: 640px) {
+          .stream-preview__grid {
+            grid-template-columns: 1.4fr 1fr;
+          }
+        }
+        .stream-preview__list {
+          display: grid;
+          gap: 0.65rem;
+          margin: 0;
+        }
+        .stream-preview__row {
+          display: flex;
+          justify-content: space-between;
+          gap: 1rem;
+          font-size: 0.9rem;
+        }
+        .stream-preview__row dt {
+          color: var(--muted);
+        }
+        .stream-preview__row dd {
+          margin: 0;
+          font-weight: 600;
+          text-align: right;
+          overflow-wrap: anywhere;
+        }
+        .stream-preview__totals {
+          display: flex;
+          flex-direction: column;
+          gap: 0.35rem;
+          padding: 1rem;
+          border-radius: 0.75rem;
+          background: var(--accent-strong, rgba(34, 197, 94, 0.12));
+          color: var(--foreground, inherit);
+        }
+        .stream-preview__totals-label {
+          font-size: 0.8rem;
+          color: var(--muted);
+        }
+        .stream-preview__totals-value {
+          font-size: 1.4rem;
+          font-weight: 700;
+        }
+      `}</style>
+    </section>
+  );
+}
+
+export default StreamPreview;

--- a/app/streams/new/preview/page.tsx
+++ b/app/streams/new/preview/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React, { Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { StreamPreview, type StreamPreviewData } from "../../../components/StreamPreview";
+
+/**
+ * CreateStream wizard — Preview step.
+ *
+ * Renders a side-by-side review of the configured stream (parameters + computed
+ * totals) before the creator confirms. Stream parameters are passed through the
+ * URL query so the step is deep-linkable and survives a refresh.
+ *
+ * Query params: `recipient`, `rate`, `schedule`, `duration`, `token`, `gas`.
+ */
+
+function parsePreviewData(params: URLSearchParams): StreamPreviewData {
+  const durationRaw = Number(params.get("duration"));
+  return {
+    recipient: params.get("recipient") ?? "",
+    rate: params.get("rate") ?? "",
+    schedule: params.get("schedule") ?? "day",
+    durationIntervals: Number.isFinite(durationRaw) && durationRaw > 0 ? durationRaw : 1,
+    token: params.get("token") ?? "XLM",
+    gasOnRecipient: params.get("gas") === "recipient",
+  };
+}
+
+function PreviewContent() {
+  const searchParams = useSearchParams();
+  const data = parsePreviewData(new URLSearchParams(searchParams.toString()));
+
+  return (
+    <main className="page-shell" aria-labelledby="preview-page-title">
+      <header className="page-hero">
+        <p className="page-hero__eyebrow">Create stream</p>
+        <h1 id="preview-page-title" className="page-hero__title">
+          Preview &amp; confirm
+        </h1>
+        <p className="page-hero__description">
+          Double-check the details below. Nothing is sent on-chain until you confirm.
+        </p>
+      </header>
+
+      <StreamPreview data={data} />
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          justifyContent: "flex-end",
+        }}
+      >
+        <Link href="/streams/new" className="button button--secondary">
+          Back to edit
+        </Link>
+        <Link href="/streams/new?confirm=1" className="button button--primary">
+          Confirm &amp; create
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+export default function StreamPreviewPage() {
+  // useSearchParams requires a Suspense boundary in the App Router.
+  return (
+    <Suspense fallback={<main className="page-shell">Loading preview…</main>}>
+      <PreviewContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
Adds a polished, side-by-side preview step for the CreateStream wizard.

- New `app/components/StreamPreview.tsx`: review card with parameter list beside a computed totals panel (`rate × duration`, Stellar 7-dp precision, trailing zeros trimmed).
- New `app/streams/new/preview/page.tsx`: deep-linkable preview step that reads stream params from the URL query (Suspense-wrapped `useSearchParams`) with Back/Confirm actions.
- WCAG 2.1 AA: labelled `role="group"` region, `<dl>` semantics, `aria-live` totals; responsive single-→two-column layout; design-token theming for light/dark.
- Tests cover `computeTotal` math/edge cases, address shortening, pluralisation, and gas attribution.

Closes #659