### PR TITLE
feat: pause/resume entrypoints with accrual freeze

### DIFF
--- a/contracts/contracts/streampay-stream/src/events.rs
+++ b/contracts/contracts/streampay-stream/src/events.rs
@@ -150,8 +150,11 @@ pub fn amended(
 /// Carries the action symbol (e.g., "pause", "resume", "force_cancel") so
 /// indexers can track admin operations on behalf of senders.
 pub fn admin_action(env: &Env, stream_id: u64, admin: &Address, action: Symbol, timestamp: u64) {
+    // `symbol_short!` caps topics at 9 characters, so the admin-action topic is
+    // abbreviated to "admin_act"; the specific action ("pause"/"resume"/…) is
+    // carried in the event body for indexers.
     env.events().publish(
-        (symbol_short!("stream"), symbol_short!("admin_action")),
+        (symbol_short!("stream"), symbol_short!("admin_act")),
         (stream_id, admin.clone(), action, timestamp),
     );
 }

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -28,83 +28,12 @@ use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
 pub use storage::{Stream, StreamStatus};
 
 /// The StreamPay contract entry point registered with the Soroban host.
+///
+/// The [`Stream`] record and [`StreamStatus`] enum are defined once in the
+/// [`storage`] module and re-exported above, so there is a single source of
+/// truth for the on-chain data layout.
 #[contract]
 pub struct Contract;
-
-/// Lifecycle state of a payment stream.
-///
-/// Transitions allowed by the current public API:
-/// ```text
-/// Draft ──start_stream──► Active ──withdraw (full)──► Settled
-/// ```
-/// `Paused`, `Ended`, and `Cancelled` are reserved for future entry points.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum StreamStatus {
-    /// Created and funded but not yet activated; accrual has not started.
-    Draft,
-    /// Tokens are flowing linearly to the recipient.
-    Active,
-    /// Reserved — stream-level pause not yet implemented.
-    Paused,
-    /// All `total_amount` tokens have been released to the recipient.
-    Settled,
-    /// Reserved — natural expiry entry point not yet implemented.
-    Ended,
-    /// Reserved — sender-initiated cancellation not yet implemented.
-    Cancelled,
-}
-
-/// On-chain record for a single payment stream.
-///
-/// All token amounts are in the token's base unit (stroops for XLM-based
-/// assets). All timestamps are Unix seconds as reported by the ledger.
-#[derive(Clone, Debug)]
-#[contracttype]
-pub struct Stream {
-    /// Unique monotonic identifier assigned at creation. Starts at 1.
-    pub id: u64,
-    /// Address that created the stream and escrowed `total_amount`.
-    pub sender: Address,
-    /// Address that receives streamed tokens via [`Contract::withdraw`].
-    pub recipient: Address,
-    /// Stellar asset contract address being streamed.
-    pub token: Address,
-    /// Total tokens (base units) locked in escrow at creation. Always > 0.
-    pub total_amount: i128,
-    /// Tokens already transferred to `recipient`. Monotonically non-decreasing.
-    /// Invariant: `released_amount <= total_amount`.
-    pub released_amount: i128,
-    /// Ledger timestamp when accrual begins. Zero for `Draft` streams.
-    pub start_time: u64,
-    /// Ledger timestamp when accrual ends (`start_time + duration`).
-    /// Zero for `Draft` streams.
-    pub end_time: u64,
-    /// Stream length in seconds. Set at creation; never changes.
-    pub duration: u64,
-    /// Ledger timestamp of the last state-mutating operation on this stream.
-    pub last_update: u64,
-    /// Current lifecycle status.
-    pub status: StreamStatus,
-}
-
-/// Ledger storage keys used internally by this contract.
-///
-/// Not exposed to callers; listed here for auditability.
-#[derive(Clone)]
-#[contracttype]
-enum DataKey {
-    /// The privileged admin [`Address`].
-    Admin,
-    /// Global emergency pause flag (`bool`).
-    Paused,
-    /// Monotonic counter; value is the **next** stream ID to assign.
-    NextStreamId,
-    /// Per-stream record keyed by numeric ID.
-    Stream(u64),
-    /// Per-token allowlist entry. Absent or `true` → allowed; `false` → blocked.
-    TokenAllowed(Address),
-}
 
 #[contractimpl]
 impl Contract {

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -651,7 +651,7 @@ fn cancel_stream_emits_cancelled_event() {
     assert!(!events.is_empty(), "cancel_stream should emit events");
 
     // The last event should be the cancelled event
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -671,11 +671,10 @@ fn cancel_stream_requires_auth() {
         &1_200u64,
     );
 
-    // Mock auths off and try to cancel as a different address
+    // Mock auths off so the required sender authorisation is absent.
     data.env.mock_auths(&[]);
-    let impostor = Address::generate(&data.env);
 
-    let result = client.try_cancel_stream(&impostor, &id);
+    let result = client.try_cancel_stream(&id);
     assert!(
         result.is_err(),
         "cancel_stream should fail without auth from sender"
@@ -832,7 +831,7 @@ fn pause_emits_admin_action_event() {
     assert!(!events.is_empty(), "pause should emit events");
 
     // The event should have 2 topics (stream, pause)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -865,7 +864,7 @@ fn resume_emits_admin_action_event() {
     assert!(!events.is_empty(), "resume should emit events");
 
     // The event should have 2 topics (stream, resume)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -898,7 +897,7 @@ fn settle_emits_admin_action_event() {
     assert!(!events.is_empty(), "settle should emit events");
 
     // The event should have 2 topics (stream, admin_action)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -1187,4 +1186,105 @@ fn pause_resume_preserves_vested_amount() {
     data.env.ledger().set_timestamp(1_300);
     let resumed_vested = client.stream_balance(&id);
     assert_eq!(resumed_vested, 1000);
+}
+
+/// Accrual freezes at the exact pause instant and carries forward on resume (#706).
+///
+/// A 1000-token stream over 100s vests 10/s. Pausing at the 30% mark should
+/// freeze the vested amount at 300 for the entire pause window, and resuming
+/// should extend `end_time` by the paused duration so the full 1000 still vests.
+#[test]
+fn pause_freezes_accrual_and_resume_carries_forward() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    // start=1_100, end=1_200 → duration 100s, rate 10/s.
+    let id = client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &1000i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    // Advance to 30% (t=1_130) and pause.
+    data.env.ledger().set_timestamp(1_130);
+    let paused = client.pause(&id);
+    assert_eq!(paused.status, StreamStatus::Paused);
+    assert_eq!(client.stream_balance(&id), 300);
+
+    // Accrual must stay frozen at 300 throughout an arbitrarily long pause.
+    data.env.ledger().set_timestamp(1_180);
+    assert_eq!(client.stream_balance(&id), 300);
+    data.env.ledger().set_timestamp(1_500);
+    assert_eq!(client.stream_balance(&id), 300);
+
+    // Resume at t=1_500: the 370s pause must shift end_time from 1_200 to 1_570.
+    let resumed = client.resume(&id);
+    assert_eq!(resumed.status, StreamStatus::Active);
+    assert_eq!(resumed.end_time, 1_570);
+
+    // Right after resume accrual is still 300 (no time has elapsed unpaused).
+    assert_eq!(client.stream_balance(&id), 300);
+
+    // 35s further: 300 + 35*10 = 650.
+    data.env.ledger().set_timestamp(1_535);
+    assert_eq!(client.stream_balance(&id), 650);
+
+    // At the new end_time the full amount has vested.
+    data.env.ledger().set_timestamp(1_570);
+    assert_eq!(client.stream_balance(&id), 1000);
+}
+
+/// pause rejects a stream that is not currently Active.
+#[test]
+fn pause_rejects_non_active_stream() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let id = client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &1000i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    data.env.ledger().set_timestamp(1_130);
+    client.pause(&id);
+
+    // Pausing an already-paused stream must fail.
+    let result = client.try_pause(&id);
+    assert_eq!(
+        result.expect_err("double pause should fail"),
+        Ok(Error::InvalidState)
+    );
+}
+
+/// resume rejects a stream that is not currently Paused.
+#[test]
+fn resume_rejects_non_paused_stream() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let id = client.create_stream(
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &1000i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    // The stream is Active, not Paused.
+    let result = client.try_resume(&id);
+    assert_eq!(
+        result.expect_err("resume of active stream should fail"),
+        Ok(Error::InvalidState)
+    );
 }


### PR DESCRIPTION
Adds thorough test coverage for the pause/resume accrual-freeze behaviour required by #706.

- `pause_freezes_accrual_and_resume_carries_forward`: proves the vested amount freezes at the exact pause instant (300/1000 at the 30% mark), stays frozen for an arbitrarily long pause, and that resume extends `end_time` by the paused duration so the full amount still vests on the carried-forward schedule.
- `pause_rejects_non_active_stream` and `resume_rejects_non_paused_stream`: invalid-state guards.

Also repairs the contract crate build (it did not compile on main): removes duplicate `Stream`/`StreamStatus`/`DataKey` defs from `lib.rs`, shortens an over-long event topic (`admin_action` → `admin_act`), and fixes pre-existing test compile errors.

`cargo test -p streampay-stream`: 64 passing (1 pre-existing unrelated failure left untouched).

Closes #706