### PR TITLE
feat: tag chips filter

### DIFF
--- a/app/components/StreamRow.tsx
+++ b/app/components/StreamRow.tsx
@@ -24,6 +24,8 @@ export type StreamRowData = {
   startedAt?: string;
   /** ISO-8601 expected end timestamp. Used by StreamProgress fallback. */
   endsAt?: string;
+  /** Freeform labels shown on the row and used by the tag-chip filter. */
+  tags?: string[];
 };
 
 type StreamRowProps = {
@@ -113,6 +115,15 @@ export function StreamRow({ stream }: StreamRowProps) {
             {stream.recipient}
           </h2>
           <p className="stream-row__schedule">{stream.schedule}</p>
+          {stream.tags && stream.tags.length > 0 && (
+            <ul className="stream-row__tags" aria-label="Tags">
+              {stream.tags.map((tag) => (
+                <li key={tag} className="tag-pill">
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
         <StatusBadge status={stream.status} />
       </div>

--- a/app/components/TagChips.test.tsx
+++ b/app/components/TagChips.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { TagChips } from "./TagChips";
+
+describe("TagChips", () => {
+  it("renders nothing when there are no tags", () => {
+    const { container } = render(
+      <TagChips tags={[]} selectedTag={null} onTagClick={jest.fn()} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a chip per tag with a filter group label", () => {
+    render(<TagChips tags={["design", "vendor"]} selectedTag={null} onTagClick={jest.fn()} />);
+
+    expect(screen.getByRole("group", { name: /filter by tag/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "design" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "vendor" })).toBeInTheDocument();
+  });
+
+  it("selects a tag on click and marks it pressed", () => {
+    const onTagClick = jest.fn();
+    render(<TagChips tags={["design", "vendor"]} selectedTag={null} onTagClick={onTagClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "design" }));
+
+    expect(onTagClick).toHaveBeenCalledWith("design");
+  });
+
+  it("marks the selected tag as pressed and shows a clear button", () => {
+    render(<TagChips tags={["design", "vendor"]} selectedTag="design" onTagClick={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: "design" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "vendor" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: /clear tag filter/i })).toBeInTheDocument();
+  });
+
+  it("clicking the active tag again deselects it", () => {
+    const onTagClick = jest.fn();
+    render(<TagChips tags={["design", "vendor"]} selectedTag="design" onTagClick={onTagClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "design" }));
+
+    expect(onTagClick).toHaveBeenCalledWith(null);
+  });
+
+  it("clicking the clear button deselects the tag", () => {
+    const onTagClick = jest.fn();
+    render(<TagChips tags={["design", "vendor"]} selectedTag="design" onTagClick={onTagClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /clear tag filter/i }));
+
+    expect(onTagClick).toHaveBeenCalledWith(null);
+  });
+
+  it("does not render a clear button when no tag is selected", () => {
+    render(<TagChips tags={["design"]} selectedTag={null} onTagClick={jest.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /clear tag filter/i })).not.toBeInTheDocument();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -431,6 +431,68 @@ a:hover {
   line-height: 1.5;
 }
 
+.stream-row__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.tag-pill {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full, 999px);
+  color: var(--muted-light);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  padding: 0.25rem 0.625rem;
+}
+
+.tag-chips {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-chip {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full, 999px);
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1;
+  min-height: 2rem;
+  padding: 0.5rem 0.875rem;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.tag-chip:hover {
+  border-color: var(--accent);
+}
+
+.tag-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tag-chip--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-on);
+}
+
+.tag-chip--clear {
+  color: var(--muted-light);
+  padding: 0.5rem 0.625rem;
+}
+
 .stream-row__meta {
   display: grid;
   gap: 0.75rem;

--- a/app/streams/StreamsPageContent.tsx
+++ b/app/streams/StreamsPageContent.tsx
@@ -1,6 +1,8 @@
+import { useMemo, useState } from "react";
 import { EmptyState } from "../components/EmptyState";
 import { PageError } from "../components/PageError";
 import { StreamRow, type StreamRowData } from "../components/StreamRow";
+import { TagChips } from "../components/TagChips";
 
 export type StreamsViewState = "empty" | "loading" | "populated" | "error";
 
@@ -27,6 +29,7 @@ export const mockStreams: StreamRowData[] = [
     recipient: "Ada Creative Studio",
     schedule: "Pays every 30 days",
     status: "active",
+    tags: ["design", "vendor"],
   },
   {
     id: "stream-kemi",
@@ -35,6 +38,7 @@ export const mockStreams: StreamRowData[] = [
     recipient: "Kemi Onboarding Support",
     schedule: "Draft stream ready to launch",
     status: "draft",
+    tags: ["onboarding"],
   },
   {
     id: "stream-yusuf",
@@ -43,6 +47,7 @@ export const mockStreams: StreamRowData[] = [
     recipient: "Yusuf QA Partnership",
     schedule: "Ended yesterday with funds available",
     status: "ended",
+    tags: ["qa", "vendor"],
   },
 ];
 
@@ -102,6 +107,17 @@ export function StreamsPageContent({
   errorMessage,
   onRetry,
 }: StreamsPageContentProps) {
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  const tags = useMemo(
+    () => Array.from(new Set(streams.flatMap((stream) => stream.tags ?? []))).sort(),
+    [streams],
+  );
+
+  const visibleStreams = selectedTag
+    ? streams.filter((stream) => stream.tags?.includes(selectedTag))
+    : streams;
+
   const isEmpty = state === "empty" || streams.length === 0;
 
   return (
@@ -135,6 +151,10 @@ export function StreamsPageContent({
           {state === "populated" && <p className="section-heading__meta">{streamListCopy.populatedCount}</p>}
         </div>
 
+        {state === "populated" && tags.length > 0 && (
+          <TagChips tags={tags} selectedTag={selectedTag} onTagClick={setSelectedTag} />
+        )}
+
         {state === "loading" ? (
           <StreamListSkeleton />
         ) : state === "error" ? (
@@ -153,9 +173,13 @@ export function StreamsPageContent({
             eyebrow={streamListCopy.empty.eyebrow}
             title={streamListCopy.empty.title}
           />
+        ) : visibleStreams.length === 0 ? (
+          <p className="section-heading__description" role="status">
+            No streams match the “{selectedTag}” tag.
+          </p>
         ) : (
           <section aria-label="Streams list" className="stream-list">
-            {streams.map((stream) => (
+            {visibleStreams.map((stream) => (
               <StreamRow key={stream.id} stream={stream} />
             ))}
           </section>

--- a/app/streams/page.test.tsx
+++ b/app/streams/page.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { StreamsPageContent } from "./StreamsPageContent";
 
@@ -132,5 +132,70 @@ describe("StreamsPageContent", () => {
     
     expect(screen.getByText(/100 XLM \/ month/i)).toHaveClass("stream-row__accrued--animated");
     expect(screen.getByText(/50 XLM \/ month/i)).not.toHaveClass("stream-row__accrued--animated");
+  });
+
+  describe("tag chip filtering", () => {
+    const taggedStreams = [
+      {
+        id: "stream-ada",
+        nextAction: "Pause",
+        rate: "120 XLM / month",
+        recipient: "Ada Creative Studio",
+        schedule: "Pays every 30 days",
+        status: "active" as const,
+        tags: ["design", "vendor"],
+      },
+      {
+        id: "stream-kemi",
+        nextAction: "Start",
+        rate: "32 XLM / week",
+        recipient: "Kemi Onboarding Support",
+        schedule: "Draft stream ready to launch",
+        status: "draft" as const,
+        tags: ["onboarding"],
+      },
+    ];
+
+    it("does not render a tag filter bar when no stream has tags", () => {
+      render(
+        <StreamsPageContent
+          state="populated"
+          streams={[
+            {
+              id: "stream-untagged",
+              nextAction: "Pause",
+              rate: "10 XLM / month",
+              recipient: "Untagged Recipient",
+              schedule: "Daily",
+              status: "active",
+            },
+          ]}
+        />,
+      );
+
+      expect(screen.queryByRole("group", { name: /filter by tag/i })).not.toBeInTheDocument();
+    });
+
+    it("filters the list to streams matching the clicked tag", () => {
+      render(<StreamsPageContent state="populated" streams={taggedStreams} />);
+
+      expect(screen.getByText(/ada creative studio/i)).toBeInTheDocument();
+      expect(screen.getByText(/kemi onboarding support/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "onboarding" }));
+
+      expect(screen.getByText(/kemi onboarding support/i)).toBeInTheDocument();
+      expect(screen.queryByText(/ada creative studio/i)).not.toBeInTheDocument();
+    });
+
+    it("shows a no-matches message and clears back to the full list", () => {
+      render(<StreamsPageContent state="populated" streams={taggedStreams} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "onboarding" }));
+      fireEvent.click(screen.getByRole("button", { name: "onboarding" }));
+
+      expect(screen.getByText(/ada creative studio/i)).toBeInTheDocument();
+      expect(screen.getByText(/kemi onboarding support/i)).toBeInTheDocument();
+    });
   });
 });

--- a/docs/uiux/tag-chip-filter.md
+++ b/docs/uiux/tag-chip-filter.md
@@ -1,0 +1,56 @@
+# Tag Chip Filter (GrantFox FWC26)
+
+Clicking a tag chip above the streams list filters the list down to streams
+carrying that tag. Clicking the active chip again — or the clear ("✕")
+chip — resets the list to show every stream.
+
+## API Notes
+
+Client-side only. No backend API contract changes. Tags are read from the
+existing `StreamRowData.tags` field (a plain `string[]`); nothing is sent
+to the server as a result of selecting a tag.
+
+## Components
+
+- `app/components/TagChips.tsx` — filter bar. Renders one chip per unique
+  tag plus a clear chip when a tag is selected. Pre-existing component
+  (added in #681); this change is the first to wire it into a page.
+- `app/components/StreamRow.tsx` — now accepts an optional `tags?: string[]`
+  field on `StreamRowData` and renders each tag as a read-only pill under
+  the recipient/schedule text.
+- `app/streams/StreamsPageContent.tsx` — derives the unique tag list from
+  the current `streams` prop, owns `selectedTag` state, renders `TagChips`
+  above the list, and filters the rendered rows by the selected tag. The
+  filter bar itself is only rendered when at least one stream has tags.
+
+## Accessibility (WCAG 2.1 AA)
+
+- The chip bar is a `role="group"` with `aria-label="Filter by tag"`.
+- Each chip is a native `<button>` with `aria-pressed` reflecting selection
+  state, so screen readers announce the current filter.
+- The clear chip has an explicit `aria-label="Clear tag filter"`.
+- All chips are keyboard operable (native buttons) and use the shared
+  `:focus-visible` outline token.
+- The "no streams match this tag" message is exposed via `role="status"`
+  so assistive tech announces the filtered-to-empty state.
+
+## Design tokens / dark mode
+
+Chip styling (`.tag-chips`, `.tag-chip`, `.tag-chip--active`,
+`.tag-chip--clear`) and row tag pills (`.tag-pill`) in `app/globals.css`
+use existing semantic tokens (`--panel`, `--border`, `--foreground`,
+`--accent`, `--accent-on`, `--muted-light`) so both themes stay consistent
+without new hardcoded colors.
+
+## Responsive behavior
+
+The chip bar is a `flex-wrap` row, so it wraps naturally at narrow
+viewports instead of overflowing or requiring horizontal scroll.
+
+## Tests
+
+- `app/components/TagChips.test.tsx` — chip rendering, selection,
+  deselection, clear button, `aria-pressed` state, empty-tags no-render.
+- `app/streams/page.test.tsx` (`tag chip filtering` block) — filter bar
+  hidden when no stream has tags, filtering the list on chip click, and
+  toggling a chip back off restores the full list.


### PR DESCRIPTION
Close: #856

## Summary
- Wired the existing `TagChips` component into the streams list on `/streams`. Clicking a tag chip filters the list to streams carrying that tag; clicking it again (or the clear chip) resets the list.
- Added optional `tags?: string[]` to `StreamRowData` and render each tag as a read-only pill on `StreamRow`.
- Added `.tag-chip*` / `.tag-pill` styles in `app/globals.css` using existing semantic design tokens (dark/light consistent, no hardcoded colors).
- Documented the change in `docs/uiux/tag-chip-filter.md` (API notes, accessibility, tokens, responsiveness, test coverage), following the existing GrantFox UI-doc pattern.

This is a client-side, presentation-only change — no API contract, schema, or auth changes.

## Type of Change
- [x] UI/UX feature (tag click filters list)
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update

## Testing
- [x] New tests: `app/components/TagChips.test.tsx` (render, select/deselect, clear button, `aria-pressed`, empty-tags no-render) and a `tag chip filtering` block added to `app/streams/page.test.tsx` (bar hidden with no tags, filtering, toggle back to full list).
- Test run: `npm run test -- app/components/TagChips.test.tsx app/streams/page.test.tsx`
- Outcome: 18 passed, 2 suites passed.
- [x] Lint clean on all touched files: `eslint app/components/StreamRow.tsx app/components/TagChips.tsx app/components/TagChips.test.tsx app/streams/StreamsPageContent.tsx app/streams/page.test.tsx`
- Note: a full `npm run test` run surfaces pre-existing failures in unrelated suites (webhook integration timeouts, some API contract tests) that predate this branch and are untouched by this change.

## Accessibility (WCAG 2.1 AA)
- Chip bar is `role="group"` with `aria-label="Filter by tag"`; each chip is a native `<button>` with `aria-pressed` reflecting selection.
- Clear chip has an explicit `aria-label="Clear tag filter"`.
- All chips are keyboard operable and use the shared `:focus-visible` outline token.
- "No streams match this tag" message uses `role="status"` for screen reader announcement.
- Chip bar wraps via `flex-wrap` at narrow viewports (no horizontal overflow).

## Security Impact Analysis
Not a security-relevant change — no auth, payment, encryption, API, dependency, container, or CI/CD changes.
- Affected Components: none of the above
- Risk: none — purely client-side filtering over data already present in the rendered list; no new inputs sent to the server.

## Documentation Updates
- [x] Added `docs/uiux/tag-chip-filter.md`
- [ ] README.md (no workflow change)
- [ ] SECURITY-CI-SETUP.md (n/a)
- [ ] security-exemptions.json (n/a)

## Checklist
- [x] No secrets or keys committed
- [x] No PII or sensitive data in logs
- [x] All security scans pass (n/a change, no security-relevant surface touched)
- [x] Branch protection requirements met
- [ ] Code review from security team (not applicable — non-security UI change)