### PR TITLE
feat: implement sticky detail summary header

### DIFF
--- a/__tests__/stickyHeader.test.tsx
+++ b/__tests__/stickyHeader.test.tsx
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { StreamDetailClient } from "../app/streams/[id]/StreamDetailClient";
+import type { Stream } from "../app/types/openapi";
+
+const mockStream: Stream = {
+  id: "stream-ada",
+  recipient: "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3JKAKZK7G",
+  rate: "120 XLM / month",
+  schedule: "Pays every 30 days",
+  status: "active",
+  label: "Ada Creative Studio",
+  email: "ada@example.com",
+  createdAt: "2024-11-01T09:00:00.000Z",
+  updatedAt: "2024-11-20T14:30:00.000Z",
+  token: "XLM",
+};
+
+describe("StreamDetailClient Sticky Header", () => {
+  it("renders sticky summary header with WCAG region role and aria-label", () => {
+    render(<StreamDetailClient stream={mockStream} network="testnet" />);
+
+    const header = screen.getByRole("region", {
+      name: /stream detail summary header/i,
+    });
+
+    expect(header).toBeInTheDocument();
+    expect(header.className).toContain("sticky");
+    expect(header.className).toContain("top-0");
+  });
+
+  it("displays stream label, ID, rate, and status badges in sticky header", () => {
+    render(<StreamDetailClient stream={mockStream} network="testnet" />);
+
+    expect(screen.getByText("Ada Creative Studio")).toBeInTheDocument();
+    expect(screen.getByText(/ID:\s*stream-ada/i)).toBeInTheDocument();
+
+    // Using getAllByText since rate appears in both header and summary card
+    const rateElements = screen.getAllByText("120 XLM / month");
+    expect(rateElements.length).toBeGreaterThan(0);
+    expect(rateElements[0]).toBeInTheDocument();
+  });
+});

--- a/app/streams/[id]/StreamDetailClient.tsx
+++ b/app/streams/[id]/StreamDetailClient.tsx
@@ -20,7 +20,6 @@ type StreamDetailClientProps = {
   network?: "testnet" | "mainnet";
 };
 
-
 const ACTION_MAP: Record<string, string> = {
   draft: "Start",
   active: "Pause",
@@ -54,12 +53,16 @@ const STREAM_ACTION_SUMMARY: Record<
   },
 };
 
-export function StreamDetailClient({ stream, network = "testnet" }: StreamDetailClientProps) {
+export function StreamDetailClient({
+  stream,
+  network = "testnet",
+}: StreamDetailClientProps) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDestructiveOpen, setIsDestructiveOpen] = useState(false);
   const [error, setError] = useState<StreamPayError | null>(null);
 
-  const isIncidentMode = process.env.NEXT_PUBLIC_DISABLE_ONCHAIN_OPERATIONS === "true";
+  const isIncidentMode =
+    process.env.NEXT_PUBLIC_DISABLE_ONCHAIN_OPERATIONS === "true";
   const nextAction = ACTION_MAP[stream.status] || "Action";
   const actionSummary = STREAM_ACTION_SUMMARY[stream.id] ?? {
     amountLabel: stream.rate,
@@ -85,11 +88,13 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
         stream.createdAt,
         stream.status,
         stream.token,
-        stream.label
+        stream.label,
       );
     } catch (err) {
-      console.error('Failed to export ICS:', err);
-      alert('Failed to export vesting calendar. Please check the stream rate format.');
+      console.error("Failed to export ICS:", err);
+      alert(
+        "Failed to export vesting calendar. Please check the stream rate format.",
+      );
     }
   };
 
@@ -108,7 +113,7 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
 
     try {
       const actionRoute = nextAction.toLowerCase();
-      
+
       await fetchWithIdempotency(`/api/streams/${stream.id}/${actionRoute}`, {
         method: "POST",
         headers: {
@@ -121,14 +126,12 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
 
       alert(`${nextAction} successful for stream ${stream.id}!`);
     } catch (err: unknown) {
-      const normalizedError = isStreamPayError(err) 
-        ? err 
-        : normalizeError(err);
-      
-      if (process.env.NODE_ENV === 'development') {
-        console.error('Stream action failed:', err);
+      const normalizedError = isStreamPayError(err) ? err : normalizeError(err);
+
+      if (process.env.NODE_ENV === "development") {
+        console.error("Stream action failed:", err);
       }
-      
+
       setError(normalizedError);
     } finally {
       setIsProcessing(false);
@@ -154,11 +157,11 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
         }),
       });
 
-      alert(`${actionRoute === "cancel" ? "Cancel" : "Withdraw"} successful for stream ${stream.id}!`);
+      alert(
+        `${actionRoute === "cancel" ? "Cancel" : "Withdraw"} successful for stream ${stream.id}!`,
+      );
     } catch (err: unknown) {
-      const normalizedError = isStreamPayError(err)
-        ? err
-        : normalizeError(err);
+      const normalizedError = isStreamPayError(err) ? err : normalizeError(err);
 
       setError(normalizedError);
     } finally {
@@ -175,24 +178,55 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
         </Link>
       </nav>
 
-      {/* Hero section */}
-      <section className="page-hero">
+      {/* Sticky Hero Header */}
+      <header
+        className="page-hero sticky top-0 z-20 backdrop-blur-md bg-white/80 dark:bg-zinc-900/80 border-b border-zinc-200/80 dark:border-zinc-800/80 transition-all duration-200 py-4 px-2 -mx-2 rounded-b-xl shadow-sm"
+        role="region"
+        aria-label="Stream detail summary header"
+      >
         <div>
-          <p className="page-hero__eyebrow">Stream Detail</p>
-          <div className="detail-header-row">
-            <h1 className="page-hero__title detail-title">
+          <div className="flex items-center justify-between gap-2 mb-1">
+            <p className="page-hero__eyebrow mb-0">Stream Detail</p>
+            <span className="text-xs font-mono text-zinc-500 dark:text-zinc-400">
+              ID: {stream.id}
+            </span>
+          </div>
+
+          <div className="detail-header-row flex-wrap sm:flex-nowrap items-center justify-between gap-3">
+            <h1 className="page-hero__title detail-title text-xl sm:text-2xl font-bold">
               {stream.label || "Payment Stream"}
             </h1>
-            <div className="detail-badges-wrap">
-              <StatusBadge status={(stream.status === "withdrawn" ? "ended" : stream.status) as any} />
+            <div className="detail-badges-wrap flex items-center gap-2">
+              <StatusBadge
+                status={
+                  (stream.status === "withdrawn"
+                    ? "ended"
+                    : stream.status) as any
+                }
+              />
               <NetworkBadge showLabel={true} />
             </div>
           </div>
-          <p className="page-hero__description">
-            Monitor real-time progress, dynamic next actions, and full vertical payment timeline records.
-          </p>
+
+          {/* Quick Summary Strip inside Sticky Header */}
+          <div className="mt-3 pt-2 border-t border-zinc-100 dark:border-zinc-800/60 flex flex-wrap items-center justify-between text-xs sm:text-sm text-zinc-600 dark:text-zinc-300 gap-2">
+            <div>
+              <span className="text-zinc-400 dark:text-zinc-500">Rate: </span>
+              <strong className="font-semibold text-zinc-900 dark:text-zinc-100">
+                {stream.rate}
+              </strong>
+            </div>
+            {stream.schedule && (
+              <div>
+                <span className="text-zinc-400 dark:text-zinc-500">
+                  Schedule:{" "}
+                </span>
+                <span>{stream.schedule}</span>
+              </div>
+            )}
+          </div>
         </div>
-      </section>
+      </header>
 
       {/* Main Grid Layout */}
       <div className="detail-grid">
@@ -200,12 +234,16 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
         <div className="detail-left-col">
           {/* Summary Card */}
           <section className="detail-card" aria-labelledby="summary-heading">
-            <h2 id="summary-heading" className="detail-card__heading">Stream Summary</h2>
+            <h2 id="summary-heading" className="detail-card__heading">
+              Stream Summary
+            </h2>
             <div className="receipt-divider" style={{ margin: "0.75rem 0" }} />
             <dl className="detail-kv">
               <div>
                 <dt>Stream ID</dt>
-                <dd><code className="receipt-mono">{stream.id}</code></dd>
+                <dd>
+                  <code className="receipt-mono">{stream.id}</code>
+                </dd>
               </div>
               {stream.email && (
                 <div>
@@ -215,7 +253,9 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
               )}
               <div>
                 <dt>Recipient Address</dt>
-                <dd><CopyAddress value={stream.recipient} /></dd>
+                <dd>
+                  <CopyAddress value={stream.recipient} />
+                </dd>
               </div>
               <div>
                 <dt>Payment Rate</dt>
@@ -227,11 +267,15 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
               </div>
               <div>
                 <dt>Stream Created</dt>
-                <dd><Timestamp iso={stream.createdAt} /></dd>
+                <dd>
+                  <Timestamp iso={stream.createdAt} />
+                </dd>
               </div>
               <div>
                 <dt>Last Updated</dt>
-                <dd><Timestamp iso={stream.updatedAt} /></dd>
+                <dd>
+                  <Timestamp iso={stream.updatedAt} />
+                </dd>
               </div>
               {stream.memo && (
                 <div>
@@ -244,36 +288,62 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
 
           {/* Settlement Details (if applicable) */}
           {(stream.settlementTxHash || stream.withdrawal) && (
-            <section className="detail-card" aria-labelledby="settlement-heading">
-              <h2 id="settlement-heading" className="detail-card__heading">Settlement &amp; Chain Details</h2>
-              <div className="receipt-divider" style={{ margin: "0.75rem 0" }} />
+            <section
+              className="detail-card"
+              aria-labelledby="settlement-heading"
+            >
+              <h2 id="settlement-heading" className="detail-card__heading">
+                Settlement &amp; Chain Details
+              </h2>
+              <div
+                className="receipt-divider"
+                style={{ margin: "0.75rem 0" }}
+              />
               <dl className="detail-kv">
                 {stream.settlementTxHash && (
                   <div>
                     <dt>Settlement TX</dt>
-                    <dd><CopyAddress value={stream.settlementTxHash} truncateChars={8} /></dd>
+                    <dd>
+                      <CopyAddress
+                        value={stream.settlementTxHash}
+                        truncateChars={8}
+                      />
+                    </dd>
                   </div>
                 )}
                 {stream.withdrawal && (
                   <>
                     <div>
                       <dt>Withdrawal State</dt>
-                      <dd style={{ textTransform: "capitalize" }}>{stream.withdrawal.state}</dd>
+                      <dd style={{ textTransform: "capitalize" }}>
+                        {stream.withdrawal.state}
+                      </dd>
                     </div>
                     <div>
                       <dt>Requested At</dt>
-                      <dd><Timestamp iso={stream.withdrawal.requestedAt} /></dd>
+                      <dd>
+                        <Timestamp iso={stream.withdrawal.requestedAt} />
+                      </dd>
                     </div>
                     {stream.withdrawal.confirmedTxHash && (
                       <div>
                         <dt>Confirmed TX</dt>
-                        <dd><CopyAddress value={stream.withdrawal.confirmedTxHash} truncateChars={8} /></dd>
+                        <dd>
+                          <CopyAddress
+                            value={stream.withdrawal.confirmedTxHash}
+                            truncateChars={8}
+                          />
+                        </dd>
                       </div>
                     )}
                     {stream.withdrawal.failureCode && (
                       <div>
                         <dt>Failure Code</dt>
-                        <dd><code className="receipt-mono">{stream.withdrawal.failureCode}</code></dd>
+                        <dd>
+                          <code className="receipt-mono">
+                            {stream.withdrawal.failureCode}
+                          </code>
+                        </dd>
                       </div>
                     )}
                   </>
@@ -283,30 +353,46 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
           )}
 
           {/* Next Action Panel */}
-          <section className="detail-card detail-action-card no-print" aria-labelledby="action-heading">
-            <h2 id="action-heading" className="detail-card__heading">Stream Operations</h2>
+          <section
+            className="detail-card detail-action-card no-print"
+            aria-labelledby="action-heading"
+          >
+            <h2 id="action-heading" className="detail-card__heading">
+              Stream Operations
+            </h2>
             <div className="receipt-divider" style={{ margin: "0.75rem 0" }} />
             <p className="detail-action-desc">
-              Execute lifecycle actions directly on the Stellar ledger, or export / save your certified payment stream receipt.
+              Execute lifecycle actions directly on the Stellar ledger, or
+              export / save your certified payment stream receipt.
             </p>
             <div className="detail-actions-row">
               <button
                 className="button button--primary detail-action-btn"
                 type="button"
                 onClick={handleAction}
-                disabled={isProcessing || isIncidentMode || stream.status === "withdrawn"}
+                disabled={
+                  isProcessing ||
+                  isIncidentMode ||
+                  stream.status === "withdrawn"
+                }
               >
                 {isProcessing ? "Processing..." : nextAction}
               </button>
-              
-              <Link href={`/streams/${stream.id}/receipt`} className="button button--secondary detail-action-btn">
+
+              <Link
+                href={`/streams/${stream.id}/receipt`}
+                className="button button--secondary detail-action-btn"
+              >
                 Print Stream Receipt
               </Link>
 
-              <Link href={`/streams/${stream.id}/events`} className="button button--secondary detail-action-btn">
+              <Link
+                href={`/streams/${stream.id}/events`}
+                className="button button--secondary detail-action-btn"
+              >
                 View Contract Events
               </Link>
-              
+
               <button
                 className="button button--secondary detail-action-btn"
                 type="button"
@@ -331,12 +417,14 @@ export function StreamDetailClient({ stream, network = "testnet" }: StreamDetail
             </div>
             {actionSummary.destructiveAction === "cancel" && (
               <p className="detail-action-note">
-                Large cancels require a typed amount confirmation before the request is submitted.
+                Large cancels require a typed amount confirmation before the
+                request is submitted.
               </p>
             )}
             {isIncidentMode && (
               <p className="detail-incident-warning" role="alert">
-                ⚠️ On-chain operations are temporarily paused during incident mode.
+                ⚠️ On-chain operations are temporarily paused during incident
+                mode.
               </p>
             )}
           </section>


### PR DESCRIPTION
## Description
Closes #859

Implements a responsive, accessible sticky summary header on the stream detail page (`app/streams/[id]/StreamDetailClient.tsx`).

## Changes
- Added sticky positioning (`sticky top-0 z-20 backdrop-blur-md`) to the detail hero section.
- Included key stream summary metrics (ID, Label, Rate, Schedule, Status, Network) in the header.
- Added accessibility attributes (`role="region"` and `aria-label="Stream detail summary header"`).
- Added unit tests in `__tests__/stickyHeader.test.tsx`.

## Verification
- Unit tests passed via `npx jest __tests__/stickyHeader.test.tsx`.