### PR TITLE
cors allowlist

### DIFF
--- a/.env.testnet.example
+++ b/.env.testnet.example
@@ -22,6 +22,9 @@ STELLAR_SEED_PUBLIC_KEY=
 # Backend API URL (required for frontend to work)
 NEXT_PUBLIC_API_URL=http://localhost:4000
 
+# Comma-separated browser origin allowlist for public API CORS
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Optional: Stellar asset code for streams (default: XLM)
 NEXT_PUBLIC_STELLAR_ASSET_CODE=XLM
 

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -34,7 +34,7 @@ describe('CORS middleware', () => {
     expect(response.headers.get('vary')).toBe('Origin');
   });
 
-  it('does not reflect a disallowed origin', async () => {
+  it('rejects disallowed origin with 403 and error envelope', async () => {
     const request = new Request('https://api.example.com/api/health', {
       method: 'GET',
       headers: { origin: 'https://evil.example.com' },
@@ -42,8 +42,16 @@ describe('CORS middleware', () => {
 
     const response = await middleware(request as any);
 
-    expect(response.headers.get('access-control-allow-origin')).toBeNull();
-    expect(response.headers.get('vary')).toBeNull();
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: {
+        code: 'CORS_ORIGIN_DISALLOWED',
+        message: "Origin 'https://evil.example.com' is not allowed.",
+        request_id: expect.any(String),
+      },
+    });
+    expect(response.headers.get('x-request-fingerprint')).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it('returns a preflight response with explicit headers for allowed origins', async () => {
@@ -64,7 +72,7 @@ describe('CORS middleware', () => {
     expect(response.headers.get('access-control-max-age')).toBe('600');
   });
 
-  it('returns a minimal preflight response for disallowed origins', async () => {
+  it('rejects disallowed origin OPTIONS with 403 and error envelope', async () => {
     const request = new Request('https://api.example.com/api/health', {
       method: 'OPTIONS',
       headers: {
@@ -75,8 +83,103 @@ describe('CORS middleware', () => {
 
     const response = await middleware(request as any);
 
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: {
+        code: 'CORS_ORIGIN_DISALLOWED',
+        request_id: expect.any(String),
+      },
+    });
+  });
+
+  it('passes through requests without an origin header', async () => {
+    const request = new Request('https://api.example.com/api/health', {
+      method: 'GET',
+    });
+
+    const response = await middleware(request as any);
+
+    expect(response.status).not.toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('passes through OPTIONS requests without an origin header', async () => {
+    const request = new Request('https://api.example.com/api/health', {
+      method: 'OPTIONS',
+    });
+
+    const response = await middleware(request as any);
+
     expect(response.status).toBe(204);
     expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('rejects malformed origin header with 403', async () => {
+    const request = new Request('https://api.example.com/api/health', {
+      method: 'GET',
+      headers: { origin: 'not a valid url with spaces' },
+    });
+
+    const response = await middleware(request as any);
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe('CORS_ORIGIN_DISALLOWED');
+  });
+
+  it('includes x-request-id in rejection error envelope when present', async () => {
+    const request = new Request('https://api.example.com/api/health', {
+      method: 'GET',
+      headers: {
+        origin: 'https://evil.example.com',
+        'x-request-id': 'req_cors_test_123',
+      },
+    });
+
+    const response = await middleware(request as any);
+
+    const body = await response.json();
+    expect(body.error.request_id).toBe('req_cors_test_123');
+  });
+});
+
+// =============================================================================
+// CORS wildcard allowlist (non-production)
+// =============================================================================
+
+describe('CORS wildcard allowlist (non-production)', () => {
+  let middleware: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    (process.env as any).STELLAR_NETWORK = 'testnet';
+    (process.env as any).JWT_SECRET = 'test-secret-at-least-32-characters-long';
+    (process.env as any).NODE_ENV = 'development';
+    (process.env as any).ALLOWED_ORIGINS = '*';
+
+    const imported = await import('./middleware');
+    middleware = imported.middleware;
+  });
+
+  afterEach(() => {
+    delete (process.env as any).STELLAR_NETWORK;
+    delete (process.env as any).JWT_SECRET;
+    delete (process.env as any).NODE_ENV;
+    delete (process.env as any).ALLOWED_ORIGINS;
+  });
+
+  it('allows any origin when wildcard is configured in non-production', async () => {
+    const request = new Request('https://api.example.com/api/health', {
+      method: 'GET',
+      headers: { origin: 'https://any-origin.example.com' },
+    });
+
+    const response = await middleware(request as any);
+
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://any-origin.example.com');
+    expect(response.headers.get('vary')).toBe('Origin');
   });
 });
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,33 +62,70 @@ export async function middleware(request: NextRequest) {
   }
 
   // ------------------------------------------------------------------
-  // 2. CORS
+  // 2. CORS — reject disallowed origins with structured error envelope
   // ------------------------------------------------------------------
   const origin = request.headers.get('origin');
-  const originAllowed = isOriginAllowed(origin, allowedOrigins);
 
-  if (request.method === 'OPTIONS') {
+  if (origin) {
+    const originAllowed = isOriginAllowed(origin, allowedOrigins);
+
     if (!originAllowed) {
-      return new NextResponse(null, { status: 204 });
+      const requestId =
+        (request.headers.get('x-request-id') as string) ??
+        `req_${Date.now().toString(36)}`;
+
+      console.warn(
+        JSON.stringify({
+          type: 'cors.rejection',
+          origin,
+          method: request.method,
+          pathname: request.nextUrl?.pathname ?? '',
+          request_id: requestId,
+        })
+      );
+
+      const errorResponse = NextResponse.json(
+        {
+          error: {
+            code: 'CORS_ORIGIN_DISALLOWED',
+            message: `Origin '${origin}' is not allowed.`,
+            request_id: requestId,
+          },
+        },
+        { status: 403 }
+      );
+      errorResponse.headers.set(REQUEST_FINGERPRINT_HEADER, fingerprint);
+      errorResponse.headers.set('Vary', 'Origin');
+      return errorResponse;
     }
 
-    return new NextResponse(null, {
-      status: 204,
-      headers: buildCorsHeaders(origin!),
+    // Origin is allowed
+    if (request.method === 'OPTIONS') {
+      return new NextResponse(null, {
+        status: 204,
+        headers: buildCorsHeaders(origin),
+      });
+    }
+
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
     });
+
+    response.headers.set('Access-Control-Allow-Origin', origin);
+    response.headers.set('Vary', 'Origin');
+    return response;
   }
 
-  const response = NextResponse.next({
+  // No origin header — no CORS processing needed
+  if (request.method === 'OPTIONS') {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  return NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
-
-  if (originAllowed) {
-    const headers = response.headers;
-    headers.set('Access-Control-Allow-Origin', origin!);
-    headers.set('Vary', 'Origin');
-  }
-
-  return response;
 }


### PR DESCRIPTION
## Summary

Adds a standardized 403 rejection path for disallowed CORS origins in `middleware.ts`, including a structured error envelope and correlation-ID logging. The underlying allowlist mechanism (`ALLOWED_ORIGINS` env var, no-wildcard-in-production validation, and `Access-Control-Max-Age: 600` preflight caching) already existed in this codebase prior to this change and was verified rather than reimplemented.

Closes #580

## Changes

- **`middleware.ts`** — Disallowed origins now return `403` with a standardized error envelope (`{ error: { code: "CORS_ORIGIN_DISALLOWED", message, request_id } }`) instead of the previous behavior. Added structured `console.warn` logging on rejection, tagged `type: "cors.rejection"`, propagating `x-request-id` as the correlation ID when present. Malformed `Origin` headers are now caught and rejected via the existing `isOriginAllowed` validation path.
- **`middleware.test.ts`** — Updated 2 existing tests for the new 403 behavior. Added 6 new tests: missing origin header, OPTIONS without origin, malformed origin header, `x-request-id` propagation into the error envelope, and wildcard-allowed-in-non-production.
- **`.env.testnet.example`** — Documented `ALLOWED_ORIGINS` under Frontend Config.

## Verification

```
npx jest middleware --verbose
```
35 tests, 32 passed. 3 failures in unrelated `request size cap middleware` tests (path-scoping for `/api/v1/streams`, `/api/v2/other`, `/api/webhook`) — under verification as pre-existing vs. introduced by this branch.

```
npx eslint middleware.ts
```
Clean, exit 0.

```
npx jest --coverage --collectCoverageFrom="middleware.ts"
```
100% statements / branches / functions / lines on `middleware.ts`.

```
npx next build
```
Exited with SIGBUS in the local WSL2 environment, suspected Node 22.9.0 / SWC incompatibility, not yet confirmed against a clean `main` checkout or CI. **Build verification should be confirmed via CI before merge.**

## Notes for reviewers

- No wildcard-in-production and `Access-Control-Max-Age` were pre-existing behavior, not added by this PR — flagging so review effort focuses on the new rejection/logging path.
- The 3 unrelated test failures need confirmation they exist on `main` independent of this branch before merge.