### PR TITLE
feat: input validation /api/auth/wallet

### DIFF
--- a/app/api/auth/wallet/route.test.ts
+++ b/app/api/auth/wallet/route.test.ts
@@ -11,7 +11,10 @@ jest.mock("next/server", () => ({
   },
 }));
 
-const VALID_ADDRESS = "GABC2345674567ABCDEFGHIJKLMNOPQRSTUVWXYZ2345674567ABCDEF";
+const VALID_ADDRESS = "GCLH2SNM5MTV4TGNNOADLYOZJYIFBXTIDVSNW4XP3LEI2UQV2MZ46OD7";
+// Right shape, bad strkey checksum
+const SHAPE_ONLY_ADDRESS = "GABC2345674567ABCDEFGHIJKLMNOPQRSTUVWXYZ2345674567ABCDEF";
+const VALID_CHALLENGE = "streampay_auth_1721800000000_abc123xyz";
 
 function makeGetRequest(params: Record<string, string> = {}) {
   const searchParams = new URLSearchParams(params);
@@ -48,6 +51,20 @@ function makePostRequest(
   } as unknown as import("next/server").NextRequest;
 }
 
+function validPostBody() {
+  return {
+    address: VALID_ADDRESS,
+    challenge: VALID_CHALLENGE,
+    signature: "validbase64sig==",
+  };
+}
+
+function detailFields(res: unknown): string[] {
+  return ((res as any).body.error.details as { field: string }[]).map(
+    (d) => d.field,
+  );
+}
+
 beforeEach(() => {
   resetRateLimitStore();
 });
@@ -61,76 +78,125 @@ describe("GET /api/auth/wallet", () => {
     expect(body.challenge).toMatch(/^streampay_auth_/);
   });
 
-  it("returns 400 when address is missing", async () => {
+  it("returns 422 VALIDATION_ERROR with details when address is missing", async () => {
     const res = await GET(makeGetRequest());
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
+    const body = (res as any).body;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(detailFields(res)).toEqual(["address"]);
+  });
+
+  it("returns 422 when address has the right shape but a bad checksum", async () => {
+    const res = await GET(makeGetRequest({ address: SHAPE_ONLY_ADDRESS }));
+    expect(res.status).toBe(422);
+    expect((res as any).body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("POST /api/auth/wallet validation", () => {
+  it("returns 422 with a detail per missing field on an empty body", async () => {
+    const res = await POST(makePostRequest({}, "csrf", "csrf"));
+    expect(res.status).toBe(422);
+    expect(detailFields(res).sort()).toEqual([
+      "address",
+      "challenge",
+      "signature",
+    ]);
+  });
+
+  it("returns 422 when fields have the wrong type", async () => {
+    const res = await POST(
+      makePostRequest(
+        { address: 5, challenge: true, signature: null },
+        "csrf",
+        "csrf",
+      ),
+    );
+    expect(res.status).toBe(422);
+    expect(detailFields(res).sort()).toEqual([
+      "address",
+      "challenge",
+      "signature",
+    ]);
+  });
+
+  it("returns 422 when the challenge does not match the issued format", async () => {
+    const res = await POST(
+      makePostRequest({ ...validPostBody(), challenge: "ch" }, "csrf", "csrf"),
+    );
+    expect(res.status).toBe(422);
+    expect(detailFields(res)).toEqual(["challenge"]);
+  });
+
+  it("returns 422 when signature is empty", async () => {
+    const res = await POST(
+      makePostRequest({ ...validPostBody(), signature: "" }, "csrf", "csrf"),
+    );
+    expect(res.status).toBe(422);
+    expect(detailFields(res)).toEqual(["signature"]);
+  });
+
+  it("returns 422 when signature exceeds the maximum length", async () => {
+    const res = await POST(
+      makePostRequest(
+        { ...validPostBody(), signature: "a".repeat(1025) },
+        "csrf",
+        "csrf",
+      ),
+    );
+    expect(res.status).toBe(422);
+    expect(detailFields(res)).toEqual(["signature"]);
+  });
+
+  it("returns 422 INVALID_JSON detail when the body is not valid JSON", async () => {
+    const res = await POST(makePostRequest("THROW"));
+    expect(res.status).toBe(422);
+    const body = (res as any).body;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details[0].code).toBe("INVALID_JSON");
+  });
+
+  it("ignores unknown extra fields when the known fields are valid", async () => {
+    const res = await POST(
+      makePostRequest(
+        { ...validPostBody(), extra: "ignored" },
+        "securecsrf123",
+        "securecsrf123",
+      ),
+    );
+    expect(res.status).toBe(200);
   });
 });
 
 describe("POST /api/auth/wallet", () => {
   it("returns 403 when csrf token is missing entirely", async () => {
-    const res = await POST(
-      makePostRequest({
-        address: VALID_ADDRESS,
-        challenge: "ch",
-        signature: "sig",
-      })
-    );
+    const res = await POST(makePostRequest(validPostBody()));
     expect(res.status).toBe(403);
   });
 
   it("returns 403 when csrf tokens are tampered/mismatched", async () => {
     const res = await POST(
       makePostRequest(
-        { address: VALID_ADDRESS, challenge: "ch", signature: "sig" },
+        validPostBody(),
         "valid_cookie_token",
-        "tampered_header_token"
-      )
+        "tampered_header_token",
+      ),
     );
     expect(res.status).toBe(403);
   });
 
   it("returns 200 with token for valid matching double-submit CSRF tokens", async () => {
     const res = await POST(
-      makePostRequest(
-        {
-          address: VALID_ADDRESS,
-          challenge: "streampay_auth_123_abc",
-          signature: "validbase64sig==",
-        },
-        "securecsrf123",
-        "securecsrf123"
-      )
+      makePostRequest(validPostBody(), "securecsrf123", "securecsrf123"),
     );
     expect(res.status).toBe(200);
     const body = (res as any).body;
     expect(typeof body.token).toBe("string");
   });
 
-  it("returns 401 when signature is empty but CSRF matches", async () => {
-    const res = await POST(
-      makePostRequest(
-        { address: VALID_ADDRESS, challenge: "ch", signature: "" },
-        "securecsrf123",
-        "securecsrf123"
-      )
-    );
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 500 canonical error when json() throws", async () => {
-    const res = await POST(makePostRequest("THROW"));
-    expect(res.status).toBe(500);
-  });
-
   it("returns 429 when rate limit is exceeded on POST (login)", async () => {
-    const validBody = {
-      address: VALID_ADDRESS,
-      challenge: "ch",
-      signature: "validbase64sig==",
-    };
     const req = () =>
-      makePostRequest(validBody, "securecsrf123", "securecsrf123");
+      makePostRequest(validPostBody(), "securecsrf123", "securecsrf123");
 
     // Exhaust the login limit (5/min)
     for (let i = 0; i < 5; i++) {

--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -2,6 +2,28 @@ import { NextResponse, NextRequest } from "next/server";
 import { errorResponse, ErrorCode } from "@/app/lib/errors/server";
 import { validateCsrfToken } from "@/app/lib/auth";
 import { checkIpRateLimit, rateLimitResponse } from "@/lib/rateLimitIp";
+import { getCorrelationContext, logger } from "@/app/lib/logger";
+import {
+  validateWalletChallengeQuery,
+  validateWalletVerifyBody,
+} from "@/app/lib/auth-wallet-validation";
+import type { ValidationError } from "@/app/lib/stream-validation";
+
+/** 422 envelope with per-field details, matching /api/streams. */
+function validationErrorResponse(logMessage: string, errors: ValidationError[]) {
+  logger.warn(logMessage, { errors });
+  return NextResponse.json(
+    {
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "One or more fields are invalid.",
+        details: errors,
+        request_id: getCorrelationContext()?.request_id,
+      },
+    },
+    { status: 422 },
+  );
+}
 
 /**
  * GET /api/auth/wallet
@@ -17,16 +39,18 @@ export async function GET(req: NextRequest) {
   try {
     const address = req.nextUrl.searchParams.get("address");
 
-    if (!address || !/^G[A-Z2-7]{55}$/.test(address)) {
-      return errorResponse(
-        ErrorCode.BAD_REQUEST,
-        "Query param 'address' must be a valid Stellar public key.",
-        400,
+    const validationErrors = validateWalletChallengeQuery({
+      address: address ?? undefined,
+    });
+    if (validationErrors.length > 0) {
+      return validationErrorResponse(
+        "Wallet challenge validation failed",
+        validationErrors,
       );
     }
 
     const challenge = `streampay_auth_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString(); 
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
 
     return NextResponse.json({ challenge, expires_at: expiresAt }, { status: 200 });
   } catch {
@@ -51,21 +75,32 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    // Allows manual throw simulation to pass directly into catch block
-    const body = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return validationErrorResponse("Wallet verify validation failed", [
+        {
+          field: "body",
+          code: "INVALID_JSON",
+          message: "Request body must be valid JSON.",
+        },
+      ]);
+    }
 
-    if (
-      !body ||
-      typeof body.address !== "string" ||
-      typeof body.challenge !== "string" ||
-      typeof body.signature !== "string"
-    ) {
-      return errorResponse(
-        ErrorCode.BAD_REQUEST,
-        "Request body must include 'address', 'challenge', and 'signature'.",
-        400,
+    const validationErrors = validateWalletVerifyBody(body);
+    if (validationErrors.length > 0) {
+      return validationErrorResponse(
+        "Wallet verify validation failed",
+        validationErrors,
       );
     }
+
+    const { address, signature } = body as {
+      address: string;
+      challenge: string;
+      signature: string;
+    };
 
     const csrfCookie = req.cookies.get("csrf-token")?.value ?? null;
     const csrfHeader = req.headers.get("x-csrf-token");
@@ -79,7 +114,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const isValid = body.signature.length > 0; 
+    const isValid = signature.length > 0;
 
     if (!isValid) {
       return errorResponse(
@@ -89,8 +124,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const token = `tok_${Buffer.from(body.address).toString("base64url").slice(0, 24)}`;
-    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); 
+    const token = `tok_${Buffer.from(address).toString("base64url").slice(0, 24)}`;
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
     return NextResponse.json({ token, expires_at: expiresAt }, { status: 200 });
   } catch {

--- a/app/lib/auth-wallet-validation.ts
+++ b/app/lib/auth-wallet-validation.ts
@@ -1,0 +1,81 @@
+/**
+ * Auth Wallet Validation Module
+ *
+ * Zod-validated request schemas for GET and POST /api/auth/wallet.
+ * Follows stream-validation.ts: validators return structured
+ * `ValidationError` arrays so the calling route can return
+ * 422 VALIDATION_ERROR with per-field details.
+ */
+
+import { z } from "zod";
+import { isValidStellarPublicKey } from "@/app/lib/wallet-link";
+import type { ValidationError } from "@/app/lib/stream-validation";
+
+/** Challenges are issued by GET /api/auth/wallet in exactly this shape. */
+export const CHALLENGE_PATTERN = /^streampay_auth_\d+_[a-z0-9]+$/;
+
+/** Upper bounds so oversized payloads never reach signature verification. */
+export const MAX_CHALLENGE_LENGTH = 128;
+export const MAX_SIGNATURE_LENGTH = 1024;
+
+/** Checksum-validated strkey, not just the G... shape. */
+const stellarAddress = z
+  .string()
+  .refine(isValidStellarPublicKey, {
+    message: "must be a valid Stellar public key.",
+  });
+
+export const walletChallengeQuerySchema = z.object({
+  address: stellarAddress,
+});
+
+export const walletVerifyBodySchema = z.object({
+  address: stellarAddress,
+  challenge: z
+    .string()
+    .max(
+      MAX_CHALLENGE_LENGTH,
+      `must be at most ${MAX_CHALLENGE_LENGTH} characters.`,
+    )
+    .regex(
+      CHALLENGE_PATTERN,
+      "must be a challenge issued by GET /api/auth/wallet.",
+    ),
+  signature: z
+    .string()
+    .min(1, "must not be empty.")
+    .max(
+      MAX_SIGNATURE_LENGTH,
+      `must be at most ${MAX_SIGNATURE_LENGTH} characters.`,
+    ),
+});
+
+function toValidationErrors(error: z.ZodError): ValidationError[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.join(".") || "body",
+    code: issue.code.toUpperCase(),
+    message: issue.message,
+  }));
+}
+
+/**
+ * Validates the query params for GET /api/auth/wallet.
+ *
+ * @returns An array of `ValidationError`. An empty array means success.
+ */
+export function validateWalletChallengeQuery(
+  query: unknown,
+): ValidationError[] {
+  const result = walletChallengeQuerySchema.safeParse(query);
+  return result.success ? [] : toValidationErrors(result.error);
+}
+
+/**
+ * Validates the request body for POST /api/auth/wallet.
+ *
+ * @returns An array of `ValidationError`. An empty array means success.
+ */
+export function validateWalletVerifyBody(body: unknown): ValidationError[] {
+  const result = walletVerifyBodySchema.safeParse(body);
+  return result.success ? [] : toValidationErrors(result.error);
+}

--- a/docs/api/auth-wallet.md
+++ b/docs/api/auth-wallet.md
@@ -1,0 +1,51 @@
+# Wallet Auth Input Validation
+
+`GET /api/auth/wallet` and `POST /api/auth/wallet` validate input at the
+boundary with Zod schemas (`app/lib/auth-wallet-validation.ts`) before any
+other processing.
+
+## GET /api/auth/wallet
+
+Issues a one-time challenge for wallet-based authentication.
+
+| Query param | Rules |
+| ----------- | ----- |
+| `address`   | Required. Stellar public key, checksum-validated (strkey), not just shape. |
+
+## POST /api/auth/wallet
+
+Verifies the signed challenge (double-submit CSRF protected) and issues a
+bearer token. CSRF and signature checks run only after the body passes
+validation.
+
+| Body field  | Rules |
+| ----------- | ----- |
+| `address`   | Required string. Checksum-valid Stellar public key. |
+| `challenge` | Required string. Must match the issued shape `streampay_auth_<timestamp>_<nonce>`, max 128 chars. |
+| `signature` | Required non-empty string, max 1024 chars. |
+
+Unknown body fields are ignored. A body that is not valid JSON is rejected
+with a `422` and an `INVALID_JSON` detail.
+
+## Validation failures
+
+Invalid input returns `422` with the standard envelope and per-field details,
+the same shape `/api/streams` uses:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "One or more fields are invalid.",
+    "details": [
+      { "field": "address", "code": "CUSTOM", "message": "must be a valid Stellar public key." }
+    ],
+    "request_id": "req_..."
+  }
+}
+```
+
+Breaking change note: these endpoints previously returned `400 BAD_REQUEST`
+for malformed input (and `500` for a non-JSON body); both now return `422`.
+
+Rate limits are unchanged, see [rate-limits.md](../rate-limits.md).


### PR DESCRIPTION
## What
Zod-validated schemas for both `/api/auth/wallet` handlers, validated at the boundary before CSRF or signature processing. The issue suggests `src/validators/`, but the repo has no `src/` tree; the module lives at `app/lib/auth-wallet-validation.ts` following the existing `stream-validation.ts` conventions (schemas plus validators returning `ValidationError[]`).

- `address` (GET query and POST body): checksum-validated strkey via the repo's `isValidStellarPublicKey`, replacing the shape-only regex, so a well-formed but corrupted key is rejected.
- `challenge`: must match the exact shape GET issues (`streampay_auth_<timestamp>_<nonce>`), max 128 chars.
- `signature`: non-empty, max 1024 chars, so oversized payloads never reach verification.
- Failures return the standard 422 `VALIDATION_ERROR` envelope with per-field `details` and correlation `request_id`, logged via `logger.warn`, matching `/api/streams`. A non-JSON body is now a 422 `INVALID_JSON` instead of a 500.

## Behavior change
Malformed input previously returned 400 `BAD_REQUEST` (non-JSON bodies 500); both are now 422, aligning these endpoints with the repo's validation standard. No frontend callers of the endpoint exist in the tree, so the blast radius is external clients only. Documented in `docs/api/auth-wallet.md`.

## Testing
15/15 jest tests pass on the route suite (extended from 8): per-field details for missing fields and wrong types, checksum-invalid address, bad challenge format, empty and oversized signatures, invalid JSON, unknown-fields-ignored, plus the original CSRF, happy-path, and both rate-limit cases updated to the stricter inputs. The old test fixture address actually fails a real checksum, so it now serves as the negative case. eslint clean on all changed files.

One note: jest reports "did not exit one second after the test run" from a pre-existing open handle; the suite itself passes in under a second (run with `--forceExit` or kill after the summary).

Closes #1106
