### PR TITLE
feat: bottom nav badges

### DIFF
--- a/app/components/AppBottomNav.test.tsx
+++ b/app/components/AppBottomNav.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+const { screen } = require("@testing-library/react") as any;
+import { usePathname } from "next/navigation";
+import { AppBottomNav } from "./AppBottomNav";
+
+describe("AppBottomNav", () => {
+  beforeEach(() => {
+    (usePathname as jest.Mock).mockReturnValue("/streams");
+  });
+
+  it("hides the bottom nav on the home page", () => {
+    (usePathname as jest.Mock).mockReturnValue("/");
+    render(<AppBottomNav />);
+    expect(screen.queryByRole("navigation", { name: "Primary" })).not.toBeInTheDocument();
+  });
+
+  it("shows the bottom nav on app pages", () => {
+    render(<AppBottomNav />);
+    expect(screen.getByRole("navigation", { name: "Primary" })).toBeInTheDocument();
+    expect(screen.getByText("Streams")).toBeInTheDocument();
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+});

--- a/app/components/AppBottomNav.tsx
+++ b/app/components/AppBottomNav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { BottomNav, type BottomNavItem } from "./BottomNav";
+
+function IconStreams() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M2 12h20" />
+      <path d="M2 6h20" />
+      <path d="M2 18h20" />
+    </svg>
+  );
+}
+
+function IconActivity() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+    </svg>
+  );
+}
+
+function IconSettings() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+const items: BottomNavItem[] = [
+  { href: "/streams", label: "Streams", icon: <IconStreams /> },
+  { href: "/activity", label: "Activity", icon: <IconActivity /> },
+  { href: "/settings", label: "Settings", icon: <IconSettings /> },
+];
+
+export function AppBottomNav() {
+  const pathname = usePathname() ?? "/";
+
+  if (pathname === "/") return null;
+
+  return <BottomNav items={items} />;
+}

--- a/app/components/BottomNav.test.tsx
+++ b/app/components/BottomNav.test.tsx
@@ -7,10 +7,10 @@ const { screen } = require("@testing-library/react") as any;
 import { usePathname } from "next/navigation";
 import { BottomNav, type BottomNavItem } from "./BottomNav";
 
-const items: BottomNavItem[] = [
-  { href: "/streams", label: "Streams", badgeCount: 3 },
-  { href: "/activity", label: "Activity" },
-  { href: "/settings", label: "Settings", badgeCount: 12 },
+const withIcon: BottomNavItem[] = [
+  { href: "/streams", label: "Streams", badgeCount: 3, icon: <svg data-testid="icon-streams" /> },
+  { href: "/activity", label: "Activity", icon: <svg data-testid="icon-activity" /> },
+  { href: "/settings", label: "Settings", badgeCount: 12, icon: <svg data-testid="icon-settings" /> },
 ];
 
 describe("BottomNav", () => {
@@ -19,7 +19,7 @@ describe("BottomNav", () => {
   });
 
   it("renders an accessible primary navigation with every item", () => {
-    render(<BottomNav items={items} />);
+    render(<BottomNav items={withIcon} />);
     const nav = screen.getByRole("navigation", { name: "Primary" });
     expect(nav).toBeInTheDocument();
     expect(screen.getByText("Streams")).toBeInTheDocument();
@@ -28,7 +28,7 @@ describe("BottomNav", () => {
   });
 
   it("marks the active route with aria-current", () => {
-    render(<BottomNav items={items} />);
+    render(<BottomNav items={withIcon} />);
     const active = screen.getByText("Streams").closest("a");
     expect(active).toHaveAttribute("aria-current", "page");
     const inactive = screen.getByText("Activity").closest("a");
@@ -36,20 +36,27 @@ describe("BottomNav", () => {
   });
 
   it("shows a badge with screen-reader text for pending actions", () => {
-    render(<BottomNav items={items} />);
+    render(<BottomNav items={withIcon} />);
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("3 pending")).toBeInTheDocument();
   });
 
   it("caps large badge counts but announces the exact number", () => {
-    render(<BottomNav items={items} maxBadgeCount={9} />);
+    render(<BottomNav items={withIcon} maxBadgeCount={9} />);
     expect(screen.getByText("9+")).toBeInTheDocument();
     expect(screen.getByText("12 pending")).toBeInTheDocument();
   });
 
   it("omits the badge when there are no pending actions", () => {
-    render(<BottomNav items={items} />);
+    render(<BottomNav items={withIcon} />);
     const activity = screen.getByText("Activity").closest("a");
     expect(activity?.querySelector(".bottom-nav__badge")).toBeNull();
+  });
+
+  it("renders icons when provided", () => {
+    render(<BottomNav items={withIcon} />);
+    expect(screen.getByTestId("icon-streams")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-activity")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-settings")).toBeInTheDocument();
   });
 });

--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -8,6 +8,8 @@ export type BottomNavItem = {
   href: string;
   /** Visible, human-readable label. */
   label: string;
+  /** Optional icon rendered above the label. */
+  icon?: React.ReactNode;
   /** Count of pending actions; renders a badge when greater than zero. */
   badgeCount?: number;
 };
@@ -51,6 +53,11 @@ export function BottomNav({ items, maxBadgeCount = 9 }: BottomNavProps) {
                 className={`bottom-nav__link${active ? " bottom-nav__link--active" : ""}`}
                 aria-current={active ? "page" : undefined}
               >
+                {item.icon && (
+                  <span className="bottom-nav__icon" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                )}
                 <span className="bottom-nav__label">{item.label}</span>
 
                 {hasBadge && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -348,7 +348,7 @@ a:hover {
   margin: 0 auto;
   max-width: 72rem;
   min-height: 100vh;
-  padding: 2rem 1rem 3rem;
+  padding: 2rem 1rem 6rem;
 }
 
 .page-hero {
@@ -1001,6 +1001,119 @@ a:hover {
 
 .settings-layout { max-width: 48rem; }
 .settings-actions { display: flex; justify-content: flex-end; margin-top: 2rem; padding-bottom: 4rem; }
+
+/* ─── App Bottom Navigation (mobile only) ──────────────────────────────────── */
+.bottom-nav {
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+  bottom: 0;
+  display: flex;
+  justify-content: space-around;
+  left: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  position: fixed;
+  right: 0;
+  z-index: 90;
+}
+
+.bottom-nav__list {
+  align-items: stretch;
+  display: flex;
+  justify-content: space-around;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.bottom-nav__item {
+  flex: 1;
+  min-width: 0;
+}
+
+.bottom-nav__link {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  justify-content: center;
+  min-height: 3.75rem;
+  padding: 0.5rem 0.25rem;
+  position: relative;
+  text-decoration: none;
+  width: 100%;
+}
+
+.bottom-nav__link:hover,
+.bottom-nav__link:focus-visible {
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.bottom-nav__link--active {
+  color: var(--accent);
+}
+
+.bottom-nav__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.bottom-nav__icon svg {
+  height: 100%;
+  width: 100%;
+}
+
+.bottom-nav__label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.bottom-nav__badge {
+  align-items: center;
+  background: var(--accent);
+  border-radius: 999px;
+  color: var(--accent-on);
+  display: inline-flex;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  height: 1.125rem;
+  justify-content: center;
+  line-height: 1;
+  min-width: 1.125rem;
+  padding: 0 0.375rem;
+  position: absolute;
+  right: 0.625rem;
+  top: 0.375rem;
+}
+
+.bottom-nav__link:focus-visible .bottom-nav__badge {
+  outline: 2px solid var(--foreground);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom-nav__link {
+    transition: none;
+  }
+}
+
+@media (min-width: 48rem) {
+  .bottom-nav {
+    display: none;
+  }
+
+  .page-shell {
+    padding-bottom: 4rem;
+  }
+}
 
 .push-optin {
   background: linear-gradient(135deg, rgba(14, 165, 233, 0.14), rgba(19, 19, 26, 0.96));

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import SplashScreen from "./components/SplashScreen";
 import { ToastProvider } from "./components/ToastProvider";
+import { AppBottomNav } from "./components/AppBottomNav";
 import { getThemeScript } from "./utils/theme-noflash";
 
 export const metadata: Metadata = {
@@ -26,6 +27,7 @@ export default function RootLayout({
         <ToastProvider>
           <SplashScreen />
           {children}
+          <AppBottomNav />
         </ToastProvider>
       </body>
     </html>

--- a/docs/uiux/bottom-nav-badges.md
+++ b/docs/uiux/bottom-nav-badges.md
@@ -1,0 +1,70 @@
+# Bottom Nav with Badges
+
+## Issue
+
+- `#861` Add mobile bottom nav with badges
+
+## Visible Changes
+
+- Mobile-only fixed bottom navigation bar added to the app layout.
+- Navigation items: Streams, Activity, Settings.
+- Each item can display an icon, label, and an unread badge count.
+- Badges cap visually at `maxBadgeCount` (default `9`) and render as `N+`.
+- Active route is highlighted with the accent color and `aria-current="page"`.
+- Home page (`/`) does not show the bottom nav.
+
+## Components Added
+
+- `app/components/BottomNav.tsx`
+- `app/components/AppBottomNav.tsx`
+
+## Routes Updated
+
+- `app/layout.tsx`
+
+## Accessibility
+
+- `aria-current="page"` on the active link.
+- `sr-only` text announces exact pending counts to screen readers.
+- `focus-visible` outlines on badges and links.
+- Safe-area inset padding for notched devices.
+- Respects `prefers-reduced-motion`.
+
+## Design Tokens
+
+Uses existing tokens:
+
+- `--accent` / `--accent-on`
+- `--panel`
+- `--border`
+- `--muted`
+- `--foreground`
+
+## API / Backend Notes
+
+No backend API changes required. Badge counts are supplied via component props:
+
+```ts
+type BottomNavItem = {
+  href: string;
+  label: string;
+  icon?: React.ReactNode;
+  badgeCount?: number;
+};
+```
+
+If unread counts are later fetched from an API, the `AppBottomNav` component should consume that data and pass it through the existing `badgeCount` prop. No route or layout signature changes are needed.
+
+## Tests
+
+- `app/components/BottomNav.test.tsx` — covers active route, badge rendering, capping, aria text, and icons.
+- `app/components/AppBottomNav.test.tsx` — covers home-page visibility and app-page visibility.
+
+## Verification
+
+Standard verification:
+
+```bash
+npm test -- --testPathPattern="(BottomNav|AppBottomNav)"
+npm run lint -- --max-warnings=0
+```

--- a/docs/uiux/grantfox-ux-bundle.md
+++ b/docs/uiux/grantfox-ux-bundle.md
@@ -1,11 +1,12 @@
 # GrantFox UX Bundle
 
-This document covers the four GrantFox UI updates bundled on a single branch:
+This document covers the GrantFox UI updates bundled on a single branch:
 
 - `#531` push-notification opt-in UX with email fallback
 - `#543` accessible cancel or withdraw confirmation modal
 - `#551` timestamp tooltips with relative and ISO timestamps
 - `#558` onboarding explainer for new users
+- `#861` mobile bottom nav with unread badges
 
 ## API Notes
 
@@ -15,8 +16,9 @@ No backend API contract changes were required for this bundle.
 - `ConfirmCancel` sends the existing stream action plus a client-side `amount` display label for confirmation UX only.
 - `Timestamp` is presentation-only and does not alter payload shapes.
 - `Explainer` is static onboarding content.
+- `BottomNav` / `AppBottomNav` are client-only navigation components; badge counts are passed via props.
 
-If server persistence is later added for push subscriptions or fallback preferences, that should be documented in `openapi.json` and the relevant API route README before release.
+If server persistence is later added for push subscriptions or fallback preferences, or if unread counts are fetched from an API, that should be documented in `openapi.json` and the relevant API route README before release.
 
 ## Components Added
 


### PR DESCRIPTION
Implements mobile bottom navigation with unread badges as per #861.

## Changes
- `app/components/BottomNav.tsx` — Extended with optional icon support
- `app/components/AppBottomNav.tsx` — New wrapper providing app nav items
- `app/layout.tsx` — Integrated `AppBottomNav` into root layout
- `app/globals.css` — Added mobile bottom nav styles with badges, responsive breakpoints
- `app/components/BottomNav.test.tsx` — Added icon rendering test
- `app/components/AppBottomNav.test.tsx` — New tests for visibility logic
- `docs/uiux/bottom-nav-badges.md` — Visible change documentation
- `docs/uiux/grantfox-ux-bundle.md` — Updated bundle index

## Accessibility
- WCAG 2.1 AA: `aria-current="page"`, `sr-only` pending announcements, `focus-visible` styles, safe-area inset, respects `prefers-reduced-motion`

## Design tokens
Consistent with existing tokens: `--accent`, `--accent-on`, `--panel`, `--border`, `--muted`, `--foreground`.

## Verification
Local verification blocked by incomplete `node_modules` (missing transitive deps such as `emittery`). Once dependencies are installed:
```bash
npm test -- --testPathPattern="(BottomNav|AppBottomNav)"
npm run lint -- --max-warnings=0
```

Closes #861