### PR TITLE
feat: ReceiptCard aria-live

### DIFF
--- a/app/components/LiveRegion.test.tsx
+++ b/app/components/LiveRegion.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { LiveRegion } from "./LiveRegion";
+
+describe("LiveRegion", () => {
+  it("renders the message inside a polite status region by default", () => {
+    render(<LiveRegion message="Saved." />);
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveTextContent("Saved.");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("renders an assertive alert region when politeness is 'assertive'", () => {
+    render(<LiveRegion message="Failed." politeness="assertive" />);
+
+    const region = screen.getByRole("alert");
+    expect(region).toHaveTextContent("Failed.");
+    expect(region).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("is visually hidden but present in the accessibility tree", () => {
+    render(<LiveRegion message="Hidden visually." />);
+
+    expect(screen.getByRole("status")).toHaveClass("sr-only");
+  });
+
+  it("renders an empty region without announcing anything when message is empty", () => {
+    render(<LiveRegion message="" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("forwards an additional className alongside sr-only", () => {
+    render(<LiveRegion message="x" className="custom-class" />);
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveClass("sr-only");
+    expect(region).toHaveClass("custom-class");
+  });
+});

--- a/app/components/LiveRegion.tsx
+++ b/app/components/LiveRegion.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+export type LiveRegionProps = {
+  /** Text announced to assistive tech. An empty string announces nothing. */
+  message: string;
+  /**
+   * `"polite"` waits for the screen reader to finish its current utterance;
+   * `"assertive"` interrupts it. Default `"polite"` — appropriate for status
+   * updates that aren't time-critical.
+   */
+  politeness?: "polite" | "assertive";
+  /** Optional class forwarded to the wrapper, in addition to `sr-only`. */
+  className?: string;
+};
+
+/**
+ * Visually hidden `aria-live` region for announcing state changes (copy
+ * feedback, toggles, async results, ...) to screen reader users without
+ * moving focus or rendering visible UI.
+ *
+ * Mount once per component and update `message` — the DOM text change is
+ * what triggers the announcement, so the region itself must stay in the DOM
+ * across renders (don't conditionally unmount it).
+ */
+export function LiveRegion({
+  message,
+  politeness = "polite",
+  className = "",
+}: LiveRegionProps) {
+  return (
+    <div
+      className={`sr-only ${className}`.trim()}
+      aria-live={politeness}
+      aria-atomic="true"
+      role={politeness === "assertive" ? "alert" : "status"}
+    >
+      {message}
+    </div>
+  );
+}

--- a/app/components/ReceiptShareCard.test.tsx
+++ b/app/components/ReceiptShareCard.test.tsx
@@ -264,3 +264,101 @@ describe("ReceiptShareCard", () => {
     });
   });
 });
+
+describe("ReceiptShareCard aria-live announcements", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("renders a live region present from the initial render", () => {
+    render(
+      <ReceiptShareCard streamId="s-1" recipient={RECIPIENT} amount="42.00" />,
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveTextContent("");
+  });
+
+  it("announces that the share text was copied", async () => {
+    render(
+      <ReceiptShareCard streamId="s-1" recipient={RECIPIENT} amount="42.00" />,
+    );
+
+    const copyBtn = screen.getByRole("button", { name: "Copy share text" });
+    fireEvent.click(copyBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Share text copied to clipboard.",
+      );
+    });
+  });
+
+  it("announces when the recipient address is hidden", () => {
+    render(
+      <ReceiptShareCard
+        streamId="s-1"
+        recipient={RECIPIENT}
+        amount="42.00"
+        defaultMasked={false}
+      />,
+    );
+
+    const toggle = screen.getByLabelText("Mask recipient address for privacy");
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Recipient address hidden.",
+    );
+  });
+
+  it("announces when the recipient address is shown", () => {
+    render(
+      <ReceiptShareCard streamId="s-1" recipient={RECIPIENT} amount="42.00" />,
+    );
+
+    const toggle = screen.getByLabelText("Mask recipient address for privacy");
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Recipient address shown.",
+    );
+  });
+
+  it("keeps the live region mounted after the copy feedback resets", async () => {
+    render(
+      <ReceiptShareCard streamId="s-1" recipient={RECIPIENT} amount="42.00" />,
+    );
+
+    const copyBtn = screen.getByRole("button", { name: "Copy share text" });
+    fireEvent.click(copyBtn);
+
+    await waitFor(() => {
+      expect(copyBtn).toHaveTextContent("Copied");
+    });
+
+    jest.advanceTimersByTime(2000);
+
+    await waitFor(() => {
+      expect(copyBtn).toHaveTextContent("Copy");
+    });
+
+    // The announcement text itself persists (screen readers already spoke
+    // it) — only the visible button label reverts.
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Share text copied to clipboard.",
+    );
+  });
+});

--- a/app/components/ReceiptShareCard.tsx
+++ b/app/components/ReceiptShareCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { LiveRegion } from "./LiveRegion";
 
 const STATUS_LABELS: Record<string, string> = {
   active: "Active",
@@ -40,6 +41,10 @@ export function ReceiptShareCard({
 }: ReceiptShareCardProps) {
   const [masked, setMasked] = useState(defaultMasked);
   const [copied, setCopied] = useState(false);
+  // SR-only announcement text — see LiveRegion. Overwritten on every state
+  // change we care about (copy feedback, mask toggle) so screen readers get
+  // it even though nothing visible moves focus.
+  const [announcement, setAnnouncement] = useState("");
 
   const shownRecipient = masked ? maskAddress(recipient) : recipient;
 
@@ -52,12 +57,23 @@ export function ReceiptShareCard({
       `StreamPay receipt ${streamId}: ${amount} ${assetCode} to ${shownRecipient}`;
     navigator.clipboard?.writeText(shareText).then(() => {
       setCopied(true);
+      setAnnouncement("Share text copied to clipboard.");
       setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
     });
   }, [streamId, amount, assetCode, shownRecipient]);
 
+  const handleMaskToggle = useCallback((next: boolean) => {
+    setMasked(next);
+    setAnnouncement(
+      next ? "Recipient address hidden." : "Recipient address shown.",
+    );
+  }, []);
+
   return (
     <figure className="receipt-share-card" aria-label="Stream receipt share card">
+      {/* SR-only — announces copy/mask-toggle state changes without moving focus. */}
+      <LiveRegion message={announcement} />
+
       <div className="receipt-share-card__brand">
         <span className="receipt-share-card__wordmark">StreamPay</span>
         <span className="receipt-share-card__tagline">Receipt</span>
@@ -100,7 +116,7 @@ export function ReceiptShareCard({
           <input
             type="checkbox"
             checked={masked}
-            onChange={(e) => setMasked(e.target.checked)}
+            onChange={(e) => handleMaskToggle(e.target.checked)}
             aria-label="Mask recipient address for privacy"
           />
           <span className="receipt-share-card__toggle-label">

--- a/docs/receiptcard-aria-live.md
+++ b/docs/receiptcard-aria-live.md
@@ -1,0 +1,52 @@
+# ReceiptShareCard — aria-live Status Announcements
+
+## Overview
+`ReceiptShareCard` (`app/components/ReceiptShareCard.tsx`) has two pieces of
+interactive state that change without moving keyboard focus or navigating the
+page: the **copy-to-clipboard** button and the **mask address** toggle.
+Previously, the only signal of a state change was a visual text swap
+(`Copy` → `Copied`) and an `aria-label` update on the button — neither of
+which is reliably announced by screen readers unless focus happens to be on
+that exact element and the AT re-reads label changes.
+
+## Change
+- Added a new reusable `LiveRegion` component
+  (`app/components/LiveRegion.tsx`): a visually-hidden (`sr-only`)
+  `aria-live` region that announces its `message` prop whenever it changes,
+  without rendering anything visible or moving focus. Supports `"polite"`
+  (default, `role="status"`) and `"assertive"` (`role="alert"`).
+- `ReceiptShareCard` now mounts one `LiveRegion` and updates its message on:
+  - **Copy success** → `"Share text copied to clipboard."`
+  - **Mask toggle** → `"Recipient address hidden."` / `"Recipient address shown."`
+- This follows the same `sr-only` + `aria-live="polite"` + `role="status"`
+  pattern already used ad hoc in `StreamRow.tsx` for its own SR
+  announcements — `LiveRegion` is the reusable extraction of that pattern so
+  future components don't have to hand-roll it.
+
+## Accessibility (WCAG 2.1 AA)
+- **4.1.3 Status Messages**: state changes are now programmatically
+  announced to assistive technology without requiring a focus change.
+- The live region is present in the DOM from first render (not conditionally
+  mounted), which is required for `aria-live` to reliably pick up subsequent
+  text changes in most screen readers.
+- No visible UI or layout changed — `LiveRegion` renders via the existing
+  `.sr-only` utility class, and no new colors/tokens were introduced, so
+  light/dark/high-contrast theming is unaffected.
+
+## Testing
+- `app/components/LiveRegion.test.tsx` — politeness/role defaults, visual
+  hiding, className forwarding, empty-message rendering.
+- `app/components/ReceiptShareCard.test.tsx` — new `"aria-live
+  announcements"` describe block: region present on mount, copy
+  announcement, mask-hidden announcement, mask-shown announcement, and that
+  the announcement text persists after the visible "Copied" button label
+  resets (the announcement isn't tied to the button's transient visual
+  state).
+
+## Known limitation
+Setting the same announcement text twice in a row (e.g. clicking "Copy"
+twice within the same session before the message otherwise changes) may not
+re-announce in every screen reader, since the DOM text doesn't change. This
+matches the existing `StreamRow` announcement pattern and wasn't introduced
+by this change; a de-dupe/force-refresh strategy (e.g. suffixing a hidden
+counter) can be added later if this proves disruptive in practice.


### PR DESCRIPTION
## Summary
- Added a reusable `LiveRegion` component (`app/components/LiveRegion.tsx`) — a visually-hidden `sr-only` `aria-live` region (`"polite"`/`role="status"` by default, `"assertive"`/`role="alert"` optionally) that announces its `message` prop to screen readers on change, without moving keyboard focus or rendering visible UI.
- Wired it into `ReceiptShareCard` (the closest existing "receipt card" component in this repo — there's no literal `ReceiptCard.tsx`/`src/` path, so this follows the same adaptation the maintainers used on prior GrantFox issues, e.g. #1056) so its two dynamic states now get SR announcements:
  - **Copy button** → `"Share text copied to clipboard."` on successful clipboard copy.
  - **Mask-address toggle** → `"Recipient address hidden."` / `"Recipient address shown."`
- Previously these state changes only surfaced via a visual text swap (`Copy` → `Copied`) and an `aria-label` update, neither of which reliably announces to assistive tech without an explicit `aria-live` region.
- No visual/design changes — `LiveRegion` renders through the existing `.sr-only` utility class already used elsewhere in the app (e.g. `StreamRow.tsx`'s own ad-hoc announcer), so light/dark/high-contrast theming is unaffected.

Closes #1061

## Test plan
- [x] `app/components/LiveRegion.test.tsx` (new) — politeness/role defaults (`polite`/`status` vs `assertive`/`alert`), visually hidden via `sr-only`, className forwarding, empty-message rendering.
- [x] `app/components/ReceiptShareCard.test.tsx` — new `"aria-live announcements"` block: region present from initial render, copy announcement, mask-hidden announcement, mask-shown announcement, and that the announcement persists after the visible "Copied" button label resets.
- [x] `npm run lint` — clean on all changed/added files.
- [x] `npm test` (targeted): `LiveRegion.test.tsx` + `ReceiptShareCard.test.tsx` — 33/33 passing.
- [x] Ran the full `app/components/` suite to check for regressions — pre-existing, unrelated failures only (11 suites fail on `main` already with `SyntaxError: Identifier 'jest' has already been declared` in a shared navigation mock; verified this predates this change and is out of scope here).

Docs: `docs/receiptcard-aria-live.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)