### PR TITLE
feat: polish empty state with first-time guidance steps

### DIFF
--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -3,9 +3,12 @@ type EmptyStateProps = {
   title: string;
   description: string;
   actionLabel: string;
+  onAction?: () => void;
+  /** Optional first-time guidance steps to display below the description. */
+  guidanceSteps?: string[];
 };
 
-export function EmptyState({ eyebrow, title, description, actionLabel }: EmptyStateProps) {
+export function EmptyState({ eyebrow, title, description, actionLabel, onAction, guidanceSteps }: EmptyStateProps) {
   return (
     <section className="empty-state" aria-labelledby="empty-state-title">
       <p className="empty-state__eyebrow">{eyebrow}</p>
@@ -13,7 +16,16 @@ export function EmptyState({ eyebrow, title, description, actionLabel }: EmptySt
         {title}
       </h2>
       <p className="empty-state__description">{description}</p>
-      <button className="button button--primary" type="button">
+      {guidanceSteps && guidanceSteps.length > 0 && (
+        <ol className="empty-state__guidance" aria-label="Getting started steps">
+          {guidanceSteps.map((step, i) => (
+            <li key={i} className="empty-state__guidance-step">
+              {step}
+            </li>
+          ))}
+        </ol>
+      )}
+      <button className="button button--primary" type="button" onClick={onAction}>
         {actionLabel}
       </button>
     </section>


### PR DESCRIPTION
Closes #677

Adds optional guidanceSteps and onAction props to EmptyState, renders an accessible ordered list of getting-started steps when provided, and wires the action button to an onAction handler.