### PR TITLE
Add /api/admin/circuit-breaker control endpoint

### DIFF
--- a/app/api/admin/circuit-breaker/route.test.ts
+++ b/app/api/admin/circuit-breaker/route.test.ts
@@ -1,0 +1,113 @@
+/** @jest-environment node */
+import { POST, GET } from "./route";
+import { _resetAdminStateForTesting } from "@/app/lib/admin-guard";
+
+const ADMIN_ADDRESS = "GADMIN_TEST_ADDRESS_12345";
+
+/** Build a request with the test admin wallet address header. */
+function makeRequest(
+  method: "POST" | "GET",
+  body?: Record<string, unknown>,
+): Request {
+  return new Request("http://localhost/api/admin/circuit-breaker", {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "Actor-Wallet-Address": ADMIN_ADDRESS,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** Build a request without admin credentials. */
+function makeUnauthorizedRequest(body?: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/admin/circuit-breaker", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  _resetAdminStateForTesting(ADMIN_ADDRESS);
+});
+
+describe("POST /api/admin/circuit-breaker", () => {
+  it("trips the indexer circuit breaker and returns updated state", async () => {
+    const request = makeRequest("POST", { target: "indexer", open: true });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.indexer.open).toBe(true);
+    expect(body.data.indexer.updatedAt).not.toBeNull();
+    expect(body.data.webhook.open).toBe(false);
+  });
+
+  it("resets the webhook circuit breaker after tripping it", async () => {
+    // First trip it
+    await POST(makeRequest("POST", { target: "webhook", open: true }));
+    // Then reset
+    const response = await POST(makeRequest("POST", { target: "webhook", open: false }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.webhook.open).toBe(false);
+  });
+
+  it("returns 422 when target is missing", async () => {
+    const response = await POST(makeRequest("POST", { open: true }));
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 422 when target is invalid", async () => {
+    const response = await POST(makeRequest("POST", { target: "unknown-system", open: true }));
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const request = new Request("http://localhost/api/admin/circuit-breaker", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Actor-Wallet-Address": ADMIN_ADDRESS,
+      },
+      body: "not-json{{",
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("INVALID_REQUEST");
+  });
+
+  it("returns 403 when caller is not the admin", async () => {
+    const response = await POST(makeUnauthorizedRequest({ target: "indexer", open: true }));
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("Unauthorized");
+  });
+});
+
+describe("GET /api/admin/circuit-breaker", () => {
+  it("returns all circuit breaker states for the admin", async () => {
+    const response = await GET(makeRequest("GET"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toHaveProperty("indexer");
+    expect(body.data).toHaveProperty("webhook");
+    expect(body.data.indexer.open).toBe(false);
+    expect(body.data.webhook.open).toBe(false);
+  });
+
+  it("returns 403 for unauthenticated GET requests", async () => {
+    const request = new Request("http://localhost/api/admin/circuit-breaker", {
+      method: "GET",
+    });
+    const response = await GET(request);
+    expect(response.status).toBe(403);
+  });
+});

--- a/app/api/admin/circuit-breaker/route.ts
+++ b/app/api/admin/circuit-breaker/route.ts
@@ -1,0 +1,87 @@
+/**
+ * POST /api/admin/circuit-breaker
+ *
+ * Toggle a named circuit breaker for the indexer or webhook subsystem.
+ * Gated by admin auth — only the admin address may call this.
+ *
+ * Body: { "target": "indexer" | "webhook", "open": true | false }
+ *
+ * When open=true:  the named subsystem is considered tripped — consumers
+ *                  should halt event dispatch for that target.
+ * When open=false: breaker reset, normal processing resumes.
+ *
+ * GET /api/admin/circuit-breaker
+ *
+ * Returns the current state of all circuit breakers (read-only, admin-gated).
+ *
+ * ## Error codes
+ * | Code             | HTTP | Meaning                                    |
+ * |------------------|------|--------------------------------------------|
+ * | INVALID_REQUEST  | 400  | Request body is malformed JSON             |
+ * | VALIDATION_ERROR | 422  | Missing or invalid fields in body          |
+ * | Unauthorized     | 403  | Caller is not the admin                    |
+ */
+
+import { NextResponse } from "next/server";
+import {
+  setCircuitBreaker,
+  getCircuitBreakers,
+  requireAdmin,
+} from "@/app/lib/admin-guard";
+import { recordPrivilegedStreamAuditEvent } from "@/app/lib/audit-log";
+
+function err(code: string, message: string, status: number) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return err("INVALID_REQUEST", "Request body must be valid JSON", 400);
+  }
+
+  const { target, open } = body as Record<string, unknown>;
+
+  if (typeof target !== "string" || target.trim().length === 0) {
+    return err(
+      "VALIDATION_ERROR",
+      'Body must contain { target: "indexer" | "webhook", open: boolean }',
+      422,
+    );
+  }
+
+  if (typeof open !== "boolean") {
+    return err(
+      "VALIDATION_ERROR",
+      'Body must contain { target: "indexer" | "webhook", open: boolean }',
+      422,
+    );
+  }
+
+  const before = getCircuitBreakers();
+  const result = setCircuitBreaker(request, target.trim(), open);
+  if (result instanceof NextResponse) return result;
+
+  recordPrivilegedStreamAuditEvent({
+    action: open
+      ? `admin.circuit-breaker.${target}.trip`
+      : `admin.circuit-breaker.${target}.reset`,
+    before: { circuitBreaker: { target, open: before[target as keyof typeof before]?.open } },
+    after:  { circuitBreaker: { target, open } },
+    metadata: { updatedAt: result.circuitBreakers[target as "indexer" | "webhook"]?.updatedAt },
+    request,
+    streamId: "global",
+    targetAccount: result.adminAddress,
+  });
+
+  return NextResponse.json({ data: result.circuitBreakers });
+}
+
+export async function GET(request: Request) {
+  const authResult = requireAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  return NextResponse.json({ data: getCircuitBreakers() });
+}

--- a/app/lib/admin-guard.ts
+++ b/app/lib/admin-guard.ts
@@ -36,6 +36,19 @@ const TIMELOCK_MS = TIMELOCK_HOURS * 60 * 60 * 1000;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/** Supported circuit breaker targets. */
+export type CircuitBreakerTarget = "indexer" | "webhook";
+
+/** State of a single named circuit breaker. */
+export interface CircuitBreakerState {
+  /** Whether this circuit breaker is open (tripped). */
+  open: boolean;
+  /** ISO-8601 timestamp of the last toggle. */
+  updatedAt: string | null;
+  /** Admin address that last toggled this breaker. */
+  updatedBy: string | null;
+}
+
 export interface AdminState {
   /** Stellar G... address of the current admin. Never null after init. */
   adminAddress: string;
@@ -47,6 +60,8 @@ export interface AdminState {
   adminRotatedAt: string | null;
   /** Pending upgrade (if any). */
   pendingUpgrade: PendingUpgrade | null;
+  /** Per-component circuit breakers (indexer, webhook). */
+  circuitBreakers: Record<CircuitBreakerTarget, CircuitBreakerState>;
 }
 
 export interface PendingUpgrade {
@@ -96,6 +111,10 @@ const _state: AdminState = {
   pausedAt:       null,
   adminRotatedAt: null,
   pendingUpgrade: null,
+  circuitBreakers: {
+    indexer: { open: false, updatedAt: null, updatedBy: null },
+    webhook: { open: false, updatedAt: null, updatedBy: null },
+  },
 };
 
 // ── Public view ───────────────────────────────────────────────────────────────
@@ -406,6 +425,66 @@ export function checkNotPaused(operation: string): NextResponse | null {
   );
 }
 
+// ── Circuit-breaker per-component toggle ──────────────────────────────────────
+
+/** Recognized circuit breaker targets. */
+const VALID_TARGETS = new Set<CircuitBreakerTarget>(["indexer", "webhook"]);
+
+/**
+ * Toggle a named circuit breaker (indexer or webhook).
+ *
+ * Gated by admin auth. When open=true the consuming service should stop
+ * dispatching events for that subsystem; when open=false it resumes.
+ *
+ * @param request  Incoming HTTP request (used to verify admin identity).
+ * @param target   "indexer" | "webhook"
+ * @param open     true = trip the breaker; false = reset it.
+ * @returns        Updated AdminState or a NextResponse error.
+ */
+export function setCircuitBreaker(
+  request: Request,
+  target: string,
+  open: boolean,
+): AdminState | NextResponse {
+  const authResult = requireAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  if (!VALID_TARGETS.has(target as CircuitBreakerTarget)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `Invalid target '${target}'. Must be one of: ${[...VALID_TARGETS].join(", ")}.`,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  const t = target as CircuitBreakerTarget;
+  _state.circuitBreakers[t] = {
+    open,
+    updatedAt: new Date().toISOString(),
+    updatedBy: authResult,
+  };
+
+  return { ..._state };
+}
+
+/**
+ * Returns the current state of all circuit breakers.
+ */
+export function getCircuitBreakers(): Readonly<Record<CircuitBreakerTarget, CircuitBreakerState>> {
+  return { ..._state.circuitBreakers };
+}
+
+/**
+ * Returns true when the named circuit breaker is open (tripped).
+ */
+export function isCircuitBreakerOpen(target: CircuitBreakerTarget): boolean {
+  return _state.circuitBreakers[target]?.open ?? false;
+}
+
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
 /**
@@ -417,4 +496,8 @@ export function _resetAdminStateForTesting(adminAddress = DEV_ADMIN_PLACEHOLDER)
   _state.pausedAt       = null;
   _state.adminRotatedAt = null;
   _state.pendingUpgrade = null;
+  _state.circuitBreakers = {
+    indexer: { open: false, updatedAt: null, updatedBy: null },
+    webhook: { open: false, updatedAt: null, updatedBy: null },
+  };
 }


### PR DESCRIPTION
Closes #697

## Summary
- Adds `POST /api/admin/circuit-breaker` to trip or reset named circuit breakers (`indexer` | `webhook`), gated by admin auth with audit logging
- Adds `GET /api/admin/circuit-breaker` to read all breaker states (admin-only)
- Extends `AdminState` in `admin-guard.ts` with per-component `circuitBreakers` map and new `setCircuitBreaker`, `getCircuitBreakers`, `isCircuitBreakerOpen` helpers
- 8 unit tests covering happy path, validation errors, invalid target, malformed JSON, and unauthorized access

🤖 Generated with Claude Code