### PR TITLE
ci: WASM size budget

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,0 +1,61 @@
+name: WASM Size Budget
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "contracts/**"
+      - ".github/workflows/wasm-size.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "contracts/**"
+      - ".github/workflows/wasm-size.yml"
+
+jobs:
+  wasm-size-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry + build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build Contracts
+        working-directory: contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Check WASM Size
+        run: |
+          echo "Checking WASM size for contracts..."
+          MAX_SIZE=102400 # 100KB in bytes
+          FAILED=0
+          
+          for file in $(find ./contracts/target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm"); do
+            SIZE=$(stat -c%s "$file")
+            echo "File: $file - Size: $SIZE bytes"
+            
+            if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+              echo "❌ Error: $file exceeds the 100KB budget ($SIZE bytes > $MAX_SIZE bytes)"
+              FAILED=1
+            else
+              echo "✅ $file is within the budget"
+            fi
+          done
+          
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Resolves #954 

This PR introduces a CI safeguard for the GrantFox FWC26 campaign smart contracts to strictly enforce the maximum WebAssembly (WASM) binary size limit. If any compiled smart contract exceeds 100KB, the CI pipeline will automatically fail. 

### Changes Made

- **New Workflow**: Created `.github/workflows/wasm-size.yml`.
- **WASM Size Budget**: The workflow automatically triggers on pushes/PRs modifying `contracts/**`. It securely builds the smart contracts using `cargo build` targeting `wasm32-unknown-unknown` in release mode.
- **Budget Enforcement**: A strict assertion iterates over the compiled `.wasm` files. If any file's size evaluates to greater than `102400 bytes` (100KB), the pipeline exits with a clear error output, effectively preventing oversized contracts from being merged.
- **Caching**: Added cargo registry and artifact caching for optimal CI build speeds.

### Acceptance Criteria Met

- [x] Implementation matches the description (fails on WASM > 100KB).
- [x] Code adheres to repository style (clean CI step formatting).
- [x] Automatically triggers standard build mechanisms for accurate measurements.

### Testing

- [x] Verified workflow logic correctly targets `contracts/target/wasm32-unknown-unknown/release/*.wasm`.
- [x] Ensures math/evaluation for file sizes operates accurately in the bash script.

### CI Run Link