### PR TITLE
feat: add welcome tour overlay for first-time users

### DIFF
--- a/app/components/WelcomeTour.test.tsx
+++ b/app/components/WelcomeTour.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent, act } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import "@testing-library/jest-dom";
+import { WelcomeTour } from "./WelcomeTour";
+
+const STORAGE_KEY = "streampay:welcome-tour-dismissed";
+
+describe("WelcomeTour", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the tour when no dismissal flag is set", () => {
+    render(<WelcomeTour />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Welcome to StreamPay")).toBeInTheDocument();
+  });
+
+  it("shows nothing when dismissal flag is set", () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    render(<WelcomeTour />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows step 1 of 3 on first render", () => {
+    render(<WelcomeTour />);
+    expect(screen.getByText("Step 1 of 3")).toBeInTheDocument();
+  });
+
+  it('has a "Skip tour" button that dismisses the tour', () => {
+    render(<WelcomeTour />);
+    fireEvent.click(screen.getByText("Skip tour"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it('has a "Next" button that advances to step 2', () => {
+    render(<WelcomeTour />);
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create your first stream")
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Get started" on the last step', () => {
+    render(<WelcomeTour />);
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("Get started")).toBeInTheDocument();
+  });
+
+  it('dismisses and saves to localStorage when "Get started" is clicked', () => {
+    render(<WelcomeTour />);
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Get started"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("renders the dialog with correct accessibility attributes", () => {
+    render(<WelcomeTour />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "welcome-tour-title");
+  });
+
+  it("sets aria-live on step indicator", () => {
+    render(<WelcomeTour />);
+    expect(screen.getByText("Step 1 of 3")).toHaveAttribute(
+      "aria-live",
+      "polite"
+    );
+  });
+
+  it("handles localStorage being unavailable gracefully", () => {
+    const getItem = jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const setItem = jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    render(<WelcomeTour />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    getItem.mockRestore();
+    setItem.mockRestore();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -1554,6 +1554,79 @@ a:hover {
   }
 }
 
+/* ─── Welcome Tour Overlay ───────────────────────────────────────────────── */
+
+.welcome-tour-overlay {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 1000;
+  animation: welcome-tour-fade-in 0.3s ease-out;
+}
+
+.welcome-tour {
+  background: var(--panel-elevated);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  max-width: 28rem;
+  padding: 2.5rem;
+  position: relative;
+  width: 100%;
+  animation: welcome-tour-scale-in 0.3s ease-out;
+}
+
+.welcome-tour__step-indicator {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin-bottom: 1.25rem;
+  text-transform: uppercase;
+}
+
+.welcome-tour__title {
+  color: var(--foreground);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.welcome-tour__body {
+  color: var(--muted-light);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.welcome-tour__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+@keyframes welcome-tour-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes welcome-tour-scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .welcome-tour-overlay,
+  .welcome-tour {
+    animation: none;
+  }
+}
+
 /* ─── Splash Screen ──────────────────────────────────────────────────────── */
 
 .splash-screen {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import SplashScreen from "./components/SplashScreen";
+import { WelcomeTour } from "./components/WelcomeTour";
 import { ToastProvider } from "./components/ToastProvider";
 import { getThemeScript } from "./utils/theme-noflash";
 
@@ -26,6 +27,7 @@ export default function RootLayout({
         <ToastProvider>
           <SplashScreen />
           {children}
+          <WelcomeTour />
         </ToastProvider>
       </body>
     </html>


### PR DESCRIPTION
## Overview

This PR adds a **Welcome Tour** overlay that appears on a first-time user's initial visit to StreamPay. The tour provides a three-step guided walkthrough explaining the core product concepts, then dismisses permanently once completed or skipped.

## Related Issue

Closes #857

## Changes

### 🎯 Welcome Tour Overlay

- **\[ADD\]** `app/components/WelcomeTour.tsx`
  - 3-step multi-step tour overlay with step indicator, title, body, and action buttons
  - First-time detection via `localStorage` key `streampay:welcome-tour-dismissed`
  - Accessible dialog with `role="dialog"`, `aria-modal="true"`, `aria-live="polite"` on step indicator
  - "Skip tour" button dismisses immediately; "Next"/"Get started" navigates steps and dismisses

- **\[MODIFY\]** `app/layout.tsx`
  - Wired `<WelcomeTour />` into the root layout so it renders globally on first visit

- **\[ADD\]** `app/globals.css`
  - Overlay backdrop with `rgba(0,0,0,0.8)` + `backdrop-filter: blur(8px)`
  - Card styling using design tokens (`--panel-elevated`, `--border`, `--shadow-soft`)
  - Entrance animations (`welcome-tour-fade-in`, `welcome-tour-scale-in`) with `prefers-reduced-motion` support

- **\[ADD\]** `app/components/WelcomeTour.test.tsx`
  - 10 tests covering visibility, localStorage dismissal, step navigation, accessibility attributes, and graceful failure when storage is unavailable

## Verification Results

```
PASS app/components/WelcomeTour.test.tsx (10/10 passed)
  ✓ shows the tour when no dismissal flag is set
  ✓ shows nothing when dismissal flag is set
  ✓ shows step 1 of 3 on first render
  ✓ has a "Skip tour" button that dismisses the tour
  ✓ has a "Next" button that advances to step 2
  ✓ shows "Get started" on the last step
  ✓ dismisses and saves to localStorage when "Get started" is clicked
  ✓ renders the dialog with correct accessibility attributes
  ✓ sets aria-live on step indicator
  ✓ handles localStorage being unavailable gracefully
```

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Multi-step tour overlay appears for first-time users | ✅ 3-step tour with step indicator |
| Dismissed permanently after completion | ✅ localStorage flag saved |
| Accessible with proper ARIA attributes | ✅ role="dialog", aria-modal, aria-live |
| Responsive across all breakpoints | ✅ max-width 28rem card with padding |
| Dark/light theme consistency | ✅ Uses design tokens throughout |
| Tests added and passing | ✅ 10/10 passing