### PR TITLE
feat: add accessible Sort dropdown on /streams

### DIFF
--- a/app/components/SortDropdown.tsx
+++ b/app/components/SortDropdown.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+
+export type SortOption = "newest" | "oldest" | "recipient-asc" | "recipient-desc" | "rate-asc" | "rate-desc";
+
+const SORT_LABELS: Record<SortOption, string> = {
+  newest: "Newest first",
+  oldest: "Oldest first",
+  "recipient-asc": "Recipient A–Z",
+  "recipient-desc": "Recipient Z–A",
+  "rate-asc": "Rate low–high",
+  "rate-desc": "Rate high–low",
+};
+
+type SortDropdownProps = {
+  value: SortOption;
+  onChange: (value: SortOption) => void;
+};
+
+export function SortDropdown({ value, onChange }: SortDropdownProps) {
+  return (
+    <label className="sort-dropdown">
+      <span className="sr-only">Sort streams</span>
+      <select
+        aria-label="Sort streams"
+        className="sort-dropdown__select"
+        value={value}
+        onChange={(e) => onChange(e.target.value as SortOption)}
+      >
+        {(Object.entries(SORT_LABELS) as [SortOption, string][]).map(([key, label]) => (
+          <option key={key} value={key}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}


### PR DESCRIPTION
Closes #676

Adds SortDropdown component with 6 sort options (newest, oldest, recipient A-Z/Z-A, rate low/high), accessible via aria-label, typed with SortOption union.