### PR TITLE
feat: input validation /api/streams

### DIFF
--- a/app/api/streams/list-query-validation.test.ts
+++ b/app/api/streams/list-query-validation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ *
+ * GET /api/streams query validation — limit, status, and cursor are
+ * validated at the boundary and rejected with 422 VALIDATION_ERROR plus
+ * per-field details instead of silently degrading (a malformed limit
+ * previously produced an empty list).
+ */
+
+import { resetDb } from "@/app/lib/db";
+import { resetRateLimitStore } from "@/app/lib/rate-limit-store";
+import { GET as listStreams, POST as createStream } from "@/app/api/streams/route";
+
+const VALID_STELLAR_KEY = "GDSBCG3OKHCMMWS5EBH2X7XOYTJRWXN2YYQPCNS5OFBU4IDO4X7OFSQA";
+
+function getRequest(query: string = "") {
+  return new Request(`http://localhost/api/streams${query}`);
+}
+
+function postRequest(body: unknown) {
+  return new Request("http://localhost/api/streams", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedStreams(count: number) {
+  for (let i = 0; i < count; i++) {
+    const res = await createStream(
+      postRequest({ recipient: VALID_STELLAR_KEY, rate: "50", schedule: "month" }),
+    );
+    expect(res.status).toBe(201);
+  }
+}
+
+beforeEach(() => {
+  resetDb();
+  resetRateLimitStore();
+});
+
+describe("GET /api/streams query validation", () => {
+  it("returns 200 with defaults when no query params are given", async () => {
+    const res = await listStreams(getRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+  });
+
+  it("applies a valid limit", async () => {
+    await seedStreams(3);
+    const res = await listStreams(getRequest("?limit=2"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.meta.hasNext).toBe(true);
+  });
+
+  it("returns 422 with a limit detail for a non-numeric limit", async () => {
+    const res = await listStreams(getRequest("?limit=abc"));
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details).toEqual([
+      expect.objectContaining({ field: "limit" }),
+    ]);
+  });
+
+  it("returns 422 when limit is out of range", async () => {
+    for (const value of ["0", "101"]) {
+      const res = await listStreams(getRequest(`?limit=${value}`));
+      expect(res.status).toBe(422);
+    }
+  });
+
+  it("filters by a valid status", async () => {
+    await seedStreams(2);
+    const res = await listStreams(getRequest("?status=draft"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(2);
+    for (const stream of body.data) {
+      expect(stream.status).toBe("draft");
+    }
+  });
+
+  it("returns 422 with a status detail for an unknown status", async () => {
+    const res = await listStreams(getRequest("?status=bogus"));
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.details).toEqual([
+      expect.objectContaining({ field: "status" }),
+    ]);
+  });
+
+  it("returns 422 for an empty cursor param", async () => {
+    const res = await listStreams(getRequest("?cursor="));
+    expect(res.status).toBe(422);
+  });
+
+  it("treats a decodable but unknown cursor as a no-op", async () => {
+    const res = await listStreams(getRequest("?cursor=bm8tc3VjaC1pZA=="));
+    expect(res.status).toBe(200);
+  });
+
+  it("ignores unknown query params", async () => {
+    await seedStreams(1);
+    const res = await listStreams(getRequest("?foo=bar"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -13,7 +13,10 @@ import { checkRateLimit, getClientIdentity, rateLimitResponse } from "@/app/lib/
 import { getLimitForRoute } from "@/app/lib/rate-limit-config";
 import { recordRequest, recordThrottle } from "@/app/lib/rate-limit-metrics";
 import { checkTokenAllowed, normaliseToken } from "@/app/lib/token-allowlist";
-import { validateCreateStreamBody } from "@/app/lib/stream-validation";
+import {
+  validateCreateStreamBody,
+  validateListStreamsQuery,
+} from "@/app/lib/stream-validation";
 import type { Stream } from "@/app/types/openapi";
 
 function errorResponse(code: string, message: string, status: number) {
@@ -51,9 +54,33 @@ export async function GET(request: Request) {
   recordRequest(url.pathname);
 
   const { searchParams } = url;
-  const cursor = searchParams.get("cursor");
-  const status = searchParams.get("status");
-  const limit = Math.min(Number.parseInt(searchParams.get("limit") ?? "20", 10), 100);
+  const rawQuery: Record<string, string> = {};
+  for (const key of ["limit", "status", "cursor"] as const) {
+    const value = searchParams.get(key);
+    if (value !== null) {
+      rawQuery[key] = value;
+    }
+  }
+
+  const { errors: queryErrors, values: query } = validateListStreamsQuery(rawQuery);
+  if (queryErrors.length > 0) {
+    logger.warn("Stream list validation failed", { errors: queryErrors });
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "One or more query parameters are invalid.",
+          details: queryErrors,
+          request_id: getCorrelationContext()?.request_id,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  const cursor = query.cursor ?? null;
+  const status = query.status ?? null;
+  const limit = query.limit ?? 20;
 
   let streams = Array.from(streamRepository.streams.values()).sort((left, right) => {
     const timeCompare = left.createdAt.localeCompare(right.createdAt);

--- a/app/lib/stream-validation.test.ts
+++ b/app/lib/stream-validation.test.ts
@@ -7,7 +7,9 @@
 
 import {
   validateCreateStreamBody,
+  validateListStreamsQuery,
   validatePatchStreamBody,
+  STREAM_STATUSES,
   SUPPORTED_SCHEDULES,
 } from "./stream-validation";
 
@@ -520,4 +522,68 @@ describe("validatePatchStreamBody", () => {
     expect(errors[0].field).toBe('body');
     expect(errors[0].message).toBe('Expected object, received string');
   });
+});
+
+// ── GET /api/streams query ─────────────────────────────────────────────────
+
+describe("validateListStreamsQuery", () => {
+  it("returns no errors and parsed values for a valid query", () => {
+    const { errors, values } = validateListStreamsQuery({
+      limit: "25",
+      status: "active",
+      cursor: "abc",
+    });
+    expect(errors).toEqual([]);
+    expect(values).toEqual({ limit: 25, status: "active", cursor: "abc" });
+  });
+
+  it("returns no errors for an empty query", () => {
+    const { errors, values } = validateListStreamsQuery({});
+    expect(errors).toEqual([]);
+    expect(values).toEqual({});
+  });
+
+  it("rejects a non-numeric limit", () => {
+    const { errors } = validateListStreamsQuery({ limit: "abc" });
+    expect(errors.length).toBe(1);
+    expect(errors[0].field).toBe("limit");
+    expect(errors[0].code).toBe("INVALID_LIMIT");
+  });
+
+  it("rejects limits outside 1-100", () => {
+    expect(validateListStreamsQuery({ limit: "0" }).errors.length).toBe(1);
+    expect(validateListStreamsQuery({ limit: "101" }).errors.length).toBe(1);
+    expect(validateListStreamsQuery({ limit: "100" }).errors).toEqual([]);
+  });
+
+  it("accepts every known stream status and rejects others", () => {
+    for (const status of STREAM_STATUSES) {
+      expect(validateListStreamsQuery({ status }).errors).toEqual([]);
+    }
+    const { errors } = validateListStreamsQuery({ status: "bogus" });
+    expect(errors.length).toBe(1);
+    expect(errors[0].field).toBe("status");
+    expect(errors[0].code).toBe("INVALID_STATUS");
+  });
+
+  it("rejects an empty cursor", () => {
+    const { errors } = validateListStreamsQuery({ cursor: "" });
+    expect(errors.length).toBe(1);
+    expect(errors[0].field).toBe("cursor");
+    expect(errors[0].code).toBe("INVALID_CURSOR");
+  });
+});
+
+// ── Non-object bodies ──────────────────────────────────────────────────────
+
+describe("validateCreateStreamBody non-object bodies", () => {
+  it.each([null, [], "i-am-a-string", 42])(
+    "returns a single body INVALID_TYPE error for %p",
+    (body) => {
+      const errors = validateCreateStreamBody(body as Record<string, unknown>);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe("body");
+      expect(errors[0].code).toBe("INVALID_TYPE");
+    },
+  );
 });

--- a/app/lib/stream-validation.ts
+++ b/app/lib/stream-validation.ts
@@ -11,6 +11,7 @@
 
 import { isValidStellarPublicKey } from "@/app/lib/wallet-link";
 import { z } from "zod";
+import type { StreamStatus } from "@/app/types/openapi";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -79,6 +80,104 @@ export const patchStreamSchema = z
 
 // ── Validator ──────────────────────────────────────────────────────────────
 
+function zodIssuesToErrors(error: z.ZodError): ValidationError[] {
+  return error.issues.map((issue) => {
+    const params = (issue as { params?: { code?: unknown } }).params;
+    return {
+      field: issue.path.join(".") || "body",
+      code:
+        typeof params?.code === "string" ? params.code : issue.code.toUpperCase(),
+      message: issue.message,
+    };
+  });
+}
+
+/**
+ * Zod schema for the POST /api/streams body.
+ *
+ * The field rules and error codes are the long-standing contract of
+ * `validateCreateStreamBody`; each violation is emitted as a custom issue
+ * carrying its code in `params`, so callers see identical errors.
+ */
+export const createStreamSchema = z
+  .record(z.unknown())
+  .superRefine((body, ctx) => {
+    const fail = (path: string, code: string, message: string) =>
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [path],
+        message,
+        params: { code },
+      });
+
+    const recipient = body.recipient;
+    if (typeof recipient !== "string" || recipient.trim().length === 0) {
+      fail(
+        "recipient",
+        "MISSING_FIELD",
+        "recipient is required and must be a non-empty string.",
+      );
+    } else if (!isValidStellarPublicKey(recipient.trim())) {
+      fail(
+        "recipient",
+        "INVALID_STELLAR_KEY",
+        "recipient must be a valid Stellar public key (56-char string starting with G).",
+      );
+    }
+
+    const rate = body.rate;
+    if (typeof rate !== "string" || rate.trim().length === 0) {
+      fail("rate", "MISSING_FIELD", "rate is required and must be a non-empty string.");
+    } else {
+      const trimmed = rate.trim();
+
+      if (!DECIMAL_PATTERN.test(trimmed)) {
+        fail(
+          "rate",
+          "INVALID_RATE_FORMAT",
+          "rate must be a positive decimal number (e.g. 100 or 50.5).",
+        );
+      } else {
+        if (Number(trimmed) <= 0) {
+          fail("rate", "NEGATIVE_RATE", "rate must be greater than zero.");
+        }
+
+        const fractionPart = trimmed.split(".")[1] ?? "";
+        if (fractionPart.length > MAX_DECIMAL_PRECISION) {
+          fail(
+            "rate",
+            "DECIMAL_PRECISION_EXCEEDED",
+            `rate supports at most ${MAX_DECIMAL_PRECISION} decimal places.`,
+          );
+        }
+      }
+    }
+
+    const schedule = body.schedule;
+    if (typeof schedule !== "string" || schedule.trim().length === 0) {
+      fail(
+        "schedule",
+        "MISSING_FIELD",
+        "schedule is required and must be a non-empty string.",
+      );
+    } else if (
+      !SUPPORTED_SCHEDULES.includes(
+        schedule.trim().toLowerCase() as SupportedSchedule,
+      )
+    ) {
+      fail(
+        "schedule",
+        "INVALID_SCHEDULE",
+        `schedule must be one of: ${SUPPORTED_SCHEDULES.join(", ")}.`,
+      );
+    }
+
+    const token = body.token;
+    if (token !== undefined && token !== null && typeof token !== "string") {
+      fail("token", "INVALID_TOKEN_FORMAT", "token must be a string if provided.");
+    }
+  });
+
 /**
  * Validates the request body for POST /api/streams.
  *
@@ -88,94 +187,92 @@ export const patchStreamSchema = z
 export function validateCreateStreamBody(
   body: Record<string, unknown>,
 ): ValidationError[] {
-  const errors: ValidationError[] = [];
+  const result = createStreamSchema.safeParse(body);
+  return result.success ? [] : zodIssuesToErrors(result.error);
+}
 
-  // ── recipient ────────────────────────────────────────────────────────────
-  const recipient = body.recipient;
-  if (typeof recipient !== "string" || recipient.trim().length === 0) {
-    errors.push({
-      field: "recipient",
-      code: "MISSING_FIELD",
-      message: "recipient is required and must be a non-empty string.",
-    });
-  } else if (!isValidStellarPublicKey(recipient.trim())) {
-    errors.push({
-      field: "recipient",
-      code: "INVALID_STELLAR_KEY",
-      message:
-        "recipient must be a valid Stellar public key (56-char string starting with G).",
-    });
-  }
+// ── GET /api/streams query ─────────────────────────────────────────────────
 
-  // ── rate ─────────────────────────────────────────────────────────────────
-  const rate = body.rate;
-  if (typeof rate !== "string" || rate.trim().length === 0) {
-    errors.push({
-      field: "rate",
-      code: "MISSING_FIELD",
-      message: "rate is required and must be a non-empty string.",
-    });
-  } else {
-    const trimmed = rate.trim();
+export const STREAM_STATUSES = [
+  "draft",
+  "active",
+  "paused",
+  "ended",
+  "withdrawn",
+  "cancelled",
+] as const satisfies readonly StreamStatus[];
 
-    if (!DECIMAL_PATTERN.test(trimmed)) {
-      errors.push({
-        field: "rate",
-        code: "INVALID_RATE_FORMAT",
-        message: "rate must be a positive decimal number (e.g. 100 or 50.5).",
-      });
-    } else {
-      const numericValue = Number(trimmed);
+/**
+ * Zod schema for the GET /api/streams query params. Values arrive as URL
+ * strings; `limit` is returned as a number. Unknown params are ignored by
+ * the caller, and cursor decoding stays a separate semantic check
+ * (INVALID_CURSOR) in the route.
+ */
+export const listStreamsQuerySchema = z.object({
+  limit: z
+    .string()
+    .superRefine((value, ctx) => {
+      const fail = (message: string) =>
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message,
+          params: { code: "INVALID_LIMIT" },
+        });
 
-      if (numericValue <= 0) {
-        errors.push({
-          field: "rate",
-          code: "NEGATIVE_RATE",
-          message: "rate must be greater than zero.",
+      if (!/^\d+$/.test(value)) {
+        fail("limit must be a positive integer.");
+        return;
+      }
+      const parsed = Number(value);
+      if (parsed < 1 || parsed > 100) {
+        fail("limit must be between 1 and 100.");
+      }
+    })
+    .transform(Number)
+    .optional(),
+  status: z
+    .string()
+    .superRefine((value, ctx) => {
+      if (!(STREAM_STATUSES as readonly string[]).includes(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `status must be one of: ${STREAM_STATUSES.join(", ")}.`,
+          params: { code: "INVALID_STATUS" },
         });
       }
-
-      const fractionPart = trimmed.split(".")[1] ?? "";
-      if (fractionPart.length > MAX_DECIMAL_PRECISION) {
-        errors.push({
-          field: "rate",
-          code: "DECIMAL_PRECISION_EXCEEDED",
-          message: `rate supports at most ${MAX_DECIMAL_PRECISION} decimal places.`,
+    })
+    .transform((value) => value as StreamStatus)
+    .optional(),
+  cursor: z
+    .string()
+    .superRefine((value, ctx) => {
+      if (value.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "cursor must not be empty.",
+          params: { code: "INVALID_CURSOR" },
         });
       }
-    }
-  }
+    })
+    .optional(),
+});
 
-  // ── schedule ─────────────────────────────────────────────────────────────
-  const schedule = body.schedule;
-  if (typeof schedule !== "string" || schedule.trim().length === 0) {
-    errors.push({
-      field: "schedule",
-      code: "MISSING_FIELD",
-      message: "schedule is required and must be a non-empty string.",
-    });
-  } else {
-    const normalized = schedule.trim().toLowerCase();
-    if (!SUPPORTED_SCHEDULES.includes(normalized as SupportedSchedule)) {
-      errors.push({
-        field: "schedule",
-        code: "INVALID_SCHEDULE",
-        message: `schedule must be one of: ${SUPPORTED_SCHEDULES.join(", ")}.`,
-      });
-    }
-  }
+export type ListStreamsQuery = z.infer<typeof listStreamsQuerySchema>;
 
-  // ── token (optional) ─────────────────────────────────────────────────────
-  const token = body.token;
-  if (token !== undefined && token !== null && typeof token !== "string") {
-    errors.push({
-      field: "token",
-      code: "INVALID_TOKEN_FORMAT",
-      message: "token must be a string if provided.",
-    });
+/**
+ * Validates the query params for GET /api/streams.
+ *
+ * Returns field-level errors plus the parsed values on success.
+ */
+export function validateListStreamsQuery(query: Record<string, unknown>): {
+  errors: ValidationError[];
+  values: ListStreamsQuery;
+} {
+  const result = listStreamsQuerySchema.safeParse(query);
+  if (result.success) {
+    return { errors: [], values: result.data };
   }
-
-  return errors;
+  return { errors: zodIssuesToErrors(result.error), values: {} };
 }
 
 /**

--- a/docs/api/streams-validation.md
+++ b/docs/api/streams-validation.md
@@ -1,0 +1,43 @@
+# /api/streams Input Validation
+
+Both `/api/streams` handlers validate input at the boundary with Zod schemas
+in `app/lib/stream-validation.ts`.
+
+## POST /api/streams
+
+`createStreamSchema` is now a first-class Zod schema and
+`validateCreateStreamBody` delegates to it. For object bodies the error
+contract is unchanged: the same per-field errors as before
+(`MISSING_FIELD`, `INVALID_STELLAR_KEY`, `INVALID_RATE_FORMAT`,
+`NEGATIVE_RATE`, `DECIMAL_PRECISION_EXCEEDED`, `INVALID_SCHEDULE`,
+`INVALID_TOKEN_FORMAT`), returned in the existing 422 `VALIDATION_ERROR`
+envelope with `details`.
+
+Non-object JSON bodies changed: an array, string, or number body previously
+produced three `MISSING_FIELD` details, and a JSON `null` body crashed the
+handler (an unhandled 500). All of them now return a single
+`{ field: "body", code: "INVALID_TYPE" }` detail.
+
+## GET /api/streams
+
+Query params are now validated (`listStreamsQuerySchema`) instead of silently
+degrading:
+
+| Query param | Rules | Error code |
+| ----------- | ----- | ---------- |
+| `limit`     | Optional. Integer 1-100 (default 20). | `INVALID_LIMIT` |
+| `status`    | Optional. One of `draft`, `active`, `paused`, `ended`, `withdrawn`, `cancelled`. | `INVALID_STATUS` |
+| `cursor`    | Optional. Non-empty string; decoding is still checked separately (`INVALID_CURSOR` at the top level). | `INVALID_CURSOR` |
+
+Unknown query params are ignored.
+
+Behavior changes, all previously silent degradations:
+
+- A malformed `limit` produced an empty list (`parseInt` NaN propagated into
+  the slice); it is now a 422.
+- `limit` greater than 100 was silently clamped to 100; it is now a 422.
+- An unknown `status` matched nothing and returned an empty list; it is now
+  a 422.
+
+All failures use the same 422 `VALIDATION_ERROR` envelope with per-field
+`details` as the POST body path.


### PR DESCRIPTION
## What
Zod-validated schemas for both /api/streams handlers, in `app/lib/stream-validation.ts` (the repo has no `src/` tree, so the module the issue suggests lives with the existing validators).

- POST: `createStreamSchema` is now a first-class zod schema and `validateCreateStreamBody` delegates to it. For object bodies the error contract is preserved exactly (same codes, messages, fields), which the untouched 500-line validation suite proves. Non-object bodies changed for the better: arrays/strings/numbers previously produced three misleading MISSING_FIELD details and a JSON `null` body crashed the handler with an unhandled 500; all now return a single `body`/`INVALID_TYPE` detail, pinned by new tests.
- GET: new `listStreamsQuerySchema` validates `limit` (integer 1-100, default 20, code INVALID_LIMIT), `status` (StreamStatus enum, INVALID_STATUS), and `cursor` (non-empty, INVALID_CURSOR). This fixes two real silent failures: a malformed `limit` NaN-propagated into an empty list, and an unknown `status` silently matched nothing. Out-of-range limits were previously clamped; all three cases now return the standard 422 `VALIDATION_ERROR` envelope with per-field details and correlated logging, exactly like the POST path.

`STREAM_STATUSES` is compile-time-locked to the `StreamStatus` union via `satisfies`, so the enum cannot drift.

## Testing
16 new tests: query-schema unit tests (values, codes, bounds), non-object body contract pins, and a route-level suite covering defaults, valid/invalid limit and status, empty cursor, unknown-param tolerance, and cursor no-op behavior. Full validation suite green; the one failing test in that file (patch strict-schema message) and the `[id]` contract failures are pre-existing on main, verified by running both trees. eslint clean; tsc emits only main's pre-existing errors.

Documented in docs/api/streams-validation.md, including the behavior changes. Note for a follow-up: `app/api/v2/streams/route.ts` still has the old NaN-limit behavior; happy to port this there as a separate PR since this issue names the unversioned route.

Closes #1096
