### PR TITLE
docs: rustdoc sweep

### DIFF
--- a/contracts/contracts/streampay-stream/src/events.rs
+++ b/contracts/contracts/streampay-stream/src/events.rs
@@ -8,6 +8,10 @@
 
 use soroban_sdk::{contractevent, Address, BytesN, Env, Symbol};
 
+/// Emitted when a new stream is created (topic: `"stream"`, sub-topic: `"created"`).
+///
+/// Contains the stream's ID, sender, recipient, token address, total amount, and
+/// the ledger timestamp at creation.
 #[contractevent(topics = ["stream", "created"], data_format = "vec")]
 pub struct StreamCreated {
     pub stream_id: u64,
@@ -18,6 +22,10 @@ pub struct StreamCreated {
     pub timestamp: u64,
 }
 
+/// Emitted when a draft stream is started (topic: `"stream"`, sub-topic: `"started"`).
+///
+/// Records the stream ID, the computed start and end time, and the ledger
+/// timestamp of activation.
 #[contractevent(topics = ["stream", "started"], data_format = "vec")]
 pub struct StreamStarted {
     pub stream_id: u64,
@@ -26,6 +34,9 @@ pub struct StreamStarted {
     pub timestamp: u64,
 }
 
+/// Emitted when tokens are withdrawn from a stream (topic: `"stream"`, sub-topic: `"withdrawn"`).
+///
+/// Contains the stream ID, recipient, amount withdrawn, and the ledger timestamp.
 #[contractevent(topics = ["stream", "withdrawn"], data_format = "vec")]
 pub struct StreamWithdrawn {
     pub stream_id: u64,
@@ -34,6 +45,10 @@ pub struct StreamWithdrawn {
     pub timestamp: u64,
 }
 
+/// Emitted when a stream is fully settled (topic: `"stream"`, sub-topic: `"settled"`).
+///
+/// Contains the stream ID, recipient, total amount of the stream, and the
+/// ledger timestamp of settlement.
 #[contractevent(topics = ["stream", "settled"], data_format = "vec")]
 pub struct StreamSettled {
     pub stream_id: u64,
@@ -42,6 +57,10 @@ pub struct StreamSettled {
     pub timestamp: u64,
 }
 
+/// Emitted when an active stream is paused (topic: `"stream"`, sub-topic: `"paused"`).
+///
+/// Contains the stream ID, the sender who paused it, the pause time, and the
+/// ledger timestamp.
 #[contractevent(topics = ["stream", "paused"], data_format = "vec")]
 pub struct StreamPaused {
     pub stream_id: u64,
@@ -50,6 +69,10 @@ pub struct StreamPaused {
     pub timestamp: u64,
 }
 
+/// Emitted when a paused stream is resumed (topic: `"stream"`, sub-topic: `"resumed"`).
+///
+/// Contains the stream ID, the sender who resumed it, the extended end time,
+/// and the ledger timestamp.
 #[contractevent(topics = ["stream", "resumed"], data_format = "vec")]
 pub struct StreamResumed {
     pub stream_id: u64,
@@ -58,6 +81,10 @@ pub struct StreamResumed {
     pub timestamp: u64,
 }
 
+/// Emitted when a stream is cancelled (topic: `"stream"`, sub-topic: `"cancelled"`).
+///
+/// Contains the stream ID, who cancelled it, the amount returned to the
+/// sender, the amount released to the recipient, and the ledger timestamp.
 #[contractevent(topics = ["stream", "cancelled"], data_format = "vec")]
 pub struct StreamCancelled {
     pub stream_id: u64,
@@ -67,6 +94,10 @@ pub struct StreamCancelled {
     pub timestamp: u64,
 }
 
+/// Emitted when a stream is amended (topic: `"stream"`, sub-topic: `"amended"`).
+///
+/// Contains the stream ID, who amended it, the new rate per second, the new
+/// end time, and the ledger timestamp.
 #[contractevent(topics = ["stream", "amended"], data_format = "vec")]
 pub struct StreamAmended {
     pub stream_id: u64,
@@ -76,11 +107,18 @@ pub struct StreamAmended {
     pub timestamp: u64,
 }
 
+/// Emitted when the contract is upgraded (topic: `"StreamPay"`, sub-topic: `"upgraded"`).
+///
+/// Contains the new WASM hash of the upgraded contract code.
 #[contractevent(topics = ["StreamPay", "upgraded"], data_format = "single-value")]
 pub struct ContractUpgraded {
     pub new_wasm_hash: BytesN<32>,
 }
 
+/// Emitted for administrative actions on a stream (topic: `"stream"`, sub-topic: `"adminact"`).
+///
+/// Contains the stream ID, the admin address, a short action symbol, and the
+/// ledger timestamp.
 #[contractevent(topics = ["stream", "adminact"], data_format = "vec")]
 pub struct AdminAction {
     pub stream_id: u64,
@@ -89,6 +127,7 @@ pub struct AdminAction {
     pub timestamp: u64,
 }
 
+/// Publishes a [`StreamCreated`] event.
 pub fn created(
     env: &Env,
     stream_id: u64,
@@ -109,6 +148,7 @@ pub fn created(
     .publish(env);
 }
 
+/// Publishes a [`StreamStarted`] event.
 pub fn started(env: &Env, stream_id: u64, start_time: u64, end_time: u64, timestamp: u64) {
     StreamStarted {
         stream_id,
@@ -119,6 +159,7 @@ pub fn started(env: &Env, stream_id: u64, start_time: u64, end_time: u64, timest
     .publish(env);
 }
 
+/// Publishes a [`StreamWithdrawn`] event.
 pub fn withdrawn(env: &Env, stream_id: u64, recipient: &Address, amount: i128, timestamp: u64) {
     StreamWithdrawn {
         stream_id,
@@ -129,6 +170,7 @@ pub fn withdrawn(env: &Env, stream_id: u64, recipient: &Address, amount: i128, t
     .publish(env);
 }
 
+/// Publishes a [`StreamSettled`] event.
 pub fn settled(env: &Env, stream_id: u64, recipient: &Address, total_amount: i128, timestamp: u64) {
     StreamSettled {
         stream_id,
@@ -139,6 +181,7 @@ pub fn settled(env: &Env, stream_id: u64, recipient: &Address, total_amount: i12
     .publish(env);
 }
 
+/// Publishes a [`StreamPaused`] event.
 #[allow(dead_code)]
 pub fn paused(env: &Env, stream_id: u64, sender: &Address, pause_time: u64, timestamp: u64) {
     StreamPaused {
@@ -150,6 +193,7 @@ pub fn paused(env: &Env, stream_id: u64, sender: &Address, pause_time: u64, time
     .publish(env);
 }
 
+/// Publishes a [`StreamResumed`] event.
 #[allow(dead_code)]
 pub fn resumed(env: &Env, stream_id: u64, sender: &Address, end_time: u64, timestamp: u64) {
     StreamResumed {
@@ -161,10 +205,12 @@ pub fn resumed(env: &Env, stream_id: u64, sender: &Address, end_time: u64, times
     .publish(env);
 }
 
+/// Publishes a [`ContractUpgraded`] event.
 pub fn upgraded(env: &Env, new_wasm_hash: BytesN<32>) {
     ContractUpgraded { new_wasm_hash }.publish(env);
 }
 
+/// Publishes a [`StreamCancelled`] event.
 pub fn cancelled(
     env: &Env,
     stream_id: u64,
@@ -183,6 +229,7 @@ pub fn cancelled(
     .publish(env);
 }
 
+/// Publishes a [`StreamAmended`] event.
 pub fn amended(
     env: &Env,
     stream_id: u64,
@@ -201,6 +248,7 @@ pub fn amended(
     .publish(env);
 }
 
+/// Publishes an [`AdminAction`] event.
 pub fn admin_action(env: &Env, stream_id: u64, admin: &Address, action: Symbol, timestamp: u64) {
     AdminAction {
         stream_id,

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -307,8 +307,17 @@ impl Contract {
         )
     }
 
-    /// Creates a funded stream and escrows `total_amount` from `sender`.
+    /// Sets the maximum number of active streams a single sender may have
+    /// concurrently. This is a per-sender rate limit: once a sender reaches
+    /// the limit, [`Contract::create_stream`] returns
+    /// [`Error::StreamLimitExceeded`] until an existing stream transitions
+    /// to a terminal state (`Settled` or `Cancelled`).
     ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] if `admin` is not the initialised admin.
+    ///
+    /// # Auth
+    /// Requires authorisation from `admin`.
     pub fn set_max_streams_per_sender(env: Env, admin: Address, limit: u64) -> Result<(), Error> {
         require_admin(&env, &admin)?;
         limits::set_max_streams_per_sender(&env, limit);

--- a/contracts/contracts/streampay-stream/src/limits.rs
+++ b/contracts/contracts/streampay-stream/src/limits.rs
@@ -51,6 +51,11 @@ fn extend_sender_count_ttl(env: &Env, sender: &Address) {
     );
 }
 
+/// Returns the configured per-sender stream limit, or the default (10) if
+/// no limit has been explicitly set via [`set_max_streams_per_sender`].
+///
+/// This is a read-only helper; the limit is cached in instance storage and
+/// extended on every read so it should not archive under normal use.
 pub fn get_max_streams_per_sender(env: &Env) -> u64 {
     let stored: Option<u64> = env
         .storage()
@@ -62,6 +67,9 @@ pub fn get_max_streams_per_sender(env: &Env) -> u64 {
     stored.unwrap_or(DEFAULT_MAX_STREAMS_PER_SENDER)
 }
 
+/// Persists a new per-sender stream limit to instance storage and extends
+/// the instance TTL. After this call, [`get_max_streams_per_sender`] returns
+/// the new value.
 pub fn set_max_streams_per_sender(env: &Env, limit: u64) {
     env.storage()
         .instance()
@@ -69,6 +77,11 @@ pub fn set_max_streams_per_sender(env: &Env, limit: u64) {
     extend_instance_ttl(env);
 }
 
+/// Returns the number of active streams currently attributed to `sender`.
+///
+/// Persisted in a per-sender counter key. Extends the key's TTL on read so
+/// an actively streaming sender's count stays warm. Returns `0` if the
+/// sender has never created a stream.
 pub fn get_sender_stream_count(env: &Env, sender: &Address) -> u64 {
     let count: u64 = env
         .storage()
@@ -81,6 +94,11 @@ pub fn get_sender_stream_count(env: &Env, sender: &Address) -> u64 {
     count
 }
 
+/// Atomically increments the active-stream count for `sender` by one.
+///
+/// Called inside [`create_stream`](crate::Contract::create_stream) after a
+/// new stream is successfully created. Uses saturating arithmetic so an
+/// overflow cannot panic the contract.
 pub fn increment_sender_stream_count(env: &Env, sender: &Address) {
     let count = get_sender_stream_count(env, sender).saturating_add(1);
     env.storage()
@@ -89,6 +107,12 @@ pub fn increment_sender_stream_count(env: &Env, sender: &Address) {
     extend_sender_count_ttl(env, sender);
 }
 
+/// Atomically decrements the active-stream count for `sender` by one.
+///
+/// Called when a stream transitions to a terminal state (`Settled` or
+/// `Cancelled`). Uses saturating subtraction and is a no-op when the count
+/// is already zero, so it is safe to call multiple times for the same
+/// sender.
 pub fn decrement_sender_stream_count(env: &Env, sender: &Address) {
     let count = get_sender_stream_count(env, sender);
     if count > 0 {
@@ -102,6 +126,13 @@ pub fn decrement_sender_stream_count(env: &Env, sender: &Address) {
     }
 }
 
+/// Verifies that `sender` has not exceeded the per-sender stream limit.
+///
+/// Returns `Ok(())` if the sender's active-stream count is strictly below
+/// the limit, or [`Error::StreamLimitExceeded`] otherwise.
+///
+/// Called as a guard inside [`create_stream`](crate::Contract::create_stream)
+/// before any state mutation.
 pub fn check_sender_limit(env: &Env, sender: &Address) -> Result<(), Error> {
     let limit = get_max_streams_per_sender(env);
     let current = get_sender_stream_count(env, sender);

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -16,6 +16,16 @@
 
 use soroban_sdk::{contracttype, Address, Env};
 
+/// Lifecycle status of a [`Stream`] stored on-chain.
+///
+/// | Variant     | Description                                                        |
+/// |-------------|--------------------------------------------------------------------|
+/// | `Draft`     | Created but not yet started; no accrual occurs.                    |
+/// | `Active`    | Tokens are vesting linearly from `start_time` to `end_time`.       |
+/// | `Paused`    | Accrual frozen; `end_time` will be extended on resume.             |
+/// | `Settled`   | Fully paid out; terminal state.                                    |
+/// | `Ended`     | Time window elapsed, awaiting settle; transitional.                |
+/// | `Cancelled` | Cancelled by sender before full vesting; terminal state.           |
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum StreamStatus {
@@ -27,6 +37,16 @@ pub enum StreamStatus {
     Cancelled,
 }
 
+/// On-chain record for a single payment stream.
+///
+/// Each stream escrows `total_amount` from `sender` and releases it
+/// linearly to `recipient` from `start_time` to `end_time`. The
+/// `released_amount` tracks cumulative withdrawals; when it reaches
+/// `total_amount` the stream transitions to `Settled`.
+///
+/// Paused streams record `pause_time` and `total_paused_duration` so
+/// that the resumption logic can extend `end_time` by the pause length
+/// without over- or under-paying the recipient.
 #[derive(Clone, Debug)]
 #[contracttype]
 pub struct Stream {


### PR DESCRIPTION
Closes #953 

Here is the summary for the rustdoc sweep PR:

---

### Summary

Added `///` rustdoc documentation to every previously undocumented `pub fn`, `pub struct`, and `pub enum` across the `streampay-stream` contract. Also fixed a copy-paste error on `set_max_streams_per_sender` that incorrectly described it as creating a stream.

### Changes

#### `lib.rs` (1 fix)

- `set_max_streams_per_sender`: Replaced copy-pasted "Creates a funded stream and escrows total_amount from sender" doc with correct documentation describing the per-sender rate limit, error cases, and auth requirements.

#### `storage.rs` (2 items)

- `StreamStatus` enum: Added markdown-table docs documenting all 6 variants (`Draft`, `Active`, `Paused`, `Settled`, `Ended`, `Cancelled`).
- `Stream` struct: Added docs explaining the escrow lifecycle, released/total amount semantics, and pause duration fields.

#### `limits.rs` (6 items)

- `get_max_streams_per_sender`: Documents default value (10), instance storage location, and TTL extension behavior.
- `set_max_streams_per_sender`: Documents persistence and TTL extension.
- `get_sender_stream_count`: Documents per-sender counter, TTL warming on read, and default return (0).
- `increment_sender_stream_count`: Documents call site (`create_stream`) and saturating arithmetic.
- `decrement_sender_stream_count`: Documents call site (terminal states), saturating subtraction, and no-op safety.
- `check_sender_limit`: Documents guard behavior and error return.

#### `events.rs` (20 items)

- **10 event structs** (`StreamCreated`, `StreamStarted`, `StreamWithdrawn`, `StreamSettled`, `StreamPaused`, `StreamResumed`, `StreamCancelled`, `StreamAmended`, `ContractUpgraded`, `AdminAction`): Each has a one-line description referencing its topic/sub-topic pair and a description of its fields.
- **10 event emitter fns** (`created`, `started`, `withdrawn`, `settled`, `paused`, `resumed`, `upgraded`, `cancelled`, `amended`, `admin_action`): Each has a one-line doc linking to its corresponding event struct via `[` backticks.

### Verification

- All changes are pure documentation additions/fixes – no logic was modified.
- Test suite and lint should pass with no changes (rustc/cargo unavailable in this environment to run directly).