### PR TITLE
feat: add per-org token allowlist enforcement

### DIFF
--- a/contracts/contracts/streampay-stream/src/allowlist.rs
+++ b/contracts/contracts/streampay-stream/src/allowlist.rs
@@ -1,0 +1,82 @@
+//! # Per-organisation token allowlist
+//!
+//! The contract already supports a *global* token allow/deny list
+//! (`storage::set_token_allowed`). This module layers a finer-grained,
+//! **per-organisation** allowlist on top so a multi-tenant deployment can
+//! restrict which tokens each org may stream.
+//!
+//! ## Semantics
+//!
+//! For a given `(org, token)` pair the entry is one of:
+//! - **Absent** — the org has not configured this token. The org is treated as
+//!   *unrestricted* for that token (subject to the global allowlist), preserving
+//!   backwards-compatible behaviour for orgs that never opt in.
+//! - **`true`** — explicitly allowed.
+//! - **`false`** — explicitly blocked for that org, even if globally allowed.
+//!
+//! An org "opts in" to enforcement the first time it sets any entry: once an
+//! org has set at least one token to `true`, tokens it has *not* allowed are
+//! treated as blocked. This makes the allowlist a true whitelist for orgs that
+//! use it, while leaving non-participating orgs unaffected.
+//!
+//! All reads/writes use persistent storage; no arithmetic is performed, so
+//! there are no overflow concerns in this module.
+
+use soroban_sdk::{contracttype, Address, Env};
+
+/// Persistent storage keys owned by the per-org allowlist.
+#[derive(Clone)]
+#[contracttype]
+enum OrgAllowKey {
+    /// Explicit allow/deny entry for a single `(org, token)` pair.
+    Token(Address, Address),
+    /// Marker set once an org has enabled allowlist enforcement.
+    Enabled(Address),
+}
+
+/// Sets whether `token` is allowed for `org`.
+///
+/// The first call with `allowed = true` for an org flips that org into
+/// "enforced" mode (see module docs). Setting `allowed = false` records an
+/// explicit block but does not, by itself, enable enforcement.
+pub fn set_org_token_allowed(env: &Env, org: &Address, token: &Address, allowed: bool) {
+    env.storage()
+        .persistent()
+        .set(&OrgAllowKey::Token(org.clone(), token.clone()), &allowed);
+
+    if allowed {
+        env.storage()
+            .persistent()
+            .set(&OrgAllowKey::Enabled(org.clone()), &true);
+    }
+}
+
+/// Returns whether `org` has enabled allowlist enforcement.
+pub fn is_org_enforced(env: &Env, org: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&OrgAllowKey::Enabled(org.clone()))
+        .unwrap_or(false)
+}
+
+/// Returns the explicit entry for `(org, token)`, if any.
+fn explicit_entry(env: &Env, org: &Address, token: &Address) -> Option<bool> {
+    env.storage()
+        .persistent()
+        .get(&OrgAllowKey::Token(org.clone(), token.clone()))
+}
+
+/// Returns whether `token` is blocked for `org` under the per-org allowlist.
+///
+/// Resolution order:
+/// 1. An explicit `false` entry blocks the token.
+/// 2. An explicit `true` entry allows it.
+/// 3. No entry: blocked iff the org is in enforced mode (whitelist semantics);
+///    otherwise allowed.
+pub fn is_org_token_blocked(env: &Env, org: &Address, token: &Address) -> bool {
+    match explicit_entry(env, org, token) {
+        Some(true) => false,
+        Some(false) => true,
+        None => is_org_enforced(env, org),
+    }
+}

--- a/contracts/contracts/streampay-stream/src/events.rs
+++ b/contracts/contracts/streampay-stream/src/events.rs
@@ -150,8 +150,11 @@ pub fn amended(
 /// Carries the action symbol (e.g., "pause", "resume", "force_cancel") so
 /// indexers can track admin operations on behalf of senders.
 pub fn admin_action(env: &Env, stream_id: u64, admin: &Address, action: Symbol, timestamp: u64) {
+    // `symbol_short!` caps topics at 9 characters, so the admin-action topic is
+    // abbreviated to "admin_act"; the specific action ("pause"/"resume"/…) is
+    // carried in the event body for indexers.
     env.events().publish(
-        (symbol_short!("stream"), symbol_short!("admin_action")),
+        (symbol_short!("stream"), symbol_short!("admin_act")),
         (stream_id, admin.clone(), action, timestamp),
     );
 }

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -17,6 +17,7 @@
 //! - Allow or block individual token contracts ([`Contract::set_token_allowed`]).
 #![no_std]
 
+mod allowlist;
 mod error;
 mod events;
 mod limits;
@@ -28,83 +29,12 @@ use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
 pub use storage::{Stream, StreamStatus};
 
 /// The StreamPay contract entry point registered with the Soroban host.
+///
+/// The [`Stream`] record and [`StreamStatus`] enum are defined once in the
+/// [`storage`] module and re-exported above, so there is a single source of
+/// truth for the on-chain data layout.
 #[contract]
 pub struct Contract;
-
-/// Lifecycle state of a payment stream.
-///
-/// Transitions allowed by the current public API:
-/// ```text
-/// Draft ──start_stream──► Active ──withdraw (full)──► Settled
-/// ```
-/// `Paused`, `Ended`, and `Cancelled` are reserved for future entry points.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum StreamStatus {
-    /// Created and funded but not yet activated; accrual has not started.
-    Draft,
-    /// Tokens are flowing linearly to the recipient.
-    Active,
-    /// Reserved — stream-level pause not yet implemented.
-    Paused,
-    /// All `total_amount` tokens have been released to the recipient.
-    Settled,
-    /// Reserved — natural expiry entry point not yet implemented.
-    Ended,
-    /// Reserved — sender-initiated cancellation not yet implemented.
-    Cancelled,
-}
-
-/// On-chain record for a single payment stream.
-///
-/// All token amounts are in the token's base unit (stroops for XLM-based
-/// assets). All timestamps are Unix seconds as reported by the ledger.
-#[derive(Clone, Debug)]
-#[contracttype]
-pub struct Stream {
-    /// Unique monotonic identifier assigned at creation. Starts at 1.
-    pub id: u64,
-    /// Address that created the stream and escrowed `total_amount`.
-    pub sender: Address,
-    /// Address that receives streamed tokens via [`Contract::withdraw`].
-    pub recipient: Address,
-    /// Stellar asset contract address being streamed.
-    pub token: Address,
-    /// Total tokens (base units) locked in escrow at creation. Always > 0.
-    pub total_amount: i128,
-    /// Tokens already transferred to `recipient`. Monotonically non-decreasing.
-    /// Invariant: `released_amount <= total_amount`.
-    pub released_amount: i128,
-    /// Ledger timestamp when accrual begins. Zero for `Draft` streams.
-    pub start_time: u64,
-    /// Ledger timestamp when accrual ends (`start_time + duration`).
-    /// Zero for `Draft` streams.
-    pub end_time: u64,
-    /// Stream length in seconds. Set at creation; never changes.
-    pub duration: u64,
-    /// Ledger timestamp of the last state-mutating operation on this stream.
-    pub last_update: u64,
-    /// Current lifecycle status.
-    pub status: StreamStatus,
-}
-
-/// Ledger storage keys used internally by this contract.
-///
-/// Not exposed to callers; listed here for auditability.
-#[derive(Clone)]
-#[contracttype]
-enum DataKey {
-    /// The privileged admin [`Address`].
-    Admin,
-    /// Global emergency pause flag (`bool`).
-    Paused,
-    /// Monotonic counter; value is the **next** stream ID to assign.
-    NextStreamId,
-    /// Per-stream record keyed by numeric ID.
-    Stream(u64),
-    /// Per-token allowlist entry. Absent or `true` → allowed; `false` → blocked.
-    TokenAllowed(Address),
-}
 
 #[contractimpl]
 impl Contract {
@@ -287,6 +217,88 @@ impl Contract {
         require_admin(&env, &admin)?;
         storage::set_token_allowed(&env, &token, allowed);
         Ok(())
+    }
+
+    /// Configures the **per-organisation** token allowlist for `org`.
+    ///
+    /// This layers on top of the global allowlist ([`Contract::set_token_allowed`]):
+    /// the first time an org is granted a token (`allowed = true`) the org
+    /// switches to whitelist mode, after which any token the org has not
+    /// explicitly allowed is blocked for that org's streams created via
+    /// [`Contract::create_stream_for_org`]. Setting `allowed = false` records an
+    /// explicit per-org block.
+    ///
+    /// # Parameters
+    /// - `admin`   — Must match the admin set at initialisation.
+    /// - `org`     — Organisation address the rule applies to.
+    /// - `token`   — Token contract address being configured.
+    /// - `allowed` — `true` to allow for this org; `false` to block.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] if `admin` is not the initialised admin.
+    /// - [`Error::NotFound`] if the contract has not been initialised.
+    ///
+    /// # Auth
+    /// Requires authorisation from `admin`.
+    pub fn set_org_token_allowed(
+        env: Env,
+        admin: Address,
+        org: Address,
+        token: Address,
+        allowed: bool,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        allowlist::set_org_token_allowed(&env, &org, &token, allowed);
+        Ok(())
+    }
+
+    /// Returns `true` if `token` is allowed for `org` under the per-org
+    /// allowlist (read-only; also honours the global allowlist).
+    pub fn is_org_token_allowed(env: Env, org: Address, token: Address) -> bool {
+        !allowlist::is_org_token_blocked(&env, &org, &token)
+            && !storage::is_token_blocked(&env, &token)
+    }
+
+    /// Creates a funded stream on behalf of `org`, enforcing the per-org token
+    /// allowlist in addition to all the checks performed by
+    /// [`Contract::create_stream`].
+    ///
+    /// `org` is the organisation the stream is attributed to; the per-org
+    /// allowlist for `(org, token)` is consulted before the stream is created.
+    ///
+    /// # Errors
+    /// In addition to every error of [`Contract::create_stream`]:
+    /// - [`Error::TokenNotAllowed`] if `token` is blocked for `org` by the
+    ///   per-org allowlist.
+    ///
+    /// # Auth
+    /// Requires authorisation from `sender`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_stream_for_org(
+        env: Env,
+        org: Address,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        start_time: u64,
+        end_time: u64,
+    ) -> Result<u64, Error> {
+        // Per-org allowlist gate runs first so a blocked token is rejected
+        // before any auth/escrow side effects in create_stream.
+        if allowlist::is_org_token_blocked(&env, &org, &token) {
+            return Err(Error::TokenNotAllowed);
+        }
+
+        Self::create_stream(
+            env,
+            sender,
+            recipient,
+            token,
+            total_amount,
+            start_time,
+            end_time,
+        )
     }
 
     /// Creates a funded stream and escrows `total_amount` from `sender`.

--- a/contracts/contracts/streampay-stream/src/test.rs
+++ b/contracts/contracts/streampay-stream/src/test.rs
@@ -651,7 +651,7 @@ fn cancel_stream_emits_cancelled_event() {
     assert!(!events.is_empty(), "cancel_stream should emit events");
 
     // The last event should be the cancelled event
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -671,11 +671,10 @@ fn cancel_stream_requires_auth() {
         &1_200u64,
     );
 
-    // Mock auths off and try to cancel as a different address
+    // Mock auths off so the required sender authorisation is absent.
     data.env.mock_auths(&[]);
-    let impostor = Address::generate(&data.env);
 
-    let result = client.try_cancel_stream(&impostor, &id);
+    let result = client.try_cancel_stream(&id);
     assert!(
         result.is_err(),
         "cancel_stream should fail without auth from sender"
@@ -832,7 +831,7 @@ fn pause_emits_admin_action_event() {
     assert!(!events.is_empty(), "pause should emit events");
 
     // The event should have 2 topics (stream, pause)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -865,7 +864,7 @@ fn resume_emits_admin_action_event() {
     assert!(!events.is_empty(), "resume should emit events");
 
     // The event should have 2 topics (stream, resume)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -898,7 +897,7 @@ fn settle_emits_admin_action_event() {
     assert!(!events.is_empty(), "settle should emit events");
 
     // The event should have 2 topics (stream, admin_action)
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     assert_eq!(topics.len(), 2, "Event should have 2 topics");
 }
 
@@ -1187,4 +1186,132 @@ fn pause_resume_preserves_vested_amount() {
     data.env.ledger().set_timestamp(1_300);
     let resumed_vested = client.stream_balance(&id);
     assert_eq!(resumed_vested, 1000);
+}
+
+// ── Per-org token allowlist (#704) ────────────────────────────────────────────
+
+/// An org with no allowlist entries is unrestricted (backwards compatible).
+#[test]
+fn org_without_allowlist_is_unrestricted() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let org = Address::generate(&data.env);
+
+    // No per-org entries → all globally-allowed tokens are allowed.
+    assert!(client.is_org_token_allowed(&org, &data.tokens[0]));
+
+    let id = client.create_stream_for_org(
+        &org,
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &100i128,
+        &1_100u64,
+        &1_200u64,
+    );
+    assert_eq!(client.get_stream(&id).token, data.tokens[0]);
+}
+
+/// Once an org allowlists a token it enters whitelist mode: other tokens block.
+#[test]
+fn org_allowlist_enforces_whitelist_mode() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let org = Address::generate(&data.env);
+
+    // Allow token[0] for the org → org is now enforced.
+    client.set_org_token_allowed(&data.admin, &org, &data.tokens[0], &true);
+    assert!(client.is_org_token_allowed(&org, &data.tokens[0]));
+    // token[1] was never allowed for this org → blocked.
+    assert!(!client.is_org_token_allowed(&org, &data.tokens[1]));
+
+    // Allowed token streams fine.
+    client.create_stream_for_org(
+        &org,
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &100i128,
+        &1_100u64,
+        &1_200u64,
+    );
+
+    // Non-allowed token is rejected for this org.
+    let result = client.try_create_stream_for_org(
+        &org,
+        &data.sender,
+        &data.recipient,
+        &data.tokens[1],
+        &100i128,
+        &1_300u64,
+        &1_400u64,
+    );
+    assert_eq!(
+        result.expect_err("non-allowlisted token should be blocked for org"),
+        Ok(Error::TokenNotAllowed)
+    );
+}
+
+/// An explicit per-org block overrides a global allow.
+#[test]
+fn org_allowlist_explicit_block() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let org = Address::generate(&data.env);
+
+    client.set_org_token_allowed(&data.admin, &org, &data.tokens[0], &false);
+    assert!(!client.is_org_token_allowed(&org, &data.tokens[0]));
+
+    let result = client.try_create_stream_for_org(
+        &org,
+        &data.sender,
+        &data.recipient,
+        &data.tokens[0],
+        &100i128,
+        &1_100u64,
+        &1_200u64,
+    );
+    assert_eq!(
+        result.expect_err("explicitly blocked token should fail for org"),
+        Ok(Error::TokenNotAllowed)
+    );
+}
+
+/// Per-org allowlists are independent across organisations.
+#[test]
+fn org_allowlist_is_per_org() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let org_a = Address::generate(&data.env);
+    let org_b = Address::generate(&data.env);
+
+    // org_a enters whitelist mode allowing only token[0].
+    client.set_org_token_allowed(&data.admin, &org_a, &data.tokens[0], &true);
+
+    // org_a: token[1] blocked; org_b: unrestricted (never opted in).
+    assert!(!client.is_org_token_allowed(&org_a, &data.tokens[1]));
+    assert!(client.is_org_token_allowed(&org_b, &data.tokens[1]));
+}
+
+/// Only the admin may configure a per-org allowlist.
+#[test]
+fn set_org_token_allowed_requires_admin() {
+    let data = setup_init();
+    let client = contract_client(&data.env);
+    client.initialize(&data.admin);
+
+    let org = Address::generate(&data.env);
+    data.env.mock_auths(&[]);
+
+    let result =
+        client.try_set_org_token_allowed(&data.admin, &org, &data.tokens[0], &true);
+    assert!(result.is_err(), "non-authorised admin call should fail");
 }


### PR DESCRIPTION
Adds a per-organisation token allowlist layered on top of the global allowlist.

- New `src/allowlist.rs`: per-`(org, token)` allow/deny with whitelist semantics — an org becomes 'enforced' once it allows any token, after which un-allowed tokens are blocked for that org; orgs that never opt in stay unrestricted (backwards compatible). Explicit `false` overrides a global allow.
- New entrypoints: admin-gated `set_org_token_allowed`, read-only `is_org_token_allowed`, and `create_stream_for_org` which enforces the per-org gate before any auth/escrow side effects.
- Full `///` rustdoc; `require_admin` on the state-changing entrypoint.
- Tests: unrestricted-by-default, whitelist enforcement, explicit block overriding global allow, per-org independence, and admin-auth requirement.

Also repairs the contract crate build (it did not compile on main): removes duplicate type defs in `lib.rs`, shortens an over-long event topic, and fixes pre-existing test compile errors.

`cargo test -p streampay-stream`: 66 passing (1 pre-existing unrelated failure left untouched).

Closes #704