### PR TITLE
fix: StreamProgress focus

### DIFF
--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -58,3 +58,29 @@ describe("StreamProgress reduced-motion fallback", () => {
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "25");
   });
 });
+
+describe("StreamProgress keyboard focus", () => {
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it("is reachable via keyboard tab order", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" accruedAmount={50} totalAmount={100} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("receives real DOM focus and carries the shared focus-visible class hook", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" accruedAmount={50} totalAmount={100} />);
+
+    const bar = screen.getByRole("progressbar");
+    bar.focus();
+
+    expect(bar).toHaveFocus();
+    expect(bar).toHaveClass("stream-progress__track");
+  });
+});

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -16,6 +16,10 @@
  *   do not just announce a raw percentage.
  * - State is NOT conveyed by color alone — the percentage label is always
  *   visible alongside the bar.
+ * - The track is keyboard-focusable (tabIndex 0) so keyboard-only users can
+ *   reach it in tab order and hear its current value; a visible focus-visible
+ *   outline (see `app/styles/focus.css`) marks it while focused via keyboard,
+ *   and stays hidden for mouse/touch interaction.
  *
  * ## Amounts
  * Accepts raw i128-compatible bigint or number values. No decimal conversion
@@ -190,6 +194,7 @@ export function StreamProgress({
       {/* Track */}
       <div
         role="progressbar"
+        tabIndex={0}
         aria-valuenow={Math.round(percent)}
         aria-valuemin={0}
         aria-valuemax={100}

--- a/app/styles/focus.css
+++ b/app/styles/focus.css
@@ -10,7 +10,8 @@
     summary,
     [role="button"],
     [tabindex]:not([tabindex="-1"]),
-    .card--clickable
+    .card--clickable,
+    .stream-progress__track
   ):focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
@@ -27,7 +28,8 @@
     summary,
     [role="button"],
     [tabindex]:not([tabindex="-1"]),
-    .card--clickable
+    .card--clickable,
+    .stream-progress__track
   ):focus:not(:focus-visible) {
     outline: none;
     box-shadow: none;

--- a/app/styles/focus.css.test.tsx
+++ b/app/styles/focus.css.test.tsx
@@ -2,24 +2,29 @@
  * @jest-environment jsdom
  */
 
-import "./focus.css";
+import fs from "fs";
+import path from "path";
+
+// Jest maps CSS imports to an empty mock module (next/jest's styleMock), so
+// `import "./focus.css"` never actually populates `document.styleSheets` in
+// this environment. Read the source file directly instead — it's the only
+// way to assert on the real rule text.
+const styleText = fs.readFileSync(path.join(__dirname, "focus.css"), "utf8");
 
 describe("shared focus-visible layer", () => {
   it("declares a keyboard-visible focus ring for interactive elements", () => {
-    const styleText = Array.from(document.styleSheets)
-      .map((sheet) => {
-        try {
-          return Array.from(sheet.cssRules)
-            .map((rule) => rule.cssText)
-            .join("\n");
-        } catch {
-          return "";
-        }
-      })
-      .join("\n");
-
     expect(styleText).toContain(":focus-visible");
     expect(styleText).toContain("outline: 2px solid var(--accent);");
     expect(styleText).toContain("box-shadow: 0 0 0 2px var(--background);");
+  });
+
+  it("includes the StreamProgress track so keyboard focus gets a visible outline", () => {
+    expect(styleText).toContain(".stream-progress__track");
+  });
+
+  it("hides the outline again for mouse/touch focus on the StreamProgress track", () => {
+    const suppressionRule = styleText.split(":focus-visible {")[1] ?? "";
+    expect(suppressionRule).toContain(".stream-progress__track");
+    expect(styleText).toContain(":focus:not(:focus-visible)");
   });
 });

--- a/docs/streamprogress-focus-accessibility.md
+++ b/docs/streamprogress-focus-accessibility.md
@@ -1,0 +1,44 @@
+# StreamProgress — Keyboard Focus Accessibility
+
+## Overview
+`StreamProgress` (`app/components/StreamProgress.tsx`) renders the burn-down
+progress bar for a payment stream. Previously the `role="progressbar"` track
+had no `tabIndex`, so keyboard-only users could never reach it and it never
+received a visible focus indicator.
+
+## Change
+- The track now sets `tabIndex={0}`, placing it in the natural tab order
+  alongside the rest of the stream row.
+- `app/styles/focus.css` — the shared `focus-visible` layer used across the
+  app — now includes `.stream-progress__track` in its selector list, so the
+  track gets the same 2px accent-colored outline (with a background-safe
+  `box-shadow` offset) as every other interactive element when focused via
+  keyboard, and no outline at all for mouse/touch interaction
+  (`:focus:not(:focus-visible)`).
+
+No new CSS values were introduced — the fix reuses the existing
+`--accent` / `--background` design tokens, so it is automatically correct
+across the app's light, dark, and high-contrast themes.
+
+## Accessibility (WCAG 2.1 AA)
+- **2.4.7 Focus Visible**: the progress track now shows a visible focus
+  indicator when reached via keyboard.
+- **2.1.1 Keyboard**: the track is reachable via `Tab`/`Shift+Tab`.
+- Focusing the track surfaces `aria-valuetext` (e.g. "42% accrued") to
+  screen readers, giving keyboard/AT users a way to query the current
+  progress value without a mouse.
+- Color is still not the only signal — the visible `%` label next to the
+  bar is unchanged.
+
+## Testing
+- `app/components/StreamProgress.test.tsx` — asserts the track has
+  `tabIndex="0"` and that it accepts real DOM focus.
+- `app/styles/focus.css.test.tsx` — asserts `.stream-progress__track` is
+  present in the shared focus-visible layer.
+
+## Manual verification
+1. Tab through a page containing a `StreamRow`/`StreamProgress` (e.g. the
+   streams list) using only the keyboard.
+2. Confirm the progress bar receives a visible accent-colored outline when
+   focused via `Tab`, and no outline when clicked with a mouse.
+3. Confirm the outline is visible in both light and dark themes.


### PR DESCRIPTION
## Summary
- StreamProgress's `role="progressbar"` track previously had no `tabIndex`, so keyboard-only users could never reach it and it never received a visible focus indicator.
- The track is now keyboard-focusable (`tabIndex={0}`), placing it in the natural tab order alongside the rest of the stream row and surfacing `aria-valuetext` to AT/keyboard users on focus.
- The shared `focus-visible` layer (`app/styles/focus.css`) now includes `.stream-progress__track`, so it gets the same 2px accent-colored outline (with background-safe `box-shadow` offset) as every other interactive element on keyboard focus, and no outline for mouse/touch (`:focus:not(:focus-visible)`).
- No new design tokens were introduced — reuses the existing `--accent` / `--background` tokens, so it's correct across light, dark, and high-contrast themes.

Closes #1056

## Test plan
- [x] `app/components/StreamProgress.test.tsx` — track has `tabIndex="0"` and accepts real DOM focus.
- [x] `app/styles/focus.css.test.tsx` — asserts `.stream-progress__track` is present in both the focus-visible outline rule and the mouse/touch suppression rule (rewritten to read the CSS source directly via `fs`, since Jest mocks CSS imports to an empty module and the previous `document.styleSheets` approach was a no-op — confirmed this was already broken on `main` prior to this change).
- [x] `npm run lint` — clean on all changed files.
- [x] `npm test` (targeted): `StreamProgress.test.tsx` + `focus.css.test.tsx` — 8/8 passing.
- Manually verified: tabbing to the progress bar shows a visible accent-colored outline; clicking it with a mouse shows no outline.

Docs: `docs/streamprogress-focus-accessibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)