### PR TITLE
feat: templates marketplace

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2887,3 +2887,195 @@ a:hover {
     transition: none !important;
   }
 }
+
+/* ─── Templates Marketplace ───────────────────────────────────────────────── */
+.template-controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.template-controls__categories {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.template-controls__categories::-webkit-scrollbar {
+  display: none;
+}
+
+.template-controls__tab {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  transition: all 160ms ease;
+  white-space: nowrap;
+}
+
+.template-controls__tab:hover {
+  border-color: var(--accent);
+  color: var(--foreground);
+}
+
+.template-controls__tab--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-on);
+}
+
+.template-controls__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.template-controls__search {
+  display: block;
+  width: 100%;
+}
+
+.template-controls__input {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  color: var(--foreground);
+  font-size: 0.95rem;
+  padding: 0.75rem 1rem;
+  width: 100%;
+  transition: border-color 160ms ease;
+}
+
+.template-controls__input::placeholder {
+  color: var(--muted);
+}
+
+.template-controls__input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.template-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
+}
+
+.template-card {
+  background: linear-gradient(180deg, var(--panel-elevated), var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+}
+
+.template-card--skeleton {
+  pointer-events: none;
+}
+
+.template-card__header {
+  display: flex;
+  align-items: center;
+}
+
+.template-card__category {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+}
+
+.template-card__category--savings {
+  background: var(--system-success-bg);
+  color: var(--system-success-text);
+  border: 1px solid var(--system-success-border);
+}
+
+.template-card__category--income {
+  background: var(--system-info-bg);
+  color: var(--system-info-text);
+  border: 1px solid var(--system-info-border);
+}
+
+.template-card__category--bills {
+  background: var(--system-warning-bg);
+  color: var(--system-warning-text);
+  border: 1px solid var(--system-warning-border);
+}
+
+.template-card__category--custom {
+  background: rgba(113, 113, 122, 0.12);
+  color: var(--muted-light);
+  border: 1px solid var(--border);
+}
+
+.template-card__name {
+  font-size: 1.125rem;
+}
+
+.template-card__details {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.template-card__detail dt {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.template-card__detail dd {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.template-card__memo {
+  color: var(--muted-light);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.template-card__apply {
+  margin-top: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 40rem) {
+  .template-grid {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
+
+  .template-controls {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+
+  .template-controls__input {
+    max-width: 20rem;
+  }
+}
+
+@media (min-width: 64rem) {
+  .template-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .template-controls__tab {
+    transition: none !important;
+  }
+}

--- a/app/templates/page.test.tsx
+++ b/app/templates/page.test.tsx
@@ -1,0 +1,409 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TemplatesPage from "./page";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+  usePathname: () => "/templates",
+}));
+
+const TEMPLATES = [
+  {
+    id: "tpl_1",
+    name: "Monthly Savings",
+    asset: "XLM",
+    amountPerInterval: 50,
+    intervalSeconds: 2592000,
+    memo: "Automated monthly savings",
+    createdAt: "2026-01-15T00:00:00.000Z",
+  },
+  {
+    id: "tpl_2",
+    name: "Freelancer Income",
+    asset: "USDC",
+    amountPerInterval: 2000,
+    intervalSeconds: 604800,
+    memo: "Weekly freelancer payout",
+    createdAt: "2026-02-10T00:00:00.000Z",
+  },
+  {
+    id: "tpl_3",
+    name: "Utility Bill",
+    asset: "XLM",
+    amountPerInterval: 120,
+    intervalSeconds: 2592000,
+    memo: "Monthly utility payment",
+    createdAt: "2026-03-05T00:00:00.000Z",
+  },
+  {
+    id: "tpl_4",
+    name: "Savings Roundup",
+    asset: "XLM",
+    amountPerInterval: 10,
+    intervalSeconds: 86400,
+    createdAt: "2026-04-20T00:00:00.000Z",
+  },
+];
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockPush.mockClear();
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ templates: TEMPLATES }),
+  });
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe("TemplatesPage", () => {
+  it("shows loading skeleton while fetching templates", () => {
+    render(<TemplatesPage />);
+    expect(screen.getByRole("status")).toHaveTextContent(/loading templates/i);
+  });
+
+  it("renders the page heading", () => {
+    render(<TemplatesPage />);
+    expect(
+      screen.getByRole("heading", { name: /start with a template/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the browse templates section heading", () => {
+    render(<TemplatesPage />);
+    expect(
+      screen.getByRole("heading", { name: /browse templates/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders templates after loading", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Monthly Savings")).toBeInTheDocument();
+    expect(screen.getByText("Freelancer Income")).toBeInTheDocument();
+    expect(screen.getByText("Utility Bill")).toBeInTheDocument();
+    expect(screen.getByText("Savings Roundup")).toBeInTheDocument();
+  });
+
+  it("renders the template region with correct count", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const region = screen.getByRole("region", { name: /showing 4 templates/i });
+    expect(region).toBeInTheDocument();
+  });
+
+  it("clears aria-busy once templates are loaded", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const section = screen.getByRole("region", { name: /browse templates/i });
+    expect(section).toHaveAttribute("aria-busy", "false");
+  });
+
+  it("renders category filter tabs", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByRole("tab", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Savings" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Income" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Bills" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Custom" })).toBeInTheDocument();
+  });
+
+  it("marks All tab as selected by default", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const allTab = screen.getByRole("tab", { name: "All" });
+    expect(allTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("filters templates by category", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Savings" }));
+
+    expect(screen.getByText("Monthly Savings")).toBeInTheDocument();
+    expect(screen.getByText("Savings Roundup")).toBeInTheDocument();
+    expect(screen.queryByText("Freelancer Income")).not.toBeInTheDocument();
+    expect(screen.queryByText("Utility Bill")).not.toBeInTheDocument();
+  });
+
+  it("filters templates by Income category", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Income" }));
+
+    expect(screen.getByText("Freelancer Income")).toBeInTheDocument();
+    expect(screen.queryByText("Monthly Savings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Utility Bill")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no templates match filter", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ templates: [TEMPLATES[1]] }),
+    });
+
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Savings" }));
+
+    expect(screen.getByText("No templates found")).toBeInTheDocument();
+    expect(screen.getByText("Clear filters")).toBeInTheDocument();
+  });
+
+  it("search filters templates by name", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const searchInput = screen.getByPlaceholderText(/search templates/i);
+    await user.type(searchInput, "savings");
+
+    expect(screen.getByText("Monthly Savings")).toBeInTheDocument();
+    expect(screen.getByText("Savings Roundup")).toBeInTheDocument();
+    expect(screen.queryByText("Freelancer Income")).not.toBeInTheDocument();
+    expect(screen.queryByText("Utility Bill")).not.toBeInTheDocument();
+  });
+
+  it("search filters templates by memo", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const searchInput = screen.getByPlaceholderText(/search templates/i);
+    await user.type(searchInput, "freelancer");
+
+    expect(screen.getByText("Freelancer Income")).toBeInTheDocument();
+    expect(screen.queryByText("Monthly Savings")).not.toBeInTheDocument();
+  });
+
+  it("search filters templates by asset", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const searchInput = screen.getByPlaceholderText(/search templates/i);
+    await user.type(searchInput, "USDC");
+
+    expect(screen.getByText("Freelancer Income")).toBeInTheDocument();
+    expect(screen.queryByText("Monthly Savings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Utility Bill")).not.toBeInTheDocument();
+  });
+
+  it("Use template button navigates to stream creation", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const applyButtons = screen.getAllByText("Use template");
+    await user.click(applyButtons[0]);
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining("/streams/new?"),
+    );
+  });
+
+  it("navigates with correct template params", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const applyButtons = screen.getAllByText("Use template");
+    await user.click(applyButtons[1]);
+
+    const callArg = mockPush.mock.calls[0][0];
+    expect(callArg).toContain("templateId=tpl_2");
+    expect(callArg).toContain("asset=USDC");
+    expect(callArg).toContain("rate=2000");
+    expect(callArg).toContain("interval=604800");
+  });
+
+  it("shows error state when fetch fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Couldn't load templates")).toBeInTheDocument();
+    expect(screen.getByText("Try again")).toBeInTheDocument();
+  });
+
+  it("retry button re-fetches templates", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ templates: TEMPLATES }),
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByText("Try again"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Monthly Savings")).toBeInTheDocument();
+  });
+
+  it("cleans up fetch abort on unmount", () => {
+    const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+    const { unmount } = render(<TemplatesPage />);
+    unmount();
+    expect(abortSpy).toHaveBeenCalled();
+    abortSpy.mockRestore();
+  });
+
+  it("displays category badges with correct labels", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const savingsCards = screen.getAllByText("savings");
+    expect(savingsCards.length).toBe(2);
+
+    const incomeCards = screen.getAllByText("income");
+    expect(incomeCards.length).toBe(1);
+
+    const billsCards = screen.getAllByText("bills");
+    expect(billsCards.length).toBe(1);
+  });
+
+  it("displays template rates and intervals", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("50 XLM")).toBeInTheDocument();
+    expect(screen.getByText("2000 USDC")).toBeInTheDocument();
+    expect(screen.getByText("120 XLM")).toBeInTheDocument();
+    expect(screen.getByText("10 XLM")).toBeInTheDocument();
+  });
+
+  it("displays memo text when present", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Automated monthly savings")).toBeInTheDocument();
+    expect(screen.getByText("Weekly freelancer payout")).toBeInTheDocument();
+    expect(screen.getByText("Monthly utility payment")).toBeInTheDocument();
+  });
+
+  it("clear filters button resets category and search", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ templates: [TEMPLATES[1]] }),
+    });
+
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Savings" }));
+    expect(screen.queryByText("Freelancer Income")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Clear filters"));
+
+    expect(screen.getByText("Freelancer Income")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders search input", async () => {
+    render(<TemplatesPage />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByPlaceholderText(/search templates/i)).toBeInTheDocument();
+  });
+});

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Skeleton } from "../components/Skeleton";
+import { EmptyState } from "../components/EmptyState";
+import { PageError } from "../components/PageError";
+
+interface Template {
+  id: string;
+  name: string;
+  asset: string;
+  amountPerInterval: number;
+  intervalSeconds: number;
+  memo?: string;
+  createdAt: string;
+}
+
+type TemplatesPageState = "loading" | "populated" | "empty" | "error";
+
+const CATEGORIES = [
+  { id: "all", label: "All" },
+  { id: "savings", label: "Savings" },
+  { id: "income", label: "Income" },
+  { id: "bills", label: "Bills" },
+  { id: "custom", label: "Custom" },
+] as const;
+
+type CategoryId = (typeof CATEGORIES)[number]["id"];
+
+function formatInterval(seconds: number): string {
+  if (seconds >= 86400) {
+    const days = seconds / 86400;
+    return days === 1 ? "Daily" : `${days} days`;
+  }
+  if (seconds >= 3600) {
+    const hours = seconds / 3600;
+    return hours === 1 ? "Hourly" : `${hours} hours`;
+  }
+  if (seconds >= 60) {
+    const mins = seconds / 60;
+    return mins === 1 ? "Minute" : `${mins} minutes`;
+  }
+  return `${seconds}s`;
+}
+
+function categorizeTemplate(template: Template): CategoryId {
+  const name = template.name.toLowerCase();
+  const memo = (template.memo ?? "").toLowerCase();
+  const text = `${name} ${memo}`;
+
+  if (text.includes("savings") || text.includes("invest") || text.includes("roundup")) return "savings";
+  if (text.includes("income") || text.includes("freelance") || text.includes("salary") || text.includes("earn")) return "income";
+  if (text.includes("bill") || text.includes("utility") || text.includes("payment")) return "bills";
+  return "custom";
+}
+
+function TemplateCard({
+  template,
+  onApply,
+}: {
+  template: Template;
+  onApply: (template: Template) => void;
+}) {
+  const category = categorizeTemplate(template);
+
+  return (
+    <article className="template-card" aria-labelledby={`template-${template.id}`}>
+      <div className="template-card__header">
+        <span className={`template-card__category template-card__category--${category}`}>
+          {category}
+        </span>
+      </div>
+
+      <h3 className="template-card__name" id={`template-${template.id}`}>
+        {template.name}
+      </h3>
+
+      <dl className="template-card__details">
+        <div className="template-card__detail">
+          <dt className="template-card__detail-label">Rate</dt>
+          <dd className="template-card__detail-value">
+            {template.amountPerInterval} {template.asset}
+          </dd>
+        </div>
+        <div className="template-card__detail">
+          <dt className="template-card__detail-label">Interval</dt>
+          <dd className="template-card__detail-value">
+            {formatInterval(template.intervalSeconds)}
+          </dd>
+        </div>
+      </dl>
+
+      {template.memo && (
+        <p className="template-card__memo">{template.memo}</p>
+      )}
+
+      <button
+        className="button button--primary template-card__apply"
+        onClick={() => onApply(template)}
+        type="button"
+      >
+        Use template
+      </button>
+    </article>
+  );
+}
+
+function TemplateCardSkeleton() {
+  return (
+    <article className="template-card template-card--skeleton">
+      <div className="template-card__header">
+        <Skeleton className="skeleton--badge" height="1.25rem" width="4rem" />
+      </div>
+      <Skeleton className="skeleton--title" height="1.25rem" width="8rem" />
+      <div className="template-card__details">
+        <div className="template-card__detail">
+          <Skeleton className="skeleton--label" height="0.75rem" width="3rem" />
+          <Skeleton className="skeleton--value" height="1rem" width="6rem" />
+        </div>
+        <div className="template-card__detail">
+          <Skeleton className="skeleton--label" height="0.75rem" width="3rem" />
+          <Skeleton className="skeleton--value" height="1rem" width="5rem" />
+        </div>
+      </div>
+      <Skeleton className="skeleton--button" height="2.75rem" width="7.5rem" />
+    </article>
+  );
+}
+
+function TemplateGridSkeleton() {
+  return (
+    <div className="template-grid">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <TemplateCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const [pageState, setPageState] = useState<TemplatesPageState>("loading");
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [activeCategory, setActiveCategory] = useState<CategoryId>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [loadKey, setLoadKey] = useState(0);
+
+  const handleRetry = useCallback(() => {
+    setLoadKey((k) => k + 1);
+  }, []);
+
+  useEffect(() => {
+    setPageState("loading");
+
+    const controller = new AbortController();
+
+    async function fetchTemplates() {
+      try {
+        const res = await fetch("/api/streams/template", { signal: controller.signal });
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        const list: Template[] = data.templates ?? [];
+        setTemplates(list);
+        setPageState(list.length > 0 ? "populated" : "empty");
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setPageState("error");
+      }
+    }
+
+    fetchTemplates();
+    return () => controller.abort();
+  }, [loadKey]);
+
+  const filtered = useMemo(() => {
+    let result = templates;
+
+    if (activeCategory !== "all") {
+      result = result.filter((t) => categorizeTemplate(t) === activeCategory);
+    }
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (t) =>
+          t.name.toLowerCase().includes(q) ||
+          (t.memo ?? "").toLowerCase().includes(q) ||
+          t.asset.toLowerCase().includes(q),
+      );
+    }
+
+    return result;
+  }, [templates, activeCategory, searchQuery]);
+
+  const handleApply = useCallback(
+    (template: Template) => {
+      const params = new URLSearchParams({
+        templateId: template.id,
+        asset: template.asset,
+        rate: String(template.amountPerInterval),
+        interval: String(template.intervalSeconds),
+        memo: template.memo ?? "",
+      });
+      router.push(`/streams/new?${params.toString()}`);
+    },
+    [router],
+  );
+
+  return (
+    <main className="page-shell">
+      <section className="page-hero">
+        <div>
+          <p className="page-hero__eyebrow">Templates</p>
+          <h1 className="page-hero__title">Start with a template.</h1>
+          <p className="page-hero__description">
+            Reusable stream presets to set up recurring payments in seconds.
+            Pick a template, adjust the amount, and launch.
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-busy={pageState === "loading"}
+        aria-labelledby="templates-overview-title"
+        aria-live="polite"
+        className="stream-layout"
+      >
+        <div className="section-heading">
+          <div>
+            <h2 className="section-heading__title" id="templates-overview-title">
+              Browse templates
+            </h2>
+            <p className="section-heading__description">
+              Filter by category or search to find the right preset for your stream.
+            </p>
+          </div>
+        </div>
+
+        <span aria-live="polite" className="sr-only" role="status">
+          {pageState === "loading"
+            ? "Loading templates…"
+            : pageState === "error"
+              ? "Failed to load templates."
+              : ""}
+        </span>
+
+        {pageState === "loading" ? (
+          <TemplateGridSkeleton />
+        ) : pageState === "error" ? (
+          <PageError
+            heading="Couldn't load templates"
+            message="There was a problem fetching templates. Check your connection and try again."
+            onRetry={handleRetry}
+          />
+        ) : (
+          <>
+            <div className="template-controls">
+              <div className="template-controls__categories" role="tablist" aria-label="Template categories">
+                {CATEGORIES.map((cat) => {
+                  const isActive = activeCategory === cat.id;
+                  return (
+                    <button
+                      key={cat.id}
+                      aria-selected={isActive}
+                      className={`template-controls__tab${isActive ? " template-controls__tab--active" : ""}`}
+                      onClick={() => setActiveCategory(cat.id)}
+                      role="tab"
+                      type="button"
+                    >
+                      {cat.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <label className="template-controls__search" htmlFor="template-search">
+                <span className="sr-only">Search templates</span>
+                <input
+                  className="template-controls__input"
+                  id="template-search"
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search templates…"
+                  type="search"
+                  value={searchQuery}
+                />
+              </label>
+            </div>
+
+            {filtered.length > 0 ? (
+              <div
+                aria-label={`Showing ${filtered.length} template${filtered.length === 1 ? "" : "s"}`}
+                className="template-grid"
+                role="region"
+              >
+                {filtered.map((template) => (
+                  <TemplateCard
+                    key={template.id}
+                    onApply={handleApply}
+                    template={template}
+                  />
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                actionLabel="Clear filters"
+                description="No templates match your current filters. Try a different category or search term."
+                eyebrow="No results"
+                onAction={() => {
+                  setActiveCategory("all");
+                  setSearchQuery("");
+                }}
+                title="No templates found"
+              />
+            )}
+          </>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #869

---

## Summary

Adds a templates marketplace page that lets users browse, filter, and apply reusable stream presets.

### Changes
- **New page** at `/templates` — grid layout with search, category tabs (All, Savings, Income, Bills, Custom), and responsive card grid
- **Template cards** display name, rate, interval, category badge, and memo
- **Category classification** auto-categorizes templates based on name/memo keywords
- **Search** filters by name, memo, and asset
- **Apply flow** navigates to `/streams/new` with template params pre-filled
- **Loading/error/empty states** using existing PageError, EmptyState, and Skeleton components
- **CSS** — BEM classes following existing patterns (stream-row, home__grid), responsive breakpoints at 40rem and 64rem, prefers-reduced-motion support

### Tests
- 22 test cases covering: loading state, rendered content, category filtering, search filtering, apply navigation, error state, retry, cleanup, clear filters

### Accessibility
- `aria-busy` on loading section, `aria-live="polite"` for status changes
- `role="tab"` / `aria-selected` for category filters
- `role="region"` with aria-label on template grid
- sr-only live announcements for loading/error states
- Focus-visible outlines on interactive elements

### Responsive
- Mobile: single-column grid, scrollable category tabs
- Tablet (40rem+): two-column grid, inline search input
- Desktop (64rem+): three-column grid