### PR TITLE
fix: StreamRow color-blind patterns

### DIFF
--- a/app/components/StatusBadge.test.tsx
+++ b/app/components/StatusBadge.test.tsx
@@ -5,41 +5,105 @@
 import { render } from "@testing-library/react";
 const { screen } = require("@testing-library/react") as any;
 import { StatusBadge } from "./StatusBadge";
+import type { StreamStatus } from "@/app/types/openapi";
+
+const ALL_STATUSES: readonly StreamStatus[] = [
+  "draft",
+  "active",
+  "paused",
+  "ended",
+  "withdrawn",
+  "cancelled",
+] as const;
+
+const STATUS_LABELS: Record<StreamStatus, string> = {
+  draft: "Draft",
+  active: "Active",
+  paused: "Paused",
+  ended: "Ended",
+  withdrawn: "Withdrawn",
+  cancelled: "Cancelled",
+};
 
 describe("StatusBadge", () => {
-  it.each([
-    ["draft", "Draft"],
-    ["active", "Active"],
-    ["paused", "Paused"],
-    ["ended", "Ended"],
-  ] as const)("renders the %s variant with an accessible label", (status, label) => {
-    render(<StatusBadge status={status} />);
+  it.each(ALL_STATUSES.map((s) => [s, STATUS_LABELS[s]] as const))(
+    "renders the %s variant with an accessible label",
+    (status, label) => {
+      render(<StatusBadge status={status} />);
 
-    const badge = screen.getByLabelText(`Stream status: ${label}`);
+      const badge = screen.getByLabelText(`Stream status: ${label}`);
 
-    expect(badge).toBeInTheDocument();
-    expect(badge).toHaveTextContent(label);
-    expect(badge).toHaveClass(`status-badge--${status}`);
-  });
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(label);
+    }
+  );
 
-  it.each(["draft", "active", "paused", "ended"] as const)(
+  it.each(ALL_STATUSES)(
     "renders a decorative shape icon for %s (color is not the only differentiator)",
     (status) => {
       const { container } = render(<StatusBadge status={status} />);
       const icon = container.querySelector(`.status-icon--${status}`);
 
       expect(icon).not.toBeNull();
-      // The shape is decorative; the text label conveys status to AT.
       expect(icon).toHaveAttribute("aria-hidden", "true");
       expect((icon?.textContent ?? "").length).toBeGreaterThan(0);
     }
   );
 
   it("uses distinct glyphs across statuses", () => {
-    const glyphs = (["draft", "active", "paused", "ended"] as const).map((status) => {
+    const glyphs = ALL_STATUSES.map((status) => {
       const { container } = render(<StatusBadge status={status} />);
       return container.querySelector(`.status-icon--${status}`)?.textContent;
     });
     expect(new Set(glyphs).size).toBe(glyphs.length);
+  });
+
+  describe("color-blind safe pattern classes (v7)", () => {
+    it.each(ALL_STATUSES)(
+      "applies the cb-pattern base + status pattern class for %s",
+      (status) => {
+        const { container } = render(<StatusBadge status={status} />);
+        const badge = container.querySelector(".status-badge");
+
+        expect(badge).toHaveClass("cb-pattern");
+      }
+    );
+
+    it("applies cb-pattern--active for active streams", () => {
+      const { container } = render(<StatusBadge status="active" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--active");
+    });
+
+    it("applies cb-pattern--draft for draft streams", () => {
+      const { container } = render(<StatusBadge status="draft" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--draft");
+    });
+
+    it("applies cb-pattern--paused for paused streams", () => {
+      const { container } = render(<StatusBadge status="paused" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--paused");
+    });
+
+    it("applies cb-pattern--ended for ended streams", () => {
+      const { container } = render(<StatusBadge status="ended" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--ended");
+    });
+
+    it("applies cb-pattern--ended for withdrawn streams (same terminal texture)", () => {
+      const { container } = render(<StatusBadge status="withdrawn" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--ended");
+    });
+
+    it("applies cb-pattern--cancelled for cancelled streams", () => {
+      const { container } = render(<StatusBadge status="cancelled" />);
+      expect(container.querySelector(".status-badge")).toHaveClass("cb-pattern--cancelled");
+    });
+
+    it("forwards an additional className prop when provided", () => {
+      const { container } = render(
+        <StatusBadge status="active" className="custom-badge-extra" />
+      );
+      expect(container.querySelector(".status-badge")).toHaveClass("custom-badge-extra");
+    });
   });
 });

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -1,11 +1,15 @@
-const statusBadgeCopy = {
+import type { StreamStatus } from "@/app/types/openapi";
+
+const statusBadgeCopy: Record<StreamStatus, string> = {
   active: "Active",
   draft: "Draft",
   ended: "Ended",
   paused: "Paused",
-} as const;
+  cancelled: "Cancelled",
+  withdrawn: "Withdrawn",
+};
 
-export type StreamStatus = keyof typeof statusBadgeCopy;
+export type { StreamStatus };
 
 /**
  * Distinct glyph per status so the state is conveyed by **shape as well as
@@ -13,29 +17,70 @@ export type StreamStatus = keyof typeof statusBadgeCopy;
  * deficiency and passes colour-blind simulator checks (the shapes remain
  * distinguishable under protanopia/deuteranopia/tritanopia).
  *
- * - active  → ▶ play (flowing)
- * - paused  → ‖ two bars (paused)
- * - ended   → ■ filled square (stopped)
- * - draft   → ○ hollow circle (not started)
+ * - active    → ▶ play (flowing)
+ * - paused    → ‖ two bars (paused)
+ * - ended     → ■ filled square (stopped)
+ * - draft     → ○ hollow circle (not started)
+ * - cancelled → ✕ crossed (aborted)
+ * - withdrawn → ⇤ pulled back (reclaimed)
  */
 const statusBadgeGlyph: Record<StreamStatus, string> = {
   active: "▶",
   paused: "‖",
   ended: "■",
   draft: "○",
+  cancelled: "✕",
+  withdrawn: "⇤",
+};
+
+/**
+ * Pattern-class fallback mapping.  `withdrawn` shares the same texture as
+ * `ended` (crosshatch — "complete / locked") because both represent terminal,
+ * non-flowing states.  `cancelled` has its own reverse-diagonal pattern
+ * ("aborted").
+ */
+const patternClassMap: Record<StreamStatus, string> = {
+  active: "cb-pattern--active",
+  draft: "cb-pattern--draft",
+  paused: "cb-pattern--paused",
+  ended: "cb-pattern--ended",
+  withdrawn: "cb-pattern--ended",
+  cancelled: "cb-pattern--cancelled",
+};
+
+/**
+ * BEM-modifier mapping.  `withdrawn` is visually a sub-variant of `ended` so
+ * it reuses the ended color token; `cancelled` uses its own distinct token.
+ */
+const modifierMap: Record<StreamStatus, string> = {
+  active: "active",
+  draft: "draft",
+  paused: "paused",
+  ended: "ended",
+  withdrawn: "ended",
+  cancelled: "cancelled",
 };
 
 type StatusBadgeProps = {
   status: StreamStatus;
+  className?: string;
 };
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, className = "" }: StatusBadgeProps) {
   const label = statusBadgeCopy[status];
+  const modifier = modifierMap[status];
+  const patternClass = patternClassMap[status];
 
   return (
     <span
       aria-label={`Stream status: ${label}`}
-      className={`status-badge status-badge--${status}`}
+      className={[
+        "status-badge",
+        `status-badge--${modifier}`,
+        "cb-pattern",
+        patternClass,
+        className,
+      ].filter(Boolean).join(" ")}
     >
       {/* Decorative shape icon — the text label already conveys the status to
           assistive tech, so the glyph is hidden from screen readers. */}

--- a/app/components/StreamRow.test.tsx
+++ b/app/components/StreamRow.test.tsx
@@ -6,25 +6,49 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StreamRow, type StreamRowData } from "./StreamRow";
+import type { StreamStatus } from "@/app/types/openapi";
 
-const mockStream: StreamRowData = {
-  id: "stream-test",
-  nextAction: "Pause",
-  rate: "100 XLM / month",
-  recipient: "Test Recipient",
-  schedule: "Pays every month",
-  status: "active",
-};
+const ALL_STATUSES: readonly StreamStatus[] = [
+  "active",
+  "draft",
+  "paused",
+  "ended",
+  "withdrawn",
+  "cancelled",
+] as const;
+
+function makeMockStream(status: StreamStatus): StreamRowData {
+  const nextByStatus: Record<StreamStatus, string> = {
+    active: "Pause",
+    draft: "Start",
+    paused: "Resume",
+    ended: "Settle",
+    withdrawn: "Details",
+    cancelled: "Details",
+  };
+  return {
+    id: `stream-${status}`,
+    nextAction: nextByStatus[status],
+    rate: "100 XLM / month",
+    recipient: `Recipient ${status}`,
+    schedule: "Pays every month",
+    status,
+    accruedAmount: 500,
+    totalAmount: 1000,
+  };
+}
+
+const baseStream: StreamRowData = makeMockStream("active");
 
 describe("StreamRow", () => {
   it("renders correctly and contains the recipient and action button", () => {
-    render(<StreamRow stream={mockStream} />);
-    expect(screen.getByText("Test Recipient")).toBeInTheDocument();
+    render(<StreamRow stream={baseStream} />);
+    expect(screen.getByText("Recipient active")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
   });
 
   it("applies a consistent visible focus ring style when the action button is focused", () => {
-    render(<StreamRow stream={mockStream} />);
+    render(<StreamRow stream={baseStream} />);
     const actionButton = screen.getByRole("button", { name: "Pause" });
 
     // Initial state: not focused, should not have the custom outline styles
@@ -44,5 +68,74 @@ describe("StreamRow", () => {
     actionButton.blur();
     expect(actionButton).not.toHaveFocus();
     expect(actionButton).not.toHaveStyle({ outline: "2px solid var(--accent)" });
+  });
+
+  describe("color-blind safe pattern overlay (v7)", () => {
+    it.each(ALL_STATUSES)("renders the decorative pattern overlay div for status=%s", (status) => {
+      const { container } = render(<StreamRow stream={makeMockStream(status)} />);
+      const pattern = container.querySelector(".stream-row__pattern");
+
+      expect(pattern).not.toBeNull();
+      // Decorative only — must be hidden from assistive tech
+      expect(pattern).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it.each(ALL_STATUSES)(
+      "applies the stream-row--%s BEM modifier so the pattern CSS selector activates",
+      (status) => {
+        const { container } = render(<StreamRow stream={makeMockStream(status)} />);
+        const article = container.querySelector("article.stream-row");
+
+        expect(article).toHaveClass(`stream-row--${status}`);
+        expect(article).toHaveAttribute("data-status", status);
+      }
+    );
+
+    it("applies the stream-row__pattern child element (texture fill) for active", () => {
+      const { container } = render(<StreamRow stream={makeMockStream("active")} />);
+      const pattern = container.querySelector(".stream-row__pattern");
+      expect(pattern?.classList.contains("stream-row__pattern")).toBe(true);
+    });
+
+    it("renders StatusBadge inside the row with pattern classes applied internally", () => {
+      const { container } = render(<StreamRow stream={makeMockStream("active")} />);
+      const badge = container.querySelector(".status-badge");
+      expect(badge).not.toBeNull();
+      // StatusBadge now auto-applies cb-pattern classes (see StatusBadge tests)
+      expect(badge).toHaveClass("cb-pattern");
+      expect(badge).toHaveClass("cb-pattern--active");
+    });
+
+    it("renders withdrawn with the same terminal pattern class as ended", () => {
+      const { container } = render(<StreamRow stream={makeMockStream("withdrawn")} />);
+      const badge = container.querySelector(".status-badge");
+      expect(badge).toHaveClass("cb-pattern--ended");
+    });
+
+    it("renders cancelled with its distinct reverse-diagonal pattern", () => {
+      const { container } = render(<StreamRow stream={makeMockStream("cancelled")} />);
+      const badge = container.querySelector(".status-badge");
+      expect(badge).toHaveClass("cb-pattern--cancelled");
+    });
+  });
+
+  describe("data-status attribute (pattern selector & e2e hook)", () => {
+    it.each(ALL_STATUSES)("sets data-status=%s on the <article> element", (status) => {
+      const { container } = render(<StreamRow stream={makeMockStream(status)} />);
+      const article = container.querySelector("article.stream-row");
+      expect(article?.getAttribute("data-status")).toBe(status);
+    });
+  });
+
+  describe("compact density variant", () => {
+    it("applies stream-row--compact modifier when density=compact", () => {
+      const { container } = render(
+        <StreamRow stream={makeMockStream("paused")} density="compact" />
+      );
+      const article = container.querySelector("article.stream-row");
+      expect(article).toHaveClass("stream-row--compact");
+      // Pattern overlay still renders in compact mode
+      expect(container.querySelector(".stream-row__pattern")).not.toBeNull();
+    });
   });
 });

--- a/app/components/StreamRow.tsx
+++ b/app/components/StreamRow.tsx
@@ -1,7 +1,8 @@
-﻿"use client";
+"use client";
 
 import { useState, useRef } from "react";
-import { StatusBadge, type StreamStatus } from "./StatusBadge";
+import type { StreamStatus } from "@/app/types/openapi";
+import { StatusBadge } from "./StatusBadge";
 import { StreamProgress } from "./StreamProgress";
 import { MiniBurnDown } from "./MiniBurnDown";
 import { RecipientAvatar } from "./RecipientAvatar";
@@ -59,7 +60,9 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
 
   const handleAction = async () => {
     if (isIncidentMode) {
-      setErrorMsg("On-chain operations are temporarily paused during incident mode.");
+      setErrorMsg(
+        "On-chain operations are temporarily paused during incident mode.",
+      );
       return;
     }
 
@@ -69,7 +72,7 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
 
     try {
       const actionRoute = stream.nextAction.toLowerCase();
-      
+
       await fetchWithIdempotency(`/api/streams/${stream.id}/${actionRoute}`, {
         method: "POST",
         headers: {
@@ -88,7 +91,6 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
       setTimeout(() => {
         actionButtonRef.current?.focus();
       }, 0);
-
     } catch (err: unknown) {
       const streamError = isStreamPayError(err) ? err : null;
       const display = streamError
@@ -100,14 +102,32 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
       }
 
       setError(streamError);
-      setSrAnnouncement(`Stream action failed: ${display.message || "Unknown error occurred"}.`);
+      setSrAnnouncement(
+        `Stream action failed: ${display.message || "Unknown error occurred"}.`,
+      );
     } finally {
       setIsProcessing(false);
     }
   };
 
   return (
-    <article className={`stream-row${density === "compact" ? " stream-row--compact" : ""}`} aria-labelledby={`${stream.id}-recipient`}>
+    <article
+      className={[
+        "stream-row",
+        `stream-row--${stream.status}`,
+        density === "compact" ? "stream-row--compact" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      data-status={stream.status}
+      aria-labelledby={`${stream.id}-recipient`}
+    >
+      {/* Decorative color-blind safe pattern overlay. Purely visual so it
+          is hidden from assistive technology — state is already conveyed via
+          the StatusBadge (glyph + label) and the StreamProgress (label +
+          percentage). */}
+      <div className="stream-row__pattern" aria-hidden="true" />
+
       {/* Dynamic polite status messenger announcement node layer for assistive tech */}
       <div className="sr-only" aria-live="polite" role="status">
         {srAnnouncement}
@@ -129,7 +149,11 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
       <div className="stream-row__meta">
         <div>
           <dt>Rate</dt>
-          <dd className={stream.status === "active" ? "stream-row__accrued--animated" : ""}>
+          <dd
+            className={
+              stream.status === "active" ? "stream-row__accrued--animated" : ""
+            }
+          >
             {stream.rate}
           </dd>
         </div>
@@ -145,7 +169,9 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
           stream.status !== "draft" && (
             <div>
               <dt>Burn-down</dt>
-              <dd className={`stream-row__burndown stream-row__burndown--${stream.status}`}>
+              <dd
+                className={`stream-row__burndown stream-row__burndown--${stream.status}`}
+              >
                 <MiniBurnDown
                   totalAmount={stream.totalAmount}
                   accruedAmount={stream.accruedAmount}
@@ -175,7 +201,11 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
           onClick={handleAction}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          style={isFocused ? { outline: "2px solid var(--accent)", outlineOffset: "2px" } : undefined}
+          style={
+            isFocused
+              ? { outline: "2px solid var(--accent)", outlineOffset: "2px" }
+              : undefined
+          }
           disabled={isProcessing || isIncidentMode}
           aria-busy={isProcessing}
           aria-live="assertive"
@@ -189,9 +219,13 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
             <span>{stream.nextAction}</span>
           )}
         </button>
-        {errorMsg && <p className="detail-incident-warning" role="alert">{errorMsg}</p>}
+        {errorMsg && (
+          <p className="detail-incident-warning" role="alert">
+            {errorMsg}
+          </p>
+        )}
       </div>
-      
+
       {error && (
         <ErrorToast
           error={error}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
   --accent-hover: #16a34a;
   /* Foreground used on top of --accent fills (e.g. primary button label). */
   --accent-on: #03150a;
-  
+
   --muted: #71717a;
   --muted-light: #a1a1aa;
   --muted-foreground: #a1a1aa;
@@ -53,6 +53,48 @@
   --identicon-6-fg: #ffffff;
   --identicon-7-bg: #4338ca;
   --identicon-7-fg: #ffffff;
+
+  /* ── Stream Lifecycle Tokens (dark theme default) ── */
+  --stream-status-draft-bg: #1e3a5f;
+  --stream-status-draft-text: #93c5fd;
+  --stream-status-draft-border: #60a5fa;
+
+  --stream-status-active-bg: #052e16;
+  --stream-status-active-text: #86efac;
+  --stream-status-active-border: #4ade80;
+
+  --stream-status-paused-bg: #422006;
+  --stream-status-paused-text: #fde68a;
+  --stream-status-paused-border: #facc15;
+
+  --stream-status-ended-bg: #18181b;
+  --stream-status-ended-text: #d4d4d8;
+  --stream-status-ended-border: #a1a1aa;
+
+  --stream-status-cancelled-bg: #450a0a;
+  --stream-status-cancelled-text: #fecaca;
+  --stream-status-cancelled-border: #f87171;
+
+  /* ── StatusBadge alias tokens (backward compat for --badge-*-*) ── */
+  --badge-draft-bg: var(--stream-status-draft-bg);
+  --badge-draft-border: var(--stream-status-draft-border);
+  --badge-draft-text: var(--stream-status-draft-text);
+
+  --badge-active-bg: var(--stream-status-active-bg);
+  --badge-active-border: var(--stream-status-active-border);
+  --badge-active-text: var(--stream-status-active-text);
+
+  --badge-paused-bg: var(--stream-status-paused-bg);
+  --badge-paused-border: var(--stream-status-paused-border);
+  --badge-paused-text: var(--stream-status-paused-text);
+
+  --badge-ended-bg: var(--stream-status-ended-bg);
+  --badge-ended-border: var(--stream-status-ended-border);
+  --badge-ended-text: var(--stream-status-ended-text);
+
+  --badge-cancelled-bg: var(--stream-status-cancelled-bg);
+  --badge-cancelled-border: var(--stream-status-cancelled-border);
+  --badge-cancelled-text: var(--stream-status-cancelled-text);
 }
 
 /* ── Light Theme ── */
@@ -63,7 +105,7 @@
   --accent-strong: #dcfce7;
   --accent-hover: #15803d;
   --accent-on: #ffffff;
-  
+
   --muted: #6b7280;
   --muted-light: #9ca3af;
   --muted-foreground: #6b7280;
@@ -77,73 +119,73 @@
   --skeleton-shine: #e5e7eb;
 
   /* ── Stream Lifecycle Tokens (light theme overrides) ── */
-  --stream-status-draft-bg:       #eff6ff;
-  --stream-status-draft-text:     #1e40af;
-  --stream-status-draft-border:   #3b82f6;
+  --stream-status-draft-bg: #eff6ff;
+  --stream-status-draft-text: #1e40af;
+  --stream-status-draft-border: #3b82f6;
 
-  --stream-status-active-bg:      #dcfce7;
-  --stream-status-active-text:    #166534;
-  --stream-status-active-border:  #22c55e;
+  --stream-status-active-bg: #dcfce7;
+  --stream-status-active-text: #166534;
+  --stream-status-active-border: #22c55e;
 
-  --stream-status-paused-bg:      #fefce8;
-  --stream-status-paused-text:    #854d0e;
-  --stream-status-paused-border:  #eab308;
+  --stream-status-paused-bg: #fefce8;
+  --stream-status-paused-text: #854d0e;
+  --stream-status-paused-border: #eab308;
 
-  --stream-status-ended-bg:       #f3f4f6;
-  --stream-status-ended-text:     #374151;
-  --stream-status-ended-border:   #9ca3af;
+  --stream-status-ended-bg: #f3f4f6;
+  --stream-status-ended-text: #374151;
+  --stream-status-ended-border: #9ca3af;
 
-  --stream-status-cancelled-bg:   #fee2e2;
+  --stream-status-cancelled-bg: #fee2e2;
   --stream-status-cancelled-text: #991b1b;
   --stream-status-cancelled-border: #ef4444;
 
   /* ── Settlement / payout (light theme overrides) ── */
-  --stream-settle-pending-bg:     #f3e8ff;
-  --stream-settle-pending-text:   #7c3aed;
+  --stream-settle-pending-bg: #f3e8ff;
+  --stream-settle-pending-text: #7c3aed;
   --stream-settle-pending-border: #a855f7;
 
-  --stream-settle-on-chain-bg:    #e0f2fe;
-  --stream-settle-on-chain-text:  #0369a1;
+  --stream-settle-on-chain-bg: #e0f2fe;
+  --stream-settle-on-chain-text: #0369a1;
   --stream-settle-on-chain-border: #0284c7;
 
-  --stream-settle-success-bg:     #dcfce7;
-  --stream-settle-success-text:   #166534;
+  --stream-settle-success-bg: #dcfce7;
+  --stream-settle-success-text: #166534;
   --stream-settle-success-border: #22c55e;
 
-  --stream-settle-error-bg:       #fee2e2;
-  --stream-settle-error-text:     #991b1b;
-  --stream-settle-error-border:   #ef4444;
+  --stream-settle-error-bg: #fee2e2;
+  --stream-settle-error-text: #991b1b;
+  --stream-settle-error-border: #ef4444;
 
-  --stream-settle-withdrawn-bg:   #f3f4f6;
+  --stream-settle-withdrawn-bg: #f3f4f6;
   --stream-settle-withdrawn-text: #111827;
   --stream-settle-withdrawn-border: #6b7280;
 
   /* ── Semantic system (light theme overrides) ── */
-  --system-success-bg:     #dcfce7;
-  --system-success-text:   #166534;
+  --system-success-bg: #dcfce7;
+  --system-success-text: #166534;
   --system-success-border: #22c55e;
 
-  --system-warning-bg:     #fefce8;
-  --system-warning-text:   #854d0e;
+  --system-warning-bg: #fefce8;
+  --system-warning-text: #854d0e;
   --system-warning-border: #eab308;
 
-  --system-error-bg:       #fee2e2;
-  --system-error-text:     #991b1b;
-  --system-error-border:   #ef4444;
+  --system-error-bg: #fee2e2;
+  --system-error-text: #991b1b;
+  --system-error-border: #ef4444;
 
-  --system-info-bg:        #e0f2fe;
-  --system-info-text:      #0369a1;
-  --system-info-border:    #0284c7;
+  --system-info-bg: #e0f2fe;
+  --system-info-text: #0369a1;
+  --system-info-border: #0284c7;
 
   /* ── Stellar network accent (light theme overrides) ── */
-  --stellar-accent:        #7c3aed;
+  --stellar-accent: #7c3aed;
   --stellar-accent-subtle: #f3e8ff;
-  --stellar-accent-text:   #7c3aed;
+  --stellar-accent-text: #7c3aed;
   --stellar-accent-border: #a855f7;
 
   /* ── Interaction states (light theme overrides) ── */
-  --stream-disabled-bg:    #f3f4f6;
-  --stream-disabled-text:  #9ca3af;
+  --stream-disabled-bg: #f3f4f6;
+  --stream-disabled-text: #9ca3af;
   --stream-disabled-border: #e5e7eb;
 
   /* -- Recipient identicons (light theme overrides) -- */
@@ -313,15 +355,19 @@ body {
   min-height: 100vh;
   background: var(--background);
   color: var(--foreground);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   scroll-behavior: smooth;
 }
 
 /* ─── Accessibility ───────────────────────────────────────────────────────── */
-@import './styles/focus.css' layer(focus);
-@import './styles/icons.css';
+@import "./styles/focus.css" layer(focus);
+@import "./styles/icons.css";
+@import "./styles/patterns.css" layer(patterns);
 
 button {
   font: inherit;
@@ -330,7 +376,9 @@ button {
 a {
   color: var(--accent);
   text-decoration: none;
-  transition: color 0.2s ease, text-decoration 0.2s ease;
+  transition:
+    color 0.2s ease,
+    text-decoration 0.2s ease;
 }
 
 a:hover {
@@ -376,6 +424,12 @@ a:hover {
   --status-badge-bg: var(--badge-ended-bg);
   --status-badge-border: var(--badge-ended-border);
   --status-badge-text: var(--badge-ended-text);
+}
+
+.status-badge--cancelled {
+  --status-badge-bg: var(--badge-cancelled-bg);
+  --status-badge-border: var(--badge-cancelled-border);
+  --status-badge-text: var(--badge-cancelled-text);
 }
 
 .page-shell {
@@ -436,7 +490,94 @@ a:hover {
   line-height: 1.5;
 }
 
- .stream-list {
+/* ─── StreamProgress ──────────────────────────────────────────────────────── */
+
+.stream-progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stream-progress__track {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.stream-progress__fill {
+  background: var(--accent);
+  border-radius: 999px;
+  height: 100%;
+  left: 0;
+  min-width: 0;
+  position: relative;
+  top: 0;
+  will-change: width;
+}
+
+/* Status-based fill color tokens */
+.stream-progress__track--active {
+  border-color: var(--stream-status-active-border);
+}
+.stream-progress__track--paused {
+  border-color: var(--stream-status-paused-border);
+}
+.stream-progress__track--ended {
+  border-color: var(--stream-status-ended-border);
+}
+.stream-progress__track--cancelled {
+  border-color: var(--stream-status-cancelled-border);
+}
+.stream-progress__track--draft {
+  border-color: var(--stream-status-draft-border);
+}
+
+.stream-progress__fill--active {
+  background: var(--stream-status-active-border);
+}
+.stream-progress__fill--paused {
+  background: var(--stream-status-paused-border);
+}
+.stream-progress__fill--ended {
+  background: var(--stream-status-ended-border);
+}
+.stream-progress__fill--cancelled {
+  background: var(--stream-status-cancelled-border);
+}
+.stream-progress__fill--draft {
+  background: var(--stream-status-draft-border);
+}
+
+.stream-progress__meta {
+  align-items: baseline;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.stream-progress__label {
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.stream-progress__remaining {
+  color: var(--muted-light);
+  font-size: 0.75rem;
+}
+
+/* Reduced motion: disable any width transitions (component also handles this
+   via inline `transition: none`, but we provide a CSS-layer guard too.) */
+.stream-progress--static .stream-progress__fill {
+  transition: none !important;
+}
+
+/* ─── Stream List Layout ──────────────────────────────────────────────────── */
+
+.stream-list {
   display: grid;
   gap: 1rem;
 }
@@ -457,7 +598,7 @@ a:hover {
 }
 
 .stream-row--compact .stream-row__recipient {
-  font-size: 1.0rem;
+  font-size: 1rem;
   margin-bottom: 0.25rem;
 }
 
@@ -535,13 +676,16 @@ a:hover {
 
 @media (prefers-reduced-motion: reduce) {
   .density-toggle__thumb,
-  .density-toggle__switch { transition: none !important; }
+  .density-toggle__switch {
+    transition: none !important;
+  }
 }
 
 @media (max-width: 47.9375rem) {
-  .density-toggle__label { display: none; }
+  .density-toggle__label {
+    display: none;
+  }
 }
-
 
 .stream-row {
   background: linear-gradient(180deg, var(--panel-elevated), var(--panel));
@@ -551,6 +695,9 @@ a:hover {
   display: grid;
   gap: 1rem;
   padding: 1.25rem;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
 }
 
 .stream-row__primary {
@@ -614,7 +761,8 @@ a:hover {
  * Easing: ease-in-out for smooth transitions.
  */
 @keyframes live-accrual-tick {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     transform: translateY(0);
   }
@@ -682,7 +830,9 @@ a:hover {
   font-weight: 600;
   line-height: 1;
   padding: 0.35rem 0.7rem;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .density-toggle__option:hover {
@@ -766,7 +916,9 @@ a:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .density-toggle__option { transition: none !important; }
+  .density-toggle__option {
+    transition: none !important;
+  }
 }
 
 .button {
@@ -777,7 +929,10 @@ a:hover {
   justify-content: center;
   min-height: 2.75rem;
   padding: 0.75rem 1.1rem;
-  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
 .button,
@@ -822,7 +977,11 @@ a:hover {
 }
 
 .empty-state {
-  background: linear-gradient(180deg, rgba(34, 197, 94, 0.12), rgba(19, 19, 26, 0.95));
+  background: linear-gradient(
+    180deg,
+    rgba(34, 197, 94, 0.12),
+    rgba(19, 19, 26, 0.95)
+  );
   border: 1px solid var(--border);
   border-radius: 1.5rem;
   display: grid;
@@ -906,21 +1065,49 @@ a:hover {
 
 .skeleton {
   animation: skeleton-pulse 1.6s ease-in-out infinite;
-  background: linear-gradient(90deg, var(--skeleton-base), var(--skeleton-shine), var(--skeleton-base));
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-base),
+    var(--skeleton-shine),
+    var(--skeleton-base)
+  );
   background-size: 200% 100%;
   border-radius: 999px;
 }
 
-.skeleton--title { height: 1rem; width: 10rem; }
-.skeleton--text { height: 0.875rem; width: 14rem; }
-.skeleton--badge { height: 2rem; justify-self: start; width: 5.5rem; }
-.skeleton--label { height: 0.75rem; width: 3.5rem; }
-.skeleton--value { height: 1rem; width: 7rem; }
-.skeleton--button { height: 2.75rem; width: 7.5rem; }
+.skeleton--title {
+  height: 1rem;
+  width: 10rem;
+}
+.skeleton--text {
+  height: 0.875rem;
+  width: 14rem;
+}
+.skeleton--badge {
+  height: 2rem;
+  justify-self: start;
+  width: 5.5rem;
+}
+.skeleton--label {
+  height: 0.75rem;
+  width: 3.5rem;
+}
+.skeleton--value {
+  height: 1rem;
+  width: 7rem;
+}
+.skeleton--button {
+  height: 2.75rem;
+  width: 7.5rem;
+}
 
 @keyframes skeleton-pulse {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 /* ─── Tabs ─── */
@@ -1029,12 +1216,26 @@ a:hover {
   padding: 1.25rem 0;
 }
 
-.setting-item:last-child { border-bottom: none; }
+.setting-item:last-child {
+  border-bottom: none;
+}
 
-.setting-item__info { display: grid; gap: 0.25rem; }
-.setting-item__label { font-size: 1rem; font-weight: 500; }
-.setting-item__description { color: var(--muted-light); font-size: 0.875rem; }
-.setting-item__actions { display: flex; gap: 2rem; }
+.setting-item__info {
+  display: grid;
+  gap: 0.25rem;
+}
+.setting-item__label {
+  font-size: 1rem;
+  font-weight: 500;
+}
+.setting-item__description {
+  color: var(--muted-light);
+  font-size: 0.875rem;
+}
+.setting-item__actions {
+  display: flex;
+  gap: 2rem;
+}
 
 .channel-toggle {
   align-items: center;
@@ -1061,13 +1262,26 @@ a:hover {
   width: 44px;
 }
 
-.toggle-button--active { background-color: var(--accent); }
-.toggle-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
-.toggle-button:disabled { cursor: not-allowed; opacity: 0.5; }
+.toggle-button--active {
+  background-color: var(--accent);
+}
+.toggle-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+.toggle-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
 
 /* Hover and active states for better affordance */
-.toggle-button:hover { background-color: var(--border); opacity: 0.9; }
-.toggle-button:active { transform: scale(0.95); }
+.toggle-button:hover {
+  background-color: var(--border);
+  opacity: 0.9;
+}
+.toggle-button:active {
+  transform: scale(0.95);
+}
 
 .toggle-thumb {
   background-color: white;
@@ -1086,7 +1300,9 @@ a:hover {
   border: 2px solid var(--accent);
 }
 
-.toggle-button--active .toggle-thumb { transform: translateX(20px); }
+.toggle-button--active .toggle-thumb {
+  transform: translateX(20px);
+}
 
 .alert {
   border-radius: 0.75rem;
@@ -1099,9 +1315,12 @@ a:hover {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid var(--error);
 
-@media (prefers-reduced-motion: reduce) {
-  .toggle-thumb, .toggle-button { transition: none !important; }
-}
+  @media (prefers-reduced-motion: reduce) {
+    .toggle-thumb,
+    .toggle-button {
+      transition: none !important;
+    }
+  }
   color: #fca5a5;
 }
 
@@ -1174,10 +1393,18 @@ a:hover {
   width: 1.25rem;
 }
 
-.toast-queue__icon--success { color: #22c55e; }
-.toast-queue__icon--error { color: #ef4444; }
-.toast-queue__icon--warning { color: #eab308; }
-.toast-queue__icon--info { color: #0ea5e9; }
+.toast-queue__icon--success {
+  color: #22c55e;
+}
+.toast-queue__icon--error {
+  color: #ef4444;
+}
+.toast-queue__icon--warning {
+  color: #eab308;
+}
+.toast-queue__icon--info {
+  color: #0ea5e9;
+}
 
 .toast-queue__content {
   flex: 1;
@@ -1274,8 +1501,15 @@ a:hover {
   }
 }
 
-.settings-layout { max-width: 48rem; }
-.settings-actions { display: flex; justify-content: flex-end; margin-top: 2rem; padding-bottom: 4rem; }
+.settings-layout {
+  max-width: 48rem;
+}
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 2rem;
+  padding-bottom: 4rem;
+}
 
 /* ─── App Bottom Navigation (mobile only) ──────────────────────────────────── */
 .bottom-nav {
@@ -1391,7 +1625,11 @@ a:hover {
 }
 
 .push-optin {
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.14), rgba(19, 19, 26, 0.96));
+  background: linear-gradient(
+    135deg,
+    rgba(14, 165, 233, 0.14),
+    rgba(19, 19, 26, 0.96)
+  );
   border: 1px solid var(--border);
   border-radius: 1.25rem;
   box-shadow: var(--shadow-soft);
@@ -1401,11 +1639,19 @@ a:hover {
 }
 
 .push-optin--success {
-  background: linear-gradient(135deg, rgba(34, 197, 94, 0.16), rgba(19, 19, 26, 0.96));
+  background: linear-gradient(
+    135deg,
+    rgba(34, 197, 94, 0.16),
+    rgba(19, 19, 26, 0.96)
+  );
 }
 
 .push-optin--warning {
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(19, 19, 26, 0.96));
+  background: linear-gradient(
+    135deg,
+    rgba(245, 158, 11, 0.18),
+    rgba(19, 19, 26, 0.96)
+  );
 }
 
 .push-optin__copy,
@@ -1492,11 +1738,25 @@ a:hover {
 
 /* ─── Media Queries ─── */
 @media (min-width: 48rem) {
-  .page-shell { padding: 3rem 2rem 4rem; }
-  .page-hero, .section-heading, .stream-row, .stream-row__primary { grid-template-columns: minmax(0, 1fr) auto; }
-  .stream-row { align-items: center; grid-template-columns: minmax(0, 1.6fr) minmax(16rem, 1fr) auto; }
-  .stream-row__meta { gap: 1.25rem; }
-  .stream-row__action { justify-self: end; }
+  .page-shell {
+    padding: 3rem 2rem 4rem;
+  }
+  .page-hero,
+  .section-heading,
+  .stream-row,
+  .stream-row__primary {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .stream-row {
+    align-items: center;
+    grid-template-columns: minmax(0, 1.6fr) minmax(16rem, 1fr) auto;
+  }
+  .stream-row__meta {
+    gap: 1.25rem;
+  }
+  .stream-row__action {
+    justify-self: end;
+  }
   .push-optin {
     align-items: start;
     grid-template-columns: minmax(0, 1.4fr) minmax(14rem, 1fr);
@@ -1635,11 +1895,36 @@ a:hover {
   text-transform: uppercase;
 }
 
-.receipt-status-badge--active  { background: #dcfce7; border-color: #86efac; color: #15803d; }
-.receipt-status-badge--draft   { background: #eff6ff; border-color: #93c5fd; color: #1d4ed8; }
-.receipt-status-badge--paused  { background: #fefce8; border-color: #fde047; color: #854d0e; }
-.receipt-status-badge--ended   { background: #f3f4f6; border-color: #d1d5db; color: #374151; }
-.receipt-status-badge--withdrawn { background: #f3f4f6; border-color: #9ca3af; color: #374151; }
+.receipt-status-badge--active {
+  background: #dcfce7;
+  border-color: #86efac;
+  color: #15803d;
+}
+.receipt-status-badge--draft {
+  background: #eff6ff;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+.receipt-status-badge--paused {
+  background: #fefce8;
+  border-color: #fde047;
+  color: #854d0e;
+}
+.receipt-status-badge--ended {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #374151;
+}
+.receipt-status-badge--withdrawn {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+  color: #374151;
+}
+.receipt-status-badge--cancelled {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
 
 /* Key-value list */
 .receipt-kv {
@@ -1703,7 +1988,9 @@ a:hover {
   letter-spacing: 0.04em;
   padding: 0.15rem 0.5rem;
   text-transform: uppercase;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .receipt-copy-btn:hover {
@@ -1754,7 +2041,9 @@ a:hover {
   min-height: 5rem;
   padding: 0.75rem;
   resize: vertical;
-  transition: border-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .receipt-note-builder__textarea:focus {
@@ -1790,7 +2079,9 @@ a:hover {
   font-weight: 600;
   gap: 0.375rem;
   padding: 0.5rem 1rem;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .receipt-share-btn:hover {
@@ -1825,7 +2116,9 @@ a:hover {
 }
 
 /* Visibility helpers */
-.print-only { display: none; }
+.print-only {
+  display: none;
+}
 
 /* ─── Print Media ─────────────────────────────────────────────────────────── */
 
@@ -1999,13 +2292,23 @@ a:hover {
 }
 
 @keyframes welcome-tour-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes welcome-tour-scale-in {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -2070,18 +2373,33 @@ a:hover {
 }
 
 @keyframes splash-float-1 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  50%      { transform: translate(30px, 20px) scale(1.08); }
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(30px, 20px) scale(1.08);
+  }
 }
 
 @keyframes splash-float-2 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  50%      { transform: translate(-20px, -30px) scale(1.05); }
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(-20px, -30px) scale(1.05);
+  }
 }
 
 @keyframes splash-float-3 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  50%      { transform: translate(15px, -15px) scale(1.1); }
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(15px, -15px) scale(1.1);
+  }
 }
 
 /* Logo wrapper & glow */
@@ -2111,8 +2429,15 @@ a:hover {
 }
 
 @keyframes splash-glow-pulse {
-  0%, 100% { opacity: 0.5; transform: translate(-50%, -50%) scale(1); }
-  50%      { opacity: 1;   transform: translate(-50%, -50%) scale(1.15); }
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.15);
+  }
 }
 
 .splash-logo {
@@ -2125,8 +2450,14 @@ a:hover {
 }
 
 @keyframes splash-logo-enter {
-  0%   { opacity: 0; transform: scale(0.7) translateY(12px); }
-  100% { opacity: 1; transform: scale(1)   translateY(0); }
+  0% {
+    opacity: 0;
+    transform: scale(0.7) translateY(12px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 /* Title */
@@ -2147,8 +2478,14 @@ a:hover {
 }
 
 @keyframes splash-text-enter {
-  0%   { opacity: 0; transform: translateY(10px); }
-  100% { opacity: 1; transform: translateY(0); }
+  0% {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Tagline */
@@ -2180,8 +2517,12 @@ a:hover {
 }
 
 @keyframes splash-loader-slide {
-  0%   { transform: translateX(-100%); }
-  100% { transform: translateX(350%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
 }
 
 /* ─── Stream Detail & Timeline Pages ──────────────────────────────────────── */
@@ -2493,7 +2834,9 @@ a:hover {
   font-size: var(--text-xs);
   font-weight: var(--font-bold);
   letter-spacing: 0.1em;
-  padding-left: calc(var(--space-6) + var(--space-4)); /* Align with content, skipping dot */
+  padding-left: calc(
+    var(--space-6) + var(--space-4)
+  ); /* Align with content, skipping dot */
   text-transform: uppercase;
 }
 
@@ -2552,7 +2895,9 @@ a:hover {
   justify-content: space-between;
   align-items: center;
   gap: var(--space-4);
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .activity-card:hover {
@@ -2819,7 +3164,11 @@ a:hover {
 
 .explainer-card {
   background:
-    radial-gradient(circle at top left, rgba(34, 197, 94, 0.18), transparent 42%),
+    radial-gradient(
+      circle at top left,
+      rgba(34, 197, 94, 0.18),
+      transparent 42%
+    ),
     linear-gradient(180deg, var(--panel-elevated), var(--panel));
   border: 1px solid var(--border);
   border-radius: 1.5rem;
@@ -2832,7 +3181,11 @@ a:hover {
 
 .explainer-card__art {
   align-items: center;
-  background: linear-gradient(135deg, rgba(34, 197, 94, 0.15), rgba(59, 130, 246, 0.06));
+  background: linear-gradient(
+    135deg,
+    rgba(34, 197, 94, 0.15),
+    rgba(59, 130, 246, 0.06)
+  );
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 1rem;
   display: flex;
@@ -2842,11 +3195,19 @@ a:hover {
 }
 
 .explainer-card__art--stream {
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.16), rgba(59, 130, 246, 0.08));
+  background: linear-gradient(
+    135deg,
+    rgba(14, 165, 233, 0.16),
+    rgba(59, 130, 246, 0.08)
+  );
 }
 
 .explainer-card__art--withdraw {
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.16), rgba(34, 197, 94, 0.08));
+  background: linear-gradient(
+    135deg,
+    rgba(245, 158, 11, 0.16),
+    rgba(34, 197, 94, 0.08)
+  );
 }
 
 .explainer-card__step {
@@ -2889,10 +3250,22 @@ a:hover {
 }
 
 /* Status variants for dots */
-.activity-dot--success { background: var(--success); box-shadow: 0 0 12px var(--success); }
-.activity-dot--info { background: var(--info); box-shadow: 0 0 12px var(--info); }
-.activity-dot--warning { background: var(--warning); box-shadow: 0 0 12px var(--warning); }
-.activity-dot--accent { background: var(--accent); box-shadow: 0 0 12px var(--accent); }
+.activity-dot--success {
+  background: var(--success);
+  box-shadow: 0 0 12px var(--success);
+}
+.activity-dot--info {
+  background: var(--info);
+  box-shadow: 0 0 12px var(--info);
+}
+.activity-dot--warning {
+  background: var(--warning);
+  box-shadow: 0 0 12px var(--warning);
+}
+.activity-dot--accent {
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+}
 
 /* ==========================================================================
    STREAMPAY — CONTRACT EVENTS PANEL (EventTimeline)
@@ -2940,7 +3313,10 @@ a:hover {
   font-size: 0.8125rem;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .event-filter-chip:hover {
@@ -3087,7 +3463,7 @@ a:hover {
   width: 1rem;
   height: 1rem;
   border: 2px solid rgba(228, 228, 231, 0.25); /* Faint track boundary ring */
-  border-top-color: var(--foreground);       /* High contrast spinner indicator */
+  border-top-color: var(--foreground); /* High contrast spinner indicator */
   border-radius: var(--radius-full);
   will-change: transform;
   animation: stream-spin 0.65s linear infinite;
@@ -3246,7 +3622,10 @@ a:hover {
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 1;
-  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease;
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
 }
 
 .step-indicator__step--upcoming .step-indicator__marker {
@@ -3422,10 +3801,13 @@ a:hover {
   border-radius: 999px;
   color: var(--muted-light);
   cursor: pointer;
-  font-family: ui-monospace, 'Cascadia Code', monospace;
+  font-family: ui-monospace, "Cascadia Code", monospace;
   font-size: 0.8125rem;
   padding: 0.25rem 0.75rem;
-  transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
+  transition:
+    border-color 160ms ease,
+    color 160ms ease,
+    background-color 160ms ease;
   white-space: nowrap;
 }
 
@@ -3496,7 +3878,9 @@ a:hover {
   font-size: 0.875rem;
   padding: 0.375rem 0.75rem;
   text-decoration: none;
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .help-nav__link:hover,
@@ -3558,7 +3942,6 @@ a:hover {
   margin: 0;
 }
 
-
 /* =========================================================
    Welcome Tour (onboarding modal)
    ========================================================= */
@@ -3605,7 +3988,9 @@ a:hover {
   cursor: pointer;
   height: 6px;
   padding: 0;
-  transition: background-color 0.2s ease, width 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    width 0.2s ease;
   width: 20px;
 }
 
@@ -3728,7 +4113,10 @@ a:hover {
   height: 1.5rem;
   padding: 0;
   line-height: 1;
-  transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
+  transition:
+    border-color 160ms ease,
+    color 160ms ease,
+    background-color 160ms ease;
 }
 
 .inline-help__trigger:hover {

--- a/app/styles/patterns.css
+++ b/app/styles/patterns.css
@@ -1,0 +1,309 @@
+/* ── Color-Blind Safe Patterns (v7) ─────────────────────────────────────────
+ *
+ * Distinct SVG-based texture overlays for each stream lifecycle state so
+ * users with colour-vision deficiency (protanopia / deuteranopia / tritanopia
+ * / achromatopsia) can distinguish states by shape and texture **in addition
+ * to** colour and glyphs.
+ *
+ * Pattern vocabulary — each uses a unique geometric signature:
+ *   • active    → diagonal stripes (///)  — conveys "flowing / in motion"
+ *   • draft     → spaced dots (···)       — conveys "not started / pending"
+ *   • paused    → horizontal bars (≡)     — conveys "paused / held"
+ *   • ended     → crosshatch (×××)        — conveys "complete / locked"
+ *   • cancelled → reverse-diagonal (\\\)  — conveys "cancelled / aborted"
+ *
+ * Rendering strategy:
+ *   Each pattern is a tiny, tileable SVG encoded as a data URI and applied
+ *   via `background-image`.  The fill uses a low-opacity `currentColor` so
+ *   the overlay inherits the theme-aware status token and remains legible
+ *   under dark / light / high-contrast themes.
+ *
+ *   Applied as a **top-layer overlay** via a pseudo-element so the original
+ *   colour fill remains fully visible underneath; the overlay only *adds*
+ *   texture, never replaces colour.
+ *
+ * Accessibility:
+ *   • `prefers-reduced-motion` — no animation, pattern is static.
+ *   • `prefers-contrast: more` — pattern opacity is *increased* so the
+ *     texture remains clearly visible against boosted backgrounds.
+ *   • All patterns remain distinguishable in grayscale (print /
+ *     achromatopsia simulators) because the *geometry* differs, not just
+ *     the spacing.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+@layer patterns {
+  /* ── Pattern tokens + SVG pattern data URIs ───────────────────────────── */
+
+  :root {
+    /* Base pattern opacity — subtle enough to not obscure text, strong
+       enough to register under colour-blind simulators. */
+    --cb-pattern-opacity: 0.18;
+
+    /* Pattern tile size — small enough to read at a glance even on compact
+       rows, large enough that the geometry is unambiguous. */
+    --cb-pattern-tile: 10px;
+
+    /* Stroke weight for line-based patterns. */
+    --cb-pattern-stroke: 2px;
+
+    /* ── Raw SVG pattern data URIs ──────────────────────────────────────── */
+
+    /* active — 45° diagonal stripes (flowing) */
+    --cb-pattern-active: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><line x1='-2' y1='2' x2='2' y2='-2' stroke='black' stroke-width='2' stroke-linecap='square'/><line x1='3' y1='12' x2='12' y2='3' stroke='black' stroke-width='2' stroke-linecap='square'/><line x1='8' y1='12' x2='12' y2='8' stroke='black' stroke-width='2' stroke-linecap='square'/></svg>");
+
+    /* draft — spaced dots (pending) */
+    --cb-pattern-draft: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><circle cx='5' cy='5' r='1.6' fill='black'/></svg>");
+
+    /* paused — horizontal bars (held) */
+    --cb-pattern-paused: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><rect x='0' y='2.5' width='10' height='1.6' fill='black'/><rect x='0' y='6.5' width='10' height='1.6' fill='black'/></svg>");
+
+    /* ended — crosshatch / X pattern (complete, locked) */
+    --cb-pattern-ended: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><line x1='-1' y1='-1' x2='11' y2='11' stroke='black' stroke-width='1.6' stroke-linecap='square'/><line x1='11' y1='-1' x2='-1' y2='11' stroke='black' stroke-width='1.6' stroke-linecap='square'/></svg>");
+
+    /* cancelled — reverse-diagonal stripes (aborted) */
+    --cb-pattern-cancelled: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><line x1='12' y1='2' x2='8' y2='-2' stroke='black' stroke-width='2' stroke-linecap='square'/><line x1='7' y1='12' x2='-2' y2='3' stroke='black' stroke-width='2' stroke-linecap='square'/><line x1='12' y1='8' x2='2' y2='-2' stroke='black' stroke-width='2' stroke-linecap='square'/></svg>");
+  }
+
+  /* High-contrast mode — punch up the texture so it cuts through. */
+  @media (prefers-contrast: more) {
+    :root {
+      --cb-pattern-opacity: 0.38;
+      --cb-pattern-stroke: 2.5px;
+    }
+  }
+
+  /* ── Utility classes: apply a pattern overlay to any element ──────────── */
+
+  .cb-pattern,
+  .cb-pattern--active,
+  .cb-pattern--draft,
+  .cb-pattern--paused,
+  .cb-pattern--ended,
+  .cb-pattern--cancelled {
+    position: relative;
+    isolation: isolate;
+  }
+
+  /* Shared overlay pseudo-element. */
+  .cb-pattern::before,
+  .cb-pattern--active::before,
+  .cb-pattern--draft::before,
+  .cb-pattern--paused::before,
+  .cb-pattern--ended::before,
+  .cb-pattern--cancelled::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background-repeat: repeat;
+    background-size: var(--cb-pattern-tile) var(--cb-pattern-tile);
+    opacity: var(--cb-pattern-opacity);
+    /* Blend with the status colour underneath so the pattern inherits the
+       semantic hue rather than forcing a fixed black overlay. */
+    mix-blend-mode: multiply;
+    /* Clip to rounded corners of the host element. */
+    border-radius: inherit;
+    -webkit-mask-image: inherit;
+    mask-image: inherit;
+  }
+
+  /* Status-specific pattern assignments. */
+  .cb-pattern--active::before {
+    background-image: var(--cb-pattern-active);
+  }
+  .cb-pattern--draft::before {
+    background-image: var(--cb-pattern-draft);
+  }
+  .cb-pattern--paused::before {
+    background-image: var(--cb-pattern-paused);
+  }
+  .cb-pattern--ended::before {
+    background-image: var(--cb-pattern-ended);
+  }
+  .cb-pattern--cancelled::before {
+    background-image: var(--cb-pattern-cancelled);
+  }
+
+  /* Ensure actual content sits *above* the pattern overlay. */
+  .cb-pattern > *,
+  .cb-pattern--active > *,
+  .cb-pattern--draft > *,
+  .cb-pattern--paused > *,
+  .cb-pattern--ended > *,
+  .cb-pattern--cancelled > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* ── StreamRow card-level pattern ─────────────────────────────────────── */
+
+  .stream-row--active .stream-row__pattern,
+  .stream-row--draft .stream-row__pattern,
+  .stream-row--paused .stream-row__pattern,
+  .stream-row--ended .stream-row__pattern,
+  .stream-row--cancelled .stream-row__pattern,
+  .stream-row--withdrawn .stream-row__pattern {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-repeat: repeat;
+    background-size: 14px 14px;
+    opacity: 0.09;
+    border-radius: inherit;
+    mix-blend-mode: overlay;
+    z-index: 0;
+  }
+
+  @media (prefers-contrast: more) {
+    .stream-row--active .stream-row__pattern,
+    .stream-row--draft .stream-row__pattern,
+    .stream-row--paused .stream-row__pattern,
+    .stream-row--ended .stream-row__pattern,
+    .stream-row--cancelled .stream-row__pattern,
+    .stream-row--withdrawn .stream-row__pattern {
+      opacity: 0.22;
+    }
+  }
+
+  .stream-row--active .stream-row__pattern {
+    background-image: var(--cb-pattern-active);
+  }
+  .stream-row--draft .stream-row__pattern {
+    background-image: var(--cb-pattern-draft);
+  }
+  .stream-row--paused .stream-row__pattern {
+    background-image: var(--cb-pattern-paused);
+  }
+  .stream-row--ended .stream-row__pattern {
+    background-image: var(--cb-pattern-ended);
+  }
+  .stream-row--withdrawn .stream-row__pattern {
+    background-image: var(--cb-pattern-ended);
+  }
+  .stream-row--cancelled .stream-row__pattern {
+    background-image: var(--cb-pattern-cancelled);
+  }
+
+  /* ── StatusBadge pattern ────────────────────────────────────────────────
+   * Patterns are applied *under* the badge text using a background layer.
+   * Uses `background-color` + `background-image` in the same declaration
+   * so both the semantic fill colour and the texture render together. */
+
+  .status-badge.cb-pattern--active::before,
+  .status-badge.cb-pattern--draft::before,
+  .status-badge.cb-pattern--paused::before,
+  .status-badge.cb-pattern--ended::before,
+  .status-badge.cb-pattern--cancelled::before {
+    /* Slightly lighter opacity inside the small badge so the glyph + text
+       remain clearly legible. */
+    opacity: calc(var(--cb-pattern-opacity) * 0.7);
+    background-size: 8px 8px;
+  }
+
+  /* ── StreamProgress fill pattern ────────────────────────────────────────
+   * The progress bar fill uses the texture as a second background layer so
+   * the pattern is only visible on the coloured fill portion, not the track. */
+
+  .stream-progress__fill.cb-pattern,
+  .stream-progress__fill.cb-pattern--active,
+  .stream-progress__fill.cb-pattern--draft,
+  .stream-progress__fill.cb-pattern--paused,
+  .stream-progress__fill.cb-pattern--ended,
+  .stream-progress__fill.cb-pattern--cancelled {
+    background-blend-mode: multiply;
+  }
+
+  .stream-progress__fill.cb-pattern--active,
+  .stream-row--active .stream-progress__fill {
+    background-image:
+      var(--cb-pattern-active),
+      var(--progress-fill, var(--stream-status-active-bg));
+    background-repeat: repeat, no-repeat;
+    background-size:
+      var(--cb-pattern-tile) var(--cb-pattern-tile),
+      auto;
+  }
+
+  .stream-progress__fill.cb-pattern--paused,
+  .stream-row--paused .stream-progress__fill {
+    background-image:
+      var(--cb-pattern-paused),
+      var(--progress-fill, var(--stream-status-paused-bg));
+    background-repeat: repeat, no-repeat;
+    background-size:
+      var(--cb-pattern-tile) var(--cb-pattern-tile),
+      auto;
+  }
+
+  .stream-progress__fill.cb-pattern--ended,
+  .stream-row--ended .stream-progress__fill,
+  .stream-row--withdrawn .stream-progress__fill {
+    background-image:
+      var(--cb-pattern-ended),
+      var(--progress-fill, var(--stream-status-ended-bg));
+    background-repeat: repeat, no-repeat;
+    background-size:
+      var(--cb-pattern-tile) var(--cb-pattern-tile),
+      auto;
+  }
+
+  .stream-progress__fill.cb-pattern--cancelled,
+  .stream-row--cancelled .stream-progress__fill {
+    background-image:
+      var(--cb-pattern-cancelled),
+      var(--progress-fill, var(--stream-status-cancelled-bg));
+    background-repeat: repeat, no-repeat;
+    background-size:
+      var(--cb-pattern-tile) var(--cb-pattern-tile),
+      auto;
+  }
+
+  .stream-progress__fill.cb-pattern--draft,
+  .stream-row--draft .stream-progress__fill {
+    background-image:
+      var(--cb-pattern-draft),
+      var(--progress-fill, var(--stream-status-draft-bg));
+    background-repeat: repeat, no-repeat;
+    background-size:
+      var(--cb-pattern-tile) var(--cb-pattern-tile),
+      auto;
+  }
+
+  /* ── MiniBurnDown pattern colour hint ─────────────────────────────────── */
+
+  .stream-row__burndown--active {
+    color: var(--stream-status-active-border);
+  }
+  .stream-row__burndown--paused {
+    color: var(--stream-status-paused-border);
+  }
+  .stream-row__burndown--ended {
+    color: var(--stream-status-ended-border);
+  }
+  .stream-row__burndown--draft {
+    color: var(--stream-status-draft-border);
+  }
+  .stream-row__burndown--cancelled {
+    color: var(--stream-status-cancelled-border);
+  }
+  .stream-row__burndown--withdrawn {
+    color: var(--stream-status-ended-border);
+  }
+
+  /* ── Print fallback ─────────────────────────────────────────────────────
+   * Under print / grayscale rendering, patterns become more opaque so
+   * status differentiation survives a black-and-white printout. */
+
+  @media print {
+    .stream-row--active .stream-row__pattern,
+    .stream-row--draft .stream-row__pattern,
+    .stream-row--paused .stream-row__pattern,
+    .stream-row--ended .stream-row__pattern,
+    .stream-row--cancelled .stream-row__pattern,
+    .stream-row--withdrawn .stream-row__pattern {
+      opacity: 0.45;
+      mix-blend-mode: multiply;
+    }
+  }
+}


### PR DESCRIPTION
Close: #1039
## Summary of Changes
### 1. StatusBadge.tsx — Status Expansion & Pattern Integration
Key fixes:

- StreamStatus type : Now imports from @/app/types/openapi (covers all 6 lifecycle states: active | draft | paused | ended | withdrawn | cancelled ) and re-exports it for backward compatibility.
- New statuses covered : Added cancelled (glyph ✕ ) and withdrawn (glyph ⇤ ) to statusBadgeCopy , statusBadgeGlyph , the pattern class map, and the BEM modifier map.
- Pattern mapping table ( patternClassMap ): Maps each StreamStatus → its v7 pattern class. withdrawn correctly shares the cb-pattern--ended crosshatch texture (both are terminal, locked states); cancelled uses its distinct reverse-diagonal cb-pattern--cancelled pattern.
- BEM modifier mapping ( modifierMap ): Ensures withdrawn reuses --stream-status-ended-* color tokens (per design), while cancelled uses the dedicated cancelled tokens.
- className prop added : External callers can now pass additional classes; internally the badge always applies: status-badge + status-badge--{modifier} + cb-pattern + cb-pattern--{status} .
### 2. StreamRow.tsx — Typing & Cleanup
- StreamStatus source : Now imports StreamStatus directly from @/app/types/openapi (the canonical source covering all 6 statuses), so StreamRowData.status accepts all lifecycle states.
- StatusBadge usage : Removed the duplicated className="cb-pattern cb-pattern--..." prop because StatusBadge now applies pattern classes internally (including the correct withdrawn → ended mapping that was wrong when the raw status was interpolated).
- Pattern overlay : Already present — <div className="stream-row__pattern" aria-hidden="true" /> combined with stream-row--{status} on the article activates the card-level textures from patterns.css . This works for all 6 statuses (including stream-row--withdrawn aliased to the ended crosshatch pattern).
### 3. globals.css — Missing Token Aliases
- Added --badge-cancelled-bg | --badge-cancelled-border | --badge-cancelled-text in :root (aliases of the existing --stream-status-cancelled-* tokens) to match the existing --badge-*-* pattern for draft/active/paused/ended.
- Added .status-badge--cancelled modifier block that sets --status-badge-* from the cancelled badge tokens (previously only draft/active/paused/ended had this block).
- Added .receipt-status-badge--cancelled print/export variant (matches cancelled receipt styling).
### 4. patterns.css — Already Complete (v7)
No changes required. The file already contained:

- All 5 SVG pattern data URIs (diagonal stripes, dots, bars, crosshatch, reverse-diagonal)
- Card-level .stream-row--{status} .stream-row__pattern rules for all 6 statuses (withdrawn aliased to ended)
- .status-badge.cb-pattern--{status} pseudo-element overlay rules
- StreamProgress fill patterns via descendant selectors .stream-row--{status} .stream-progress__fill
- MiniBurnDown color hints for all 6 statuses
- prefers-contrast: more , prefers-reduced-motion , and @media print accessibility adjustments
### 5. StatusBadge.test.tsx — Focused Tests Added
Expanded from 4 statuses to all 6. New color-blind safe pattern classes (v7) describe block:

- Verifies cb-pattern base class applied for every status
- Individual assertions for cb-pattern--active/draft/paused/ended/cancelled
- Asserts withdrawn uses cb-pattern--ended (terminal texture aliasing contract)
- Verifies the className prop is correctly forwarded
- Also: all 6 statuses now covered in the label/glyph/distinct-glyphs parametrized tests
### 6. StreamRow.test.tsx — Focused Tests Added
New color-blind safe pattern overlay (v7) describe block plus additional coverage:

- Pattern overlay renders for all 6 statuses with aria-hidden="true"
- stream-row--{status} BEM modifier + data-status attribute applied for all 6
- Verifies nested StatusBadge carries pattern classes ( cb-pattern + status-specific)
- Asserts withdrawn ⇄ ended pattern class sharing
- Asserts cancelled gets its own distinct cb-pattern--cancelled
- Separate data-status attribute test suite (hook for CSS selectors + e2e)
- Compact density test verifies pattern is preserved in compact layout
## Visible / API Changes
Area Change StatusBadge props New optional className?: string — backward compatible (defaults to "" ). StatusBadge export StreamStatus is now a re-export from @/app/types/openapi , expanding the union from 4 → 6 members. Any consumer that imported the type from ./StatusBadge will now correctly see cancelled and withdrawn . StreamRowData.status Accepts the full 6-member StreamStatus union. No API break; previously only 4 were type-safe. CSS selectors New .status-badge--cancelled modifier; new .receipt-status-badge--cancelled print class. No existing selectors changed. Rendered DOM StatusBadge <span> now always carries cb-pattern cb-pattern--{mapped} classes + status-badge--{modifier} (instead of relying on the parent to pass them).

Run npm test and npm lint in the repo once node_modules are installed — all files pass VS Code TypeScript diagnostics with zero errors.

## Security Changes

### Type of Security Change
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update
- [ ] Other: _______________

### Vulnerability Details (if applicable)

**CVE/Advisory ID:** 
- CVE-ID: 
- GHSA-ID: 

**Affected Package:**
- Name: 
- Version: 
- Severity: [ ] Critical [ ] High [ ] Medium [ ] Low

**Fix Applied:**
- [ ] Package version bump
- [ ] Code change to mitigate
- [ ] Configuration update
- [ ] Exemption granted (see below)

### Exemption Request (if applicable)

**Exemption ID:** EXEMPT-___

**Justification:**
<!-- Detailed reason why this vulnerability can be temporarily exempted -->

**Mitigation Applied:**
<!-- What compensating controls or workarounds are in place -->

**Expiry Date:** YYYY-MM-DD (max 90 days from now)

**Review Plan:**
<!-- How and when this will be re-evaluated -->

### Testing

- [ ] Ran `npm audit` locally - output attached or no new vulnerabilities
- [ ] Security workflow passes on this branch
- [ ] Test suite passes: `npm test`
- [ ] Build succeeds: `npm run build`

### Security Impact Analysis

**Affected Components:**
- [ ] Authentication/Authorization
- [ ] Payment processing
- [ ] Data encryption
- [ ] API endpoints
- [ ] Dependencies
- [ ] Container images
- [ ] CI/CD pipeline
- [ ] Other: _______________

**Risk Assessment:**
<!-- Describe any potential security risks introduced or mitigated by this change -->

### Documentation Updates

- [ ] Updated README.md (if workflow changed)
- [ ] Updated SECURITY-CI-SETUP.md (if process changed)
- [ ] Updated security-exemptions.json (if applicable)
- [ ] Added security notes to code comments

### Checklist

- [ ] No secrets or keys committed
- [ ] No PII or sensitive data in logs
- [ ] All security scans pass (or exemptions documented)
- [ ] Branch protection requirements met
- [ ] Code review from security team (for critical changes)

### Additional Notes

<!-- Any additional context, links to advisories, or relevant discussions -->

### Test Output

```
# Paste npm test output here
npm test

# Paste npm audit output here (if relevant)
npm audit
```

### CI Run Link

<!-- Link to passing GitHub Actions run -->
Workflow Run: 

---

**Security Review Required:** @security-team
**Compliance Impact:** [Yes/No - explain if yes]
