### PR TITLE
feat: wizard progress polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
 ## [Unreleased]
 
 ### Added
+- `app/streams/new/components/StepIndicator.tsx` — the create-stream wizard's
+  step indicator now exposes a visually-hidden `role="progressbar"` alongside
+  its existing `nav`/`aria-current` step list, with `aria-valuenow` /
+  `aria-valuemin` / `aria-valuemax` reflecting the current step position and
+  an `aria-valuetext` of the form "Step X of Y: &lt;label&gt;" for screen
+  readers (WCAG 2.1 AA). No visible/markup changes for sighted users; no prop
+  changes.
 - `lib/chaos.ts` — fault-injection middleware for chaos tests. Lets test
   suites inject latency, error responses, or request aborts at configurable
   rates (defaults disabled; opt in via `CHAOS_ENABLED=true` or programmatic

--- a/app/streams/new/components/StepIndicator.test.tsx
+++ b/app/streams/new/components/StepIndicator.test.tsx
@@ -160,4 +160,65 @@ describe("StepIndicator", () => {
     expect(steps[1]).not.toHaveAttribute("aria-current");
     expect(steps[2]).not.toHaveAttribute("aria-current");
   });
+
+  describe("progressbar", () => {
+    it("exposes a progressbar with aria-valuenow/min/max reflecting the current step", () => {
+      render(<StepIndicator steps={defaultSteps} currentStep={1} />);
+
+      const progressbar = screen.getByRole("progressbar");
+      expect(progressbar).toHaveAttribute("aria-valuenow", "2");
+      expect(progressbar).toHaveAttribute("aria-valuemin", "1");
+      expect(progressbar).toHaveAttribute("aria-valuemax", "3");
+    });
+
+    it("sets aria-valuenow to 1 on the first step", () => {
+      render(<StepIndicator steps={defaultSteps} currentStep={0} />);
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "1");
+    });
+
+    it("sets aria-valuenow to the total step count on the last step", () => {
+      render(<StepIndicator steps={defaultSteps} currentStep={2} />);
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "3");
+    });
+
+    it("includes the current step's label in aria-valuetext", () => {
+      render(<StepIndicator steps={defaultSteps} currentStep={1} />);
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute(
+        "aria-valuetext",
+        "Step 2 of 3: Recipients"
+      );
+    });
+
+    it("has an accessible name distinct from the nav landmark", () => {
+      render(<StepIndicator steps={defaultSteps} currentStep={0} />);
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-label", "Wizard progress");
+    });
+
+    it("is visually hidden but present in the accessibility tree", () => {
+      const { container } = render(<StepIndicator steps={defaultSteps} currentStep={0} />);
+
+      const progressbar = container.querySelector('[role="progressbar"]');
+      expect(progressbar).toHaveClass("sr-only");
+    });
+
+    it("does not render a progressbar for an empty steps array", () => {
+      render(<StepIndicator steps={[]} currentStep={0} />);
+
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("reflects a single step as 1 of 1", () => {
+      const singleStep = [{ id: "done", label: "Done" }];
+      render(<StepIndicator steps={singleStep} currentStep={0} />);
+
+      const progressbar = screen.getByRole("progressbar");
+      expect(progressbar).toHaveAttribute("aria-valuenow", "1");
+      expect(progressbar).toHaveAttribute("aria-valuemax", "1");
+      expect(progressbar).toHaveAttribute("aria-valuetext", "Step 1 of 1: Done");
+    });
+  });
 });

--- a/app/streams/new/components/StepIndicator.tsx
+++ b/app/streams/new/components/StepIndicator.tsx
@@ -1,5 +1,22 @@
 "use client";
 
+/**
+ * StepIndicator
+ *
+ * Step progress indicator for the create-stream wizard.
+ *
+ * ## Accessibility (WCAG 2.1 AA)
+ * - Visible steps are a `nav`/`ol` list; the current step carries
+ *   `aria-current="step"` per the WAI-ARIA breadcrumb/steps pattern.
+ * - A visually hidden (`.sr-only`) `role="progressbar"` mirrors the same
+ *   state as `aria-valuenow` / `aria-valuemin` / `aria-valuemax`, with
+ *   `aria-valuetext` giving screen readers a concise "Step X of Y: <label>"
+ *   summary — mirrors the pattern used by `StreamProgress`.
+ * - Markers and connectors are `aria-hidden`; state is not conveyed by
+ *   color/icon alone since the label and (for the current step) description
+ *   remain visible text.
+ */
+
 import React from "react";
 
 export interface Step {
@@ -15,8 +32,26 @@ interface StepIndicatorProps {
 }
 
 export function StepIndicator({ steps, currentStep, className = "" }: StepIndicatorProps) {
+  const totalSteps = steps.length;
+  const currentLabel = steps[currentStep]?.label;
+  const stepPosition = currentStep + 1;
+
   return (
     <nav aria-label="Progress" className={`step-indicator ${className}`.trim()}>
+      {totalSteps > 0 && (
+        // Visually hidden progressbar: the visible ol/li list already conveys
+        // progress sighted users via aria-current, but assistive tech benefits
+        // from a concise, standards-based "step X of Y" announcement.
+        <div
+          role="progressbar"
+          aria-valuenow={stepPosition}
+          aria-valuemin={1}
+          aria-valuemax={totalSteps}
+          aria-valuetext={`Step ${stepPosition} of ${totalSteps}${currentLabel ? `: ${currentLabel}` : ""}`}
+          aria-label="Wizard progress"
+          className="step-indicator__sr-progress sr-only"
+        />
+      )}
       <ol className="step-indicator__list">
         {steps.map((step, index) => {
           const isCompleted = index < currentStep;


### PR DESCRIPTION
## Summary
- `StepIndicator` (the create-stream wizard's progress indicator) now exposes a visually hidden `role="progressbar"` alongside its existing `nav`/`aria-current` step list.
- Adds `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and a descriptive `aria-valuetext` (`"Step X of Y: <label>"`) so assistive tech gets a standards-based progress summary, per WCAG 2.1 AA — mirrors the pattern already used by `StreamProgress`.
- No visible markup, styling, or prop changes for sighted users; existing `sr-only` utility class is reused (already defined in `app/globals.css`), so design-token/dark-mode consistency is unaffected.

Closes #843

## Changes
- `app/streams/new/components/StepIndicator.tsx` — added the hidden progressbar + doc comment describing the accessibility pattern.
- `app/streams/new/components/StepIndicator.test.tsx` — added focused tests covering: `aria-valuenow`/`min`/`max` at first/last/middle step, `aria-valuetext` content, `aria-label`, `sr-only` visual hiding, single-step (`1 of 1`), and the empty-steps edge case (no progressbar rendered).
- `CHANGELOG.md` — documented the new accessibility attributes under `[Unreleased] / Added`.

## Test plan
```
npx eslint app/streams/new/components/StepIndicator.tsx app/streams/new/components/StepIndicator.test.tsx
# no errors

npm test -- app/streams/new/components/StepIndicator.test.tsx
# Tests: 1 failed, 25 passed, 26 total
```
All 8 new progressbar tests pass. The 1 failing test (`shows description only for the current step`) is **pre-existing on `main`** and unrelated to this change — it contradicts another pre-existing test in the same file (`renders description elements for all steps in DOM`), since the component intentionally renders all step descriptions and hides non-current ones via CSS (`display: none` in `app/globals.css`), not conditional JSX. Verified by stashing this diff and re-running against `main` directly. Left out of scope to keep this PR focused; happy to fix in a follow-up if maintainers prefer.

Full-suite (`npm test`) parallel workers crash in this local Windows sandbox due to a pre-existing native-module loader issue (`@next/swc-win32-x64-msvc ... not a valid Win32 application`), unrelated to this change — deferring to CI for full-suite confirmation.

- [x] Implementation matches the description
- [x] Tests added and passing (scoped to this change)
- [ ] Code review approved
- [x] Docs updated (CHANGELOG.md)
