### PR TITLE
Add /api/audit/export streaming endpoint

### DIFF
--- a/app/api/audit/export/route.test.ts
+++ b/app/api/audit/export/route.test.ts
@@ -1,0 +1,100 @@
+/** @jest-environment node */
+
+import jwt from "jsonwebtoken";
+import { GET, POST } from "./route";
+import { JWT_SECRET } from "@/app/lib/auth";
+import { auditLogStore, resetAuditLogStore } from "@/app/lib/audit-log";
+
+function signAccessToken(role: string, actorId: string) {
+  return jwt.sign(
+    { sub: `${actorId}-wallet`, role, actorId, iss: "streampay", aud: "streampay-api" },
+    JWT_SECRET,
+    { expiresIn: "15m" },
+  );
+}
+
+function makeRequest(path: string, role: string, actorId: string) {
+  return new Request(`http://localhost${path}`, {
+    headers: { authorization: `Bearer ${signAccessToken(role, actorId)}` },
+  });
+}
+
+describe("GET /api/audit/export", () => {
+  beforeEach(() => {
+    resetAuditLogStore();
+    auditLogStore.append({
+      action: "stream.settle",
+      actor: { id: "admin-1", role: "admin" },
+      after: { status: "ended" },
+      before: { status: "active" },
+      requestId: "req-export-001",
+      target: { account: "acct_demo_admin", id: "stream-abc", type: "stream" },
+      timestamp: "2026-04-28T12:00:00.000Z",
+    });
+    auditLogStore.append({
+      action: "stream.create",
+      actor: { id: "admin-2", role: "admin" },
+      after: { status: "active" },
+      before: null,
+      requestId: "req-export-002",
+      target: { account: "acct_second", id: "stream-def", type: "stream" },
+      timestamp: "2026-04-28T13:00:00.000Z",
+    });
+  });
+
+  it("returns 401 when no token is provided", async () => {
+    const request = new Request("http://localhost/api/audit/export");
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when a non-export role (support) calls the endpoint", async () => {
+    const response = await GET(makeRequest("/api/audit/export", "support", "support-9"));
+    const body = await response.json();
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("streams NDJSON rows for an admin and includes chain-integrity header", async () => {
+    // Filter to only the rows we appended in beforeEach so the test is
+    // independent of any bootstrap seeds already present in the store.
+    const response = await GET(
+      makeRequest("/api/audit/export?actorId=admin-1&requestId=req-export-001", "admin", "admin-1"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/x-ndjson");
+    expect(response.headers.get("x-audit-chain-intact")).toBe("true");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+
+    const text = await response.text();
+    const lines = text.trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const rows = lines.map((l) => JSON.parse(l));
+    expect(rows[0].action).toBe("stream.settle");
+    expect(rows[0].requestId).toBe("req-export-001");
+    // Target account must be masked in export rows.
+    expect(rows[0].redactedTargetAccount).toBeDefined();
+    expect(rows[0].redactedTargetAccount).not.toBe("acct_demo_admin");
+  });
+
+  it("honours the limit query parameter", async () => {
+    const response = await GET(
+      makeRequest("/api/audit/export?limit=1", "admin", "admin-1"),
+    );
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    const lines = text.trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("returns 405 for POST requests", async () => {
+    const response = await POST();
+    const body = await response.json();
+    expect(response.status).toBe(405);
+    expect(body.error.code).toBe("METHOD_NOT_ALLOWED");
+  });
+});

--- a/app/api/audit/export/route.ts
+++ b/app/api/audit/export/route.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/audit/export
+ *
+ * Streams the audit log as NDJSON (Newline Delimited JSON).
+ * Each line is a JSON-serialised AuditExportRow.
+ *
+ * Access: admin and compliance roles only (same as the export gate on
+ * the main /api/audit route).
+ *
+ * Query parameters (all optional):
+ *   action    – filter by audit action (e.g. "stream.settle")
+ *   actorId   – filter by actor ID
+ *   targetId  – filter by target ID
+ *   requestId – filter by originating request ID
+ *   role      – filter by actor role
+ *   q         – free-text search across serialised entry
+ *   limit     – max rows to stream (1–250, default 250)
+ */
+
+import { requireAuditLogAccess } from "@/app/lib/auth";
+import { AUDIT_LOG_RETENTION_DAYS, auditLogStore } from "@/app/lib/audit-log";
+import type { AuditActorRole, AuditListFilters } from "@/app/types/audit";
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createErrorResponse(code: string, message: string, status: number) {
+  return NextResponse.json(
+    { error: { code, message, request_id: randomUUID() } },
+    { status },
+  );
+}
+
+function parseLimit(value: string | null, defaultValue = 250): number {
+  const parsed = Number.parseInt(value ?? String(defaultValue), 10);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.min(Math.max(parsed, 1), 250);
+}
+
+function buildFilters(request: Request): AuditListFilters {
+  const { searchParams } = new URL(request.url);
+  return {
+    action: searchParams.get("action"),
+    actorId: searchParams.get("actorId"),
+    limit: parseLimit(searchParams.get("limit")),
+    q: searchParams.get("q"),
+    requestId: searchParams.get("requestId"),
+    role: searchParams.get("role") as AuditActorRole | null,
+    targetId: searchParams.get("targetId"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request) {
+  // Require export-level access (admin / compliance).
+  const actor = requireAuditLogAccess(request, "export");
+  if (actor instanceof NextResponse) {
+    return actor;
+  }
+
+  const filters = buildFilters(request);
+
+  // Build the NDJSON body by iterating the export rows lazily.
+  const rows = auditLogStore.exportRows(filters);
+  const chainIntact = auditLogStore.assertIntegrity();
+
+  // Stream the rows as NDJSON via a ReadableStream so that large exports do
+  // not need to be buffered entirely in memory before the first byte is sent.
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const row of rows) {
+        controller.enqueue(encoder.encode(JSON.stringify(row) + "\n"));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+      // Clients can verify tamper-evident chain integrity from this header.
+      "x-audit-chain-intact": String(chainIntact),
+      "x-audit-retention-days": String(AUDIT_LOG_RETENTION_DAYS),
+      // Prevent proxies from buffering the stream.
+      "x-content-type-options": "nosniff",
+      "cache-control": "no-store",
+    },
+    status: 200,
+  });
+}
+
+// Mutations are never allowed on the audit log.
+export async function POST() {
+  return createErrorResponse("METHOD_NOT_ALLOWED", "Audit log is read-only", 405);
+}
+
+export async function PUT() {
+  return createErrorResponse("METHOD_NOT_ALLOWED", "Audit log is read-only", 405);
+}
+
+export async function PATCH() {
+  return createErrorResponse("METHOD_NOT_ALLOWED", "Audit log is read-only", 405);
+}
+
+export async function DELETE() {
+  return createErrorResponse("METHOD_NOT_ALLOWED", "Audit log is read-only", 405);
+}


### PR DESCRIPTION
Closes #696

## Summary
- Adds `app/api/audit/export/route.ts`: a dedicated `GET /api/audit/export` endpoint that streams audit log rows as NDJSON via the Web Streams API
- Requires admin/compliance-level JWT (reuses `requireAuditLogAccess(request, "export")` gate)
- Responds with `content-type: application/x-ndjson`, `x-audit-chain-intact`, `x-audit-retention-days`, and `cache-control: no-store` headers
- Adds `app/api/audit/export/route.test.ts` with 5 test cases covering 401/403 auth, NDJSON streaming, `limit` parameter, and method-not-allowed

## Test plan
- [ ] `npx jest app/api/audit/export/route.test.ts` — all 5 tests pass
- [ ] Admin token receives NDJSON stream with masked target accounts
- [ ] Support-role token receives 403
- [ ] Unauthenticated request receives 401

🤖 Generated with Claude Code