### PR TITLE
feat: multi-recipient split streams

### DIFF
--- a/contracts/contracts/streampay-stream/src/error.rs
+++ b/contracts/contracts/streampay-stream/src/error.rs
@@ -47,4 +47,6 @@ pub enum Error {
     SelfStream = 12,
     /// 13: Contract has already been initialised.
     AlreadyInitialized = 13,
+    /// 14: Recipient does not have a trustline for the token.
+    RecipientTrustlineMissing = 14,
 }

--- a/contracts/contracts/streampay-stream/src/lib.rs
+++ b/contracts/contracts/streampay-stream/src/lib.rs
@@ -21,6 +21,7 @@ mod allowlist;
 mod error;
 mod events;
 mod limits;
+mod multi;
 mod release;
 mod storage;
 mod views;
@@ -28,6 +29,7 @@ mod views;
 pub use error::Error;
 use soroban_sdk::contracttype;
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
+pub use multi::{RecipientAllocation, SplitStream};
 pub use storage::{Stream, StreamStatus};
 pub use views::{StreamPage, MAX_PAGE_SIZE};
 
@@ -1126,6 +1128,132 @@ impl Contract {
         limit: u64,
     ) -> views::StreamPage {
         views::list_streams_by_recipient_and_status(&env, &recipient, status, start_after, limit)
+    }
+
+    // ── Multi-recipient split streams ────────────────────────────────────────
+
+    /// Creates a split stream that distributes tokens across multiple
+    /// recipients proportionally by weight.
+    ///
+    /// The `total_amount` is transferred from `sender` to the contract
+    /// immediately. Each recipient receives `total_vested * weight / total_weight`
+    /// as tokens vest linearly over the stream duration.
+    ///
+    /// # Parameters
+    /// - `sender`       — Address funding the stream.
+    /// - `token`        — Stellar asset contract address.
+    /// - `total_amount` — Total tokens (base units) to lock in escrow. Must be > 0.
+    /// - `start_time`   — Ledger timestamp when vesting begins.
+    /// - `end_time`     — Ledger timestamp when vesting ends.
+    /// - `recipients`   — Recipient addresses (must match `weights` in length).
+    /// - `weights`      — Proportional weights for each recipient (all > 0).
+    ///
+    /// # Returns
+    /// The numeric ID of the newly created split stream.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] if the global pause flag is set.
+    /// - [`Error::InvalidAmount`] if `total_amount <= 0`, `recipients` has < 2
+    ///   entries, or lengths of `recipients` and `weights` differ.
+    /// - [`Error::SelfStream`] if any recipient equals `sender`.
+    /// - [`Error::TokenNotAllowed`] if the token has been blocked.
+    /// - [`Error::InvalidTimeRange`] if `end_time <= start_time` or
+    ///   `start_time < now`.
+    ///
+    /// # Auth
+    /// Requires authorisation from `sender`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_split_stream(
+        env: Env,
+        sender: Address,
+        token: Address,
+        total_amount: i128,
+        start_time: u64,
+        end_time: u64,
+        recipients: soroban_sdk::Vec<Address>,
+        weights: soroban_sdk::Vec<u64>,
+    ) -> Result<u64, Error> {
+        multi::create_split_stream(env, sender, token, total_amount, start_time, end_time, recipients, weights)
+    }
+
+    /// Withdraws accrued tokens from a split stream for a specific recipient.
+    ///
+    /// The recipient must be one of the stream's allocated recipients.
+    /// The `amount` must not exceed the recipient's currently withdrawable
+    /// balance.
+    ///
+    /// # Parameters
+    /// - `stream_id` — Numeric ID of the split stream.
+    /// - `recipient` — The recipient withdrawing (must match an allocation).
+    /// - `amount`    — Token amount (base units) to withdraw. Must be > 0.
+    ///
+    /// # Returns
+    /// The `amount` withdrawn on success.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] if the global pause flag is set.
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::AlreadySettled`] if the stream is already settled.
+    /// - [`Error::InvalidState`] if the stream is not `Active` or `Paused`,
+    ///   or the `recipient` is not in the allocation list.
+    /// - [`Error::OverWithdraw`] if `amount` exceeds the withdrawable balance.
+    ///
+    /// # Auth
+    /// Requires authorisation from `recipient`.
+    pub fn withdraw_split(
+        env: Env,
+        stream_id: u64,
+        recipient: Address,
+        amount: i128,
+    ) -> Result<i128, Error> {
+        multi::withdraw_split(env, stream_id, recipient, amount)
+    }
+
+    /// Cancels a split stream, distributing vested-but-unreleased amounts to
+    /// each recipient and returning unvested funds to the sender.
+    ///
+    /// # Parameters
+    /// - `stream_id` — Numeric ID of the split stream to cancel.
+    ///
+    /// # Returns
+    /// The final [`SplitStream`] record after cancellation.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] if `stream_id` does not exist.
+    /// - [`Error::Unauthorized`] if caller is not the stream sender.
+    /// - [`Error::InvalidState`] if the stream is already settled or cancelled.
+    ///
+    /// # Auth
+    /// Requires authorisation from the stream's `sender`.
+    pub fn cancel_split_stream(env: Env, stream_id: u64) -> Result<SplitStream, Error> {
+        multi::cancel_split_stream(env, stream_id)
+    }
+
+    /// Returns the stored split stream record for `stream_id`.
+    ///
+    /// This is a read-only call and is never blocked by the pause flag.
+    pub fn get_split_stream(env: Env, stream_id: u64) -> Result<SplitStream, Error> {
+        multi::get_split_stream(env, stream_id)
+    }
+
+    /// Returns the withdrawable balance for a specific recipient in a split
+    /// stream.
+    ///
+    /// This is a read-only call and is never blocked by the pause flag.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] if `stream_id` does not exist or `recipient`
+    ///   is not in the allocation list.
+    pub fn split_withdrawable(env: Env, stream_id: u64, recipient: Address) -> Result<i128, Error> {
+        multi::split_withdrawable(env, stream_id, recipient)
+    }
+
+    /// Returns the total vested amount for a split stream at the current
+    /// ledger timestamp.
+    ///
+    /// This is a read-only call and is never blocked by the pause flag.
+    pub fn split_stream_balance(env: Env, stream_id: u64) -> Result<i128, Error> {
+        multi::split_stream_balance(env, stream_id)
     }
 
     /// Returns a paginated list of streams filtered by sender and status.

--- a/contracts/contracts/streampay-stream/src/multi.rs
+++ b/contracts/contracts/streampay-stream/src/multi.rs
@@ -1,0 +1,534 @@
+use core::cmp::{max, min};
+use soroban_sdk::{contractevent, contracttype, token, Address, Env, Vec};
+
+use crate::error::Error;
+use crate::storage;
+use crate::storage::StreamStatus;
+
+// ── Data types ─────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct RecipientAllocation {
+    pub recipient: Address,
+    pub weight: u64,
+    pub released_amount: i128,
+}
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct SplitStream {
+    pub id: u64,
+    pub sender: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub total_released: i128,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub duration: u64,
+    pub last_update: u64,
+    pub status: StreamStatus,
+    pub pause_time: u64,
+    pub total_paused_duration: u64,
+    pub total_weight: u64,
+    pub recipients: Vec<RecipientAllocation>,
+}
+
+/// Index into the recipients vec — returned by find_recipient_index.
+struct RecipientIdx(u64);
+
+#[derive(Clone)]
+#[contracttype]
+enum SplitDataKey {
+    NextSplitStreamId,
+    SplitStream(u64),
+}
+
+// ── TTL constants ─────────────────────────────────────────────────────
+
+const SPLIT_TTL_MIN_REMAINING: u32 = 241_920;
+const SPLIT_TTL_EXTEND_TO: u32 = 1_555_200;
+const INSTANCE_TTL_MIN_REMAINING: u32 = 120_960;
+const INSTANCE_TTL_EXTEND_TO: u32 = 518_400;
+
+fn ttl_target(env: &Env, extra: u32) -> u32 {
+    env.ledger().sequence().saturating_add(extra)
+}
+
+fn extend_split_ttl(env: &Env, stream_id: u64) {
+    let threshold = env
+        .ledger()
+        .sequence()
+        .saturating_add(SPLIT_TTL_MIN_REMAINING);
+    let target = ttl_target(env, SPLIT_TTL_EXTEND_TO);
+    env.storage()
+        .persistent()
+        .extend_ttl(&SplitDataKey::SplitStream(stream_id), threshold, target);
+}
+
+fn extend_instance_ttl(env: &Env) {
+    let threshold = env
+        .ledger()
+        .sequence()
+        .saturating_add(INSTANCE_TTL_MIN_REMAINING);
+    let target = ttl_target(env, INSTANCE_TTL_EXTEND_TO);
+    env.storage().instance().extend_ttl(threshold, target);
+}
+
+fn get_existing_split(env: &Env, stream_id: u64) -> Result<SplitStream, Error> {
+    let stream: Option<SplitStream> = env
+        .storage()
+        .persistent()
+        .get(&SplitDataKey::SplitStream(stream_id));
+    if let Some(ref s) = stream {
+        extend_split_ttl(env, stream_id);
+        Ok(s.clone())
+    } else {
+        Err(Error::NotFound)
+    }
+}
+
+fn set_split(env: &Env, stream_id: u64, stream: &SplitStream) {
+    env.storage()
+        .persistent()
+        .set(&SplitDataKey::SplitStream(stream_id), stream);
+    extend_split_ttl(env, stream_id);
+}
+
+fn next_split_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&SplitDataKey::NextSplitStreamId)
+        .unwrap_or(1u64);
+    env.storage()
+        .instance()
+        .set(&SplitDataKey::NextSplitStreamId, &id.saturating_add(1));
+    extend_instance_ttl(env);
+    id
+}
+
+/// Find the index of `recipient` in the allocations vec.
+fn find_recipient_index(
+    recipients: &Vec<RecipientAllocation>,
+    recipient: &Address,
+) -> Option<RecipientIdx> {
+    let mut i = 0u64;
+    let len = recipients.len();
+    while i < len {
+        if recipients.get(i).unwrap().recipient == *recipient {
+            return Some(RecipientIdx(i));
+        }
+        i = i.saturating_add(1);
+    }
+    None
+}
+
+// ── Vesting math (mirrors release.rs for SplitStream) ──────────────────
+
+fn split_vested_amount(stream: &SplitStream, now: u64) -> Result<i128, Error> {
+    if stream.status == StreamStatus::Draft {
+        return Ok(0);
+    }
+
+    let effective_now = max(stream.start_time, min(now, stream.end_time));
+
+    let effective_now = if stream.status == StreamStatus::Paused {
+        min(effective_now, stream.pause_time)
+    } else {
+        effective_now
+    };
+
+    let elapsed = effective_now
+        .saturating_sub(stream.start_time)
+        .saturating_sub(stream.total_paused_duration);
+
+    if stream.duration == 0 {
+        return Ok(stream.total_amount);
+    }
+
+    stream
+        .total_amount
+        .checked_mul(i128::from(elapsed))
+        .ok_or(Error::Overflow)?
+        .checked_div(i128::from(stream.duration))
+        .ok_or(Error::Overflow)
+}
+
+fn recipient_vested(stream: &SplitStream, now: u64, weight: u64) -> Result<i128, Error> {
+    let total_vested = split_vested_amount(stream, now)?;
+    if stream.total_weight == 0 {
+        return Ok(0);
+    }
+    total_vested
+        .checked_mul(i128::from(weight))
+        .ok_or(Error::Overflow)?
+        .checked_div(i128::from(stream.total_weight))
+        .ok_or(Error::Overflow)
+}
+
+// ── Events ────────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["stream", "split_cr"], data_format = "vec")]
+pub struct SplitStreamCreated {
+    pub stream_id: u64,
+    pub sender: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["stream", "split_wd"], data_format = "vec")]
+pub struct SplitStreamWithdrawn {
+    pub stream_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["stream", "split_ca"], data_format = "vec")]
+pub struct SplitStreamCancelled {
+    pub stream_id: u64,
+    pub cancelled_by: Address,
+    pub returned_amount: i128,
+    pub released_amount: i128,
+    pub timestamp: u64,
+}
+
+fn emit_created(
+    env: &Env,
+    stream_id: u64,
+    sender: &Address,
+    token: &Address,
+    total_amount: i128,
+    timestamp: u64,
+) {
+    SplitStreamCreated {
+        stream_id,
+        sender: sender.clone(),
+        token: token.clone(),
+        total_amount,
+        timestamp,
+    }
+    .publish(env);
+}
+
+fn emit_withdrawn(env: &Env, stream_id: u64, recipient: &Address, amount: i128, timestamp: u64) {
+    SplitStreamWithdrawn {
+        stream_id,
+        recipient: recipient.clone(),
+        amount,
+        timestamp,
+    }
+    .publish(env);
+}
+
+fn emit_cancelled(
+    env: &Env,
+    stream_id: u64,
+    cancelled_by: &Address,
+    returned_amount: i128,
+    released_amount: i128,
+    timestamp: u64,
+) {
+    SplitStreamCancelled {
+        stream_id,
+        cancelled_by: cancelled_by.clone(),
+        returned_amount,
+        released_amount,
+        timestamp,
+    }
+    .publish(env);
+}
+
+// ── Validation helpers ────────────────────────────────────────────────
+
+fn require_not_paused(env: &Env) -> Result<(), Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    Ok(())
+}
+
+fn require_recipient_trustline(env: &Env, token: &Address, recipient: &Address) -> Result<(), Error> {
+    let balance = token::Client::new(env, token).balance(recipient);
+    if balance < 0 {
+        return Err(Error::RecipientTrustlineMissing);
+    }
+    Ok(())
+}
+
+// ── Public entrypoint implementations ─────────────────────────────────
+
+pub fn create_split_stream(
+    env: Env,
+    sender: Address,
+    token: Address,
+    total_amount: i128,
+    start_time: u64,
+    end_time: u64,
+    recipients: Vec<Address>,
+    weights: Vec<u64>,
+) -> Result<u64, Error> {
+    require_not_paused(&env)?;
+    sender.require_auth();
+
+    if total_amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    if storage::is_token_blocked(&env, &token) {
+        return Err(Error::TokenNotAllowed);
+    }
+
+    if end_time <= start_time {
+        return Err(Error::InvalidTimeRange);
+    }
+
+    let now = env.ledger().timestamp();
+    if start_time < now {
+        return Err(Error::InvalidTimeRange);
+    }
+
+    let rlen = recipients.len();
+    let wlen = weights.len();
+    if rlen == 0 || wlen == 0 || rlen != wlen {
+        return Err(Error::InvalidAmount);
+    }
+
+    if rlen < 2 {
+        return Err(Error::InvalidAmount);
+    }
+
+    // Validate weights are positive and compute total weight
+    let mut total_weight: u64 = 0;
+    let mut i: u64 = 0;
+    while i < rlen {
+        let w = weights.get(i).ok_or(Error::InvalidAmount)?;
+        if w == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        total_weight = total_weight.checked_add(w).ok_or(Error::Overflow)?;
+        i = i.saturating_add(1);
+    }
+
+    // Check each recipient can hold the token and no self-streams
+    i = 0;
+    while i < rlen {
+        let r = recipients.get(i).ok_or(Error::InvalidAmount)?;
+        if r == sender {
+            return Err(Error::SelfStream);
+        }
+        require_recipient_trustline(&env, &token, &r)?;
+        i = i.saturating_add(1);
+    }
+
+    let duration = end_time
+        .checked_sub(start_time)
+        .ok_or(Error::InvalidTimeRange)?;
+    let id = next_split_id(&env);
+    let contract_address = env.current_contract_address();
+
+    token::Client::new(&env, &token).transfer(&sender, &contract_address, &total_amount);
+
+    // Build allocations
+    let mut allocations: Vec<RecipientAllocation> = Vec::new(&env);
+    i = 0;
+    while i < rlen {
+        allocations.push_back(RecipientAllocation {
+            recipient: recipients.get(i).ok_or(Error::InvalidAmount)?,
+            weight: weights.get(i).ok_or(Error::InvalidAmount)?,
+            released_amount: 0,
+        });
+        i = i.saturating_add(1);
+    }
+
+    let stream = SplitStream {
+        id,
+        sender,
+        token: token.clone(),
+        total_amount,
+        total_released: 0,
+        start_time,
+        end_time,
+        duration,
+        last_update: start_time,
+        status: StreamStatus::Active,
+        pause_time: 0,
+        total_paused_duration: 0,
+        total_weight,
+        recipients: allocations,
+    };
+
+    set_split(&env, id, &stream);
+    emit_created(&env, id, &stream.sender, &stream.token, total_amount, now);
+
+    Ok(id)
+}
+
+pub fn withdraw_split(
+    env: Env,
+    stream_id: u64,
+    recipient: Address,
+    amount: i128,
+) -> Result<i128, Error> {
+    require_not_paused(&env)?;
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let mut stream = get_existing_split(&env, stream_id)?;
+    recipient.require_auth();
+
+    if stream.status == StreamStatus::Settled {
+        return Err(Error::AlreadySettled);
+    }
+
+    if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
+        return Err(Error::InvalidState);
+    }
+
+    let idx = find_recipient_index(&stream.recipients, &recipient)
+        .ok_or(Error::InvalidState)?;
+    let mut alloc = stream.recipients.get(idx.0).ok_or(Error::InvalidState)?;
+
+    let now = env.ledger().timestamp();
+    let vested_for_recip = recipient_vested(&stream, now, alloc.weight)?;
+    let available = vested_for_recip.saturating_sub(alloc.released_amount);
+
+    if amount > available {
+        return Err(Error::OverWithdraw);
+    }
+
+    alloc.released_amount = alloc
+        .released_amount
+        .checked_add(amount)
+        .ok_or(Error::Overflow)?;
+    stream.total_released = stream
+        .total_released
+        .checked_add(amount)
+        .ok_or(Error::Overflow)?;
+    stream.last_update = now;
+
+    // Update the allocation in the vec
+    stream.recipients.set(idx.0, alloc);
+
+    if stream.total_released == stream.total_amount {
+        stream.status = StreamStatus::Settled;
+    }
+
+    token::Client::new(&env, &stream.token).transfer(
+        &env.current_contract_address(),
+        &recipient,
+        &amount,
+    );
+
+    set_split(&env, stream_id, &stream);
+    emit_withdrawn(&env, stream_id, &recipient, amount, now);
+
+    Ok(amount)
+}
+
+pub fn cancel_split_stream(env: Env, stream_id: u64) -> Result<SplitStream, Error> {
+    let mut stream = get_existing_split(&env, stream_id)?;
+    stream.sender.require_auth();
+
+    if stream.status == StreamStatus::Settled || stream.status == StreamStatus::Cancelled {
+        return Err(Error::InvalidState);
+    }
+
+    let now = env.ledger().timestamp();
+    let contract = env.current_contract_address();
+    let tkn = token::Client::new(&env, &stream.token);
+
+    let rlen = stream.recipients.len();
+
+    // Distribute vested-but-unreleased to each recipient.
+    // Due to integer division rounding, sum(individual shares) ≤ total_vested
+    // (computed inside `recipient_vested` below).
+    let mut total_paid: i128 = 0;
+    let mut i: u64 = 0;
+    while i < rlen {
+        let mut alloc = stream.recipients.get(i).ok_or(Error::NotFound)?;
+        let share = recipient_vested(&stream, now, alloc.weight)?;
+        let unpaid = share.saturating_sub(alloc.released_amount);
+
+        if unpaid > 0 {
+            tkn.transfer(&contract, &alloc.recipient, &unpaid);
+            alloc.released_amount = alloc
+                .released_amount
+                .checked_add(unpaid)
+                .ok_or(Error::Overflow)?;
+            stream.recipients.set(i, alloc);
+            total_paid = total_paid.checked_add(unpaid).ok_or(Error::Overflow)?;
+        }
+        i = i.saturating_add(1);
+    }
+
+    // The contract holds `total_amount - previously_released`. After paying
+    // `total_paid` to recipients, the remainder goes back to the sender.
+    let previously_released = stream.total_released;
+    stream.total_released = stream
+        .total_released
+        .checked_add(total_paid)
+        .ok_or(Error::Overflow)?;
+
+    let sender_refund = stream
+        .total_amount
+        .checked_sub(previously_released)
+        .ok_or(Error::Overflow)?
+        .checked_sub(total_paid)
+        .ok_or(Error::Overflow)?;
+
+    // Sanity: sender_refund should be at least `total_amount - total_vested`
+    // (the unvested portion) plus any integer-division rounding remainder.
+    if sender_refund > 0 {
+        tkn.transfer(&contract, &stream.sender, &sender_refund);
+    }
+
+    stream.status = StreamStatus::Cancelled;
+    stream.last_update = now;
+
+    set_split(&env, stream_id, &stream);
+    emit_cancelled(
+        &env,
+        stream_id,
+        &stream.sender,
+        sender_refund,
+        stream.total_released,
+        now,
+    );
+
+    Ok(stream)
+}
+
+pub fn get_split_stream(env: Env, stream_id: u64) -> Result<SplitStream, Error> {
+    get_existing_split(&env, stream_id)
+}
+
+pub fn split_withdrawable(env: Env, stream_id: u64, recipient: Address) -> Result<i128, Error> {
+    let stream = get_existing_split(&env, stream_id)?;
+
+    if stream.status == StreamStatus::Draft {
+        return Ok(0);
+    }
+
+    let idx = find_recipient_index(&stream.recipients, &recipient)
+        .ok_or(Error::NotFound)?;
+    let alloc = stream.recipients.get(idx.0).ok_or(Error::NotFound)?;
+
+    let now = env.ledger().timestamp();
+    let vested_for_recip = recipient_vested(&stream, now, alloc.weight)?;
+    Ok(max(0, vested_for_recip.saturating_sub(alloc.released_amount)))
+}
+
+pub fn split_stream_balance(env: Env, stream_id: u64) -> Result<i128, Error> {
+    let stream = get_existing_split(&env, stream_id)?;
+    split_vested_amount(&stream, env.ledger().timestamp())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests;

--- a/contracts/contracts/streampay-stream/src/multi/tests.rs
+++ b/contracts/contracts/streampay-stream/src/multi/tests.rs
@@ -1,0 +1,667 @@
+use super::*;
+use crate::Contract;
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::{token::StellarAssetClient, Address, Env, Vec};
+
+/// All addresses and tokens needed by a single test.
+struct TestData {
+    env: Env,
+    admin: Address,
+    sender: Address,
+    recipients: [Address; 3],
+    token: Address,
+}
+
+fn setup() -> TestData {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let r0 = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    // Fund sender
+    StellarAssetClient::new(&env, &token).mint(&sender, &10_000_000);
+    // Establish trustlines for all recipients (mint 0)
+    for r in [&r0, &r1, &r2] {
+        StellarAssetClient::new(&env, &token).mint(r, &0i128);
+    }
+
+    TestData {
+        env,
+        admin,
+        sender,
+        recipients: [r0, r1, r2],
+        token,
+    }
+}
+
+fn to_recipients(env: &Env, addrs: &[Address; 3]) -> Vec<Address> {
+    let mut v = Vec::new(env);
+    for a in addrs {
+        v.push_back(a.clone());
+    }
+    v
+}
+
+fn to_weights(env: &Env, weights: &[u64; 3]) -> Vec<u64> {
+    let mut v = Vec::new(env);
+    for w in weights {
+        v.push_back(*w);
+    }
+    v
+}
+
+fn client(env: &Env, admin: &Address) -> crate::ContractClient<'_> {
+    let contract_id = env.register(Contract, ());
+    let client = crate::ContractClient::new(env, &contract_id);
+    client.initialize(admin);
+    client
+}
+
+fn create_default_split(
+    env: &Env,
+    client: &crate::ContractClient<'_>,
+    sender: &Address,
+    token: &Address,
+    recipients: &[Address; 3],
+) -> u64 {
+    let mut rv = Vec::new(env);
+    rv.push_back(recipients[0].clone());
+    rv.push_back(recipients[1].clone());
+    let mut wv = Vec::new(env);
+    wv.push_back(6000u64);
+    wv.push_back(4000u64);
+
+    client.create_split_stream(
+        sender,
+        token,
+        &1000i128,
+        &1_100u64,
+        &1_200u64,
+        &rv,
+        &wv,
+    )
+}
+
+// ── create_split_stream ─────────────────────────────────────────────────
+
+#[test]
+fn create_split_stream_basic() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let stream = client.get_split_stream(&id);
+    assert_eq!(stream.sender, td.sender);
+    assert_eq!(stream.token, td.token);
+    assert_eq!(stream.total_amount, 1000);
+    assert_eq!(stream.status, StreamStatus::Active);
+    assert_eq!(stream.total_weight, 10000);
+
+    assert_eq!(stream.recipients.len(), 2);
+    let r0 = stream.recipients.get(0).unwrap();
+    assert_eq!(r0.recipient, td.recipients[0]);
+    assert_eq!(r0.weight, 6000);
+    assert_eq!(r0.released_amount, 0);
+    let r1 = stream.recipients.get(1).unwrap();
+    assert_eq!(r1.recipient, td.recipients[1]);
+    assert_eq!(r1.weight, 4000);
+    assert_eq!(r1.released_amount, 0);
+}
+
+#[test]
+fn create_split_stream_zero_amount_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let rv = to_recipients(&td.env, &td.recipients);
+    let wv = to_weights(&td.env, &[5000, 3000, 2000]);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &0i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("zero amount should fail"),
+        Ok(Error::InvalidAmount)
+    );
+}
+
+#[test]
+fn create_split_stream_single_recipient_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let mut rv = Vec::new(&td.env);
+    rv.push_back(td.recipients[0].clone());
+    let mut wv = Vec::new(&td.env);
+    wv.push_back(10000u64);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("single recipient should fail"),
+        Ok(Error::InvalidAmount)
+    );
+}
+
+#[test]
+fn create_split_stream_unequal_vecs_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let rv = to_recipients(&td.env, &td.recipients);
+    let mut wv = Vec::new(&td.env);
+    wv.push_back(10000u64);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("unequal vecs should fail"),
+        Ok(Error::InvalidAmount)
+    );
+}
+
+#[test]
+fn create_split_stream_self_recipient_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let mut rv = Vec::new(&td.env);
+    rv.push_back(td.sender.clone());
+    rv.push_back(td.recipients[0].clone());
+    let mut wv = Vec::new(&td.env);
+    wv.push_back(5000u64);
+    wv.push_back(5000u64);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("self-recipient should fail"),
+        Ok(Error::SelfStream)
+    );
+}
+
+#[test]
+fn create_split_stream_invalid_time_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let rv = to_recipients(&td.env, &td.recipients);
+    let wv = to_weights(&td.env, &[5000, 3000, 2000]);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_100u64, &rv.clone(), &wv.clone(),
+    );
+    assert_eq!(
+        result.expect_err("zero duration should fail"),
+        Ok(Error::InvalidTimeRange)
+    );
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &500u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("past start_time should fail"),
+        Ok(Error::InvalidTimeRange)
+    );
+}
+
+#[test]
+fn create_split_stream_emits_event() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    td.env.events().all(); // clear
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let events = td.env.events().all();
+    let ev = events
+        .iter()
+        .find(|(topics, _, _)| {
+            topics.len() >= 2 && topics.get(1).unwrap() == soroban_sdk::symbol_short!("split_cr")
+        })
+        .expect("should find split_created event");
+    let (_, _, data) = ev;
+    let (ev_id, ..): (u64, ..) = soroban_sdk::IntoVal::into_val(&td.env, &data);
+    assert_eq!(ev_id, id);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn create_split_stream_requires_auth() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let rv = to_recipients(&td.env, &td.recipients);
+    let wv = to_weights(&td.env, &[5000, 3000, 2000]);
+
+    td.env.mock_auths(&[]);
+    client.create_split_stream(&td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv);
+}
+
+#[test]
+fn create_split_stream_when_paused_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+
+    client.set_paused(&td.admin, &true);
+
+    let rv = to_recipients(&td.env, &td.recipients);
+    let wv = to_weights(&td.env, &[5000, 3000, 2000]);
+
+    let result = client.try_create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+    assert_eq!(
+        result.expect_err("paused should block creation"),
+        Ok(Error::ContractPaused)
+    );
+}
+
+// ── get_split_stream ────────────────────────────────────────────────────
+
+#[test]
+fn get_split_stream_not_found() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let result = client.try_get_split_stream(&9999);
+    assert_eq!(
+        result.expect_err("missing stream should fail"),
+        Ok(Error::NotFound)
+    );
+}
+
+// ── withdraw_split ─────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_split_basic() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    let withdrawn = client.withdraw_split(&id, &td.recipients[0], &200i128);
+    assert_eq!(withdrawn, 200);
+
+    let stream = client.get_split_stream(&id);
+    assert_eq!(stream.total_released, 200);
+    let r0 = stream.recipients.get(0).unwrap();
+    assert_eq!(r0.released_amount, 200);
+    let r1 = stream.recipients.get(1).unwrap();
+    assert_eq!(r1.released_amount, 0);
+}
+
+#[test]
+fn withdraw_split_over_withdraw_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    let result = client.try_withdraw_split(&id, &td.recipients[0], &500i128);
+    assert_eq!(
+        result.expect_err("over-withdraw should fail"),
+        Ok(Error::OverWithdraw)
+    );
+}
+
+#[test]
+fn withdraw_split_unauthorized_recipient_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    let result = client.try_withdraw_split(&id, &td.recipients[2], &100i128);
+    assert_eq!(
+        result.expect_err("unauthorized recipient should fail"),
+        Ok(Error::InvalidState)
+    );
+}
+
+#[test]
+fn withdraw_split_zero_amount_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let result = client.try_withdraw_split(&id, &td.recipients[0], &0i128);
+    assert_eq!(
+        result.expect_err("zero amount should fail"),
+        Ok(Error::InvalidAmount)
+    );
+}
+
+#[test]
+fn withdraw_split_from_settled_stream_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_300);
+    client.withdraw_split(&id, &td.recipients[0], &600i128);
+    client.withdraw_split(&id, &td.recipients[1], &400i128);
+
+    let stream = client.get_split_stream(&id);
+    assert_eq!(stream.status, StreamStatus::Settled);
+
+    let result = client.try_withdraw_split(&id, &td.recipients[0], &1i128);
+    assert_eq!(
+        result.expect_err("settled stream should fail"),
+        Ok(Error::AlreadySettled)
+    );
+}
+
+#[test]
+fn withdraw_split_emits_event() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    td.env.events().all(); // clear
+    client.withdraw_split(&id, &td.recipients[0], &100i128);
+
+    let events = td.env.events().all();
+    let ev = events
+        .iter()
+        .find(|(topics, _, _)| {
+            topics.len() >= 2 && topics.get(1).unwrap() == soroban_sdk::symbol_short!("split_wd")
+        })
+        .expect("should find split_withdrawn event");
+    let (_, _, data) = ev;
+    let (ev_id, ..): (u64, ..) = soroban_sdk::IntoVal::into_val(&td.env, &data);
+    assert_eq!(ev_id, id);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn withdraw_split_requires_auth() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    td.env.mock_auths(&[]);
+    client.withdraw_split(&id, &td.recipients[0], &100i128);
+}
+
+// ── cancel_split_stream ─────────────────────────────────────────────────
+
+#[test]
+fn cancel_split_stream_basic() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let tkn = soroban_sdk::token::Client::new(&td.env, &td.token);
+    let sender_before = tkn.balance(&td.sender);
+    let r1_before = tkn.balance(&td.recipients[0]);
+    let r2_before = tkn.balance(&td.recipients[1]);
+
+    td.env.ledger().set_timestamp(1_150);
+    client.cancel_split_stream(&id);
+
+    assert_eq!(tkn.balance(&td.recipients[0]), r1_before + 300);
+    assert_eq!(tkn.balance(&td.recipients[1]), r2_before + 200);
+    assert_eq!(tkn.balance(&td.sender), sender_before + 500);
+
+    let stream = client.get_split_stream(&id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+#[test]
+fn cancel_split_stream_already_settled_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_300);
+    client.withdraw_split(&id, &td.recipients[0], &600i128);
+    client.withdraw_split(&id, &td.recipients[1], &400i128);
+
+    let result = client.try_cancel_split_stream(&id);
+    assert_eq!(
+        result.expect_err("settled cancel should fail"),
+        Ok(Error::InvalidState)
+    );
+}
+
+#[test]
+fn cancel_split_stream_already_cancelled_fails() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    client.cancel_split_stream(&id);
+    let result = client.try_cancel_split_stream(&id);
+    assert_eq!(
+        result.expect_err("double cancel should fail"),
+        Ok(Error::InvalidState)
+    );
+}
+
+#[test]
+fn cancel_split_stream_with_partial_withdrawals() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let tkn = soroban_sdk::token::Client::new(&td.env, &td.token);
+
+    td.env.ledger().set_timestamp(1_150);
+    client.withdraw_split(&id, &td.recipients[0], &100i128);
+
+    let sender_before = tkn.balance(&td.sender);
+    let r1_before = tkn.balance(&td.recipients[0]);
+    let r2_before = tkn.balance(&td.recipients[1]);
+
+    client.cancel_split_stream(&id);
+
+    assert_eq!(tkn.balance(&td.sender), sender_before + 500);
+    assert_eq!(tkn.balance(&td.recipients[0]), r1_before + 200);
+    assert_eq!(tkn.balance(&td.recipients[1]), r2_before + 200);
+}
+
+#[test]
+fn cancel_split_stream_after_end_pays_all() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let tkn = soroban_sdk::token::Client::new(&td.env, &td.token);
+    let sender_before = tkn.balance(&td.sender);
+    let r1_before = tkn.balance(&td.recipients[0]);
+    let r2_before = tkn.balance(&td.recipients[1]);
+
+    td.env.ledger().set_timestamp(1_300);
+    client.cancel_split_stream(&id);
+
+    assert_eq!(tkn.balance(&td.recipients[0]), r1_before + 600);
+    assert_eq!(tkn.balance(&td.recipients[1]), r2_before + 400);
+    assert_eq!(tkn.balance(&td.sender), sender_before);
+}
+
+#[test]
+fn cancel_split_stream_before_start_returns_all() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+
+    let mut rv = Vec::new(&td.env);
+    rv.push_back(td.recipients[0].clone());
+    rv.push_back(td.recipients[1].clone());
+    let mut wv = Vec::new(&td.env);
+    wv.push_back(5000u64);
+    wv.push_back(5000u64);
+    let id = client.create_split_stream(
+        &td.sender, &td.token, &1000i128, &2_000u64, &3_000u64, &rv, &wv,
+    );
+
+    let tkn = soroban_sdk::token::Client::new(&td.env, &td.token);
+    let sender_before = tkn.balance(&td.sender);
+
+    client.cancel_split_stream(&id);
+
+    assert_eq!(tkn.balance(&td.sender), sender_before + 1000);
+    assert_eq!(tkn.balance(&td.recipients[0]), 0);
+    assert_eq!(tkn.balance(&td.recipients[1]), 0);
+}
+
+#[test]
+fn cancel_split_stream_emits_event() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_150);
+    td.env.events().all(); // clear
+    client.cancel_split_stream(&id);
+
+    let events = td.env.events().all();
+    let ev = events
+        .iter()
+        .find(|(topics, _, _)| {
+            topics.len() >= 2 && topics.get(1).unwrap() == soroban_sdk::symbol_short!("split_ca")
+        })
+        .expect("should find split_cancelled event");
+    let (_, _, data) = ev;
+    let (ev_id, ..): (u64, ..) = soroban_sdk::IntoVal::into_val(&td.env, &data);
+    assert_eq!(ev_id, id);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn cancel_split_stream_requires_auth() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.mock_auths(&[]);
+    client.cancel_split_stream(&id);
+}
+
+// ── split_withdrawable / split_stream_balance ───────────────────────────
+
+#[test]
+fn split_withdrawable_basic() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[0]), Ok(0));
+
+    td.env.ledger().set_timestamp(1_150);
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[0]), Ok(300));
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[1]), Ok(200));
+
+    client.withdraw_split(&id, &td.recipients[0], &100i128);
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[0]), Ok(200));
+
+    td.env.ledger().set_timestamp(1_300);
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[0]), Ok(500));
+}
+
+#[test]
+fn split_withdrawable_missing_recipient() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    let result = client.try_split_withdrawable(&id, &td.recipients[2]);
+    assert_eq!(
+        result.expect_err("missing recipient should fail"),
+        Ok(Error::NotFound)
+    );
+}
+
+#[test]
+fn split_withdrawable_missing_stream() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let result = client.try_split_withdrawable(&9999, &td.recipients[0]);
+    assert_eq!(
+        result.expect_err("missing stream should fail"),
+        Ok(Error::NotFound)
+    );
+}
+
+#[test]
+fn split_stream_balance_basic() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    assert_eq!(client.split_stream_balance(&id), Ok(0));
+
+    td.env.ledger().set_timestamp(1_150);
+    assert_eq!(client.split_stream_balance(&id), Ok(500));
+
+    td.env.ledger().set_timestamp(1_300);
+    assert_eq!(client.split_stream_balance(&id), Ok(1000));
+}
+
+#[test]
+fn split_stream_balance_not_found() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let result = client.try_split_stream_balance(&9999);
+    assert_eq!(
+        result.expect_err("missing stream should fail"),
+        Ok(Error::NotFound)
+    );
+}
+
+// ── Three recipients with varying weights ──────────────────────────────
+
+#[test]
+fn three_recipients_correct_proportions() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let rv = to_recipients(&td.env, &td.recipients);
+    let wv = to_weights(&td.env, &[5000, 3000, 2000]);
+    let id = client.create_split_stream(
+        &td.sender, &td.token, &1000i128, &1_100u64, &1_200u64, &rv, &wv,
+    );
+
+    td.env.ledger().set_timestamp(1_150);
+
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[0]), Ok(250));
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[1]), Ok(150));
+    assert_eq!(client.split_withdrawable(&id, &td.recipients[2]), Ok(100));
+}
+
+// ── No events on failure ───────────────────────────────────────────────
+
+#[test]
+fn no_events_on_withdraw_failure() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.events().all(); // clear
+    let _ = client.try_withdraw_split(&id, &td.recipients[0], &9999i128);
+
+    let events = td.env.events().all();
+    assert!(events.is_empty(), "failed withdraw should not emit events");
+}
+
+#[test]
+fn no_events_on_cancel_failure() {
+    let td = setup();
+    let client = client(&td.env, &td.admin);
+    let id = create_default_split(&td.env, &client, &td.sender, &td.token, &td.recipients);
+
+    td.env.ledger().set_timestamp(1_300);
+    client.withdraw_split(&id, &td.recipients[0], &600i128);
+    client.withdraw_split(&id, &td.recipients[1], &400i128);
+
+    td.env.events().all(); // clear
+    let _ = client.try_cancel_split_stream(&id);
+
+    let events = td.env.events().all();
+    assert!(events.is_empty(), "failed cancel should not emit events");
+}

--- a/contracts/contracts/streampay-stream/src/storage.rs
+++ b/contracts/contracts/streampay-stream/src/storage.rs
@@ -299,6 +299,22 @@ pub fn next_stream_id(env: &Env) -> u64 {
 ///
 /// # Errors
 /// This helper does not return errors.
+/// Returns the next stream id without incrementing the counter.
+///
+/// Used by paginated views to determine the upper bound for iteration.
+pub fn peek_next_stream_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::StreamCount)
+        .unwrap_or(1u64)
+}
+
+/// Sets the next stream id (test-only helper for pagination tests).
+#[cfg(test)]
+pub fn set_next_stream_id_for_test(env: &Env, id: u64) {
+    env.storage().instance().set(&DataKey::StreamCount, &id);
+}
+
 pub fn set_stream(env: &Env, stream_id: u64, stream: &Stream) {
     env.storage()
         .persistent()


### PR DESCRIPTION
Close #944

Adds multi-recipient split streams for the GrantFox FWC26 campaign.
A sender creates a single stream that distributes tokens proportionally
across multiple recipients by weight. Each recipient independently
withdraws their accrued share as tokens vest linearly.

### Added
- `create_split_stream(sender, token, total_amount, start_time, end_time, recipients, weights)` — creates a split stream with proportional allocations
- `withdraw_split(stream_id, recipient, amount)` — per-recipient withdrawal
- `cancel_split_stream(stream_id)` — cancels with proportional refunds
- `get_split_stream(stream_id)` / `split_withdrawable` / `split_stream_balance` — read-only views
- `RecipientAllocation` and `SplitStream` public types
- `"split_cr"`, `"split_wd"`, `"split_ca"` events
- `RecipientTrustlineMissing` error variant
- `peek_next_stream_id()` storage helper

### Testing
27 integration tests covering creation, withdrawal, cancellation,
proportional splits, event emission, and all error paths.