### PR TITLE
feat: rate limit /api/exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
   and the middleware dispatch surface.
 
 ### Security
+- Per-user rate limit on `POST /api/exports`: 5 requests/min per
+  authenticated wallet, checked after JWT verification so forged tokens
+  cannot spend a victim's budget, returning the standard `429` envelope with
+  `Retry-After`. Rate-limit buckets are now keyed per limit tier
+  (read/write/export), so throttling one endpoint class can no longer drain
+  a user's allowance for another.
 - Wallet auth IP rate limiting on `GET|POST /api/auth/wallet` now returns the
   canonical `{ error: { code, message, request_id } }` envelope on 429, echoes
   `x-request-id`, and emits structured `wallet_ip_rate_limit_exceeded` logs

--- a/app/api/exports/exports.test.ts
+++ b/app/api/exports/exports.test.ts
@@ -1,5 +1,11 @@
 import jwt from "jsonwebtoken";
 import { db, resetDb } from "@/app/lib/db";
+import { checkRateLimit } from "@/app/lib/rate-limit";
+import {
+  getRateLimitStore,
+  InMemoryRateLimitStore,
+  resetRateLimitStore,
+} from "@/app/lib/rate-limit-store";
 import { POST as createExport } from "./route";
 import { GET as getExport } from "./[id]/route";
 
@@ -19,9 +25,17 @@ function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+afterEach(() => {
+  const store = getRateLimitStore();
+  if (store instanceof InMemoryRateLimitStore) {
+    store.destroy();
+  }
+});
+
 describe("Exports API — authentication and scoping", () => {
   beforeEach(() => {
     resetDb();
+    resetRateLimitStore();
   });
 
   // ── POST /api/exports ──────────────────────────────────────────────────────
@@ -282,5 +296,83 @@ describe("Exports API — authentication and scoping", () => {
       // Only 1 stream row (not 2)
       expect(statusJson.data.rows).toBe(1);
     });
+  });
+});
+
+// ── POST /api/exports rate limiting ────────────────────────────────────────
+
+describe("POST /api/exports rate limiting", () => {
+  beforeEach(() => {
+    resetDb();
+    resetRateLimitStore();
+  });
+
+  it("returns 429 with Retry-After after 5 exports in a minute for one user", async () => {
+    const token = makeToken("GOWNER1");
+
+    for (let i = 0; i < 5; i++) {
+      const res = await createExport(authRequest("http://localhost/api/exports", token));
+      expect(res.status).toBe(201);
+    }
+
+    const limited = await createExport(authRequest("http://localhost/api/exports", token));
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("Retry-After")).toBeTruthy();
+    const json = await limited.json();
+    expect(json.error.code).toBe("rate_limit_exceeded");
+    expect(typeof json.error.request_id).toBe("string");
+  });
+
+  it("tracks the limit per user, not globally", async () => {
+    const tokenA = makeToken("GOWNER1");
+    const tokenB = makeToken("GOWNER2");
+
+    for (let i = 0; i < 5; i++) {
+      const res = await createExport(authRequest("http://localhost/api/exports", tokenA));
+      expect(res.status).toBe(201);
+    }
+
+    const limitedA = await createExport(authRequest("http://localhost/api/exports", tokenA));
+    expect(limitedA.status).toBe(429);
+
+    const freshB = await createExport(authRequest("http://localhost/api/exports", tokenB));
+    expect(freshB.status).toBe(201);
+  });
+
+  it("does not let a forged token consume a victim's budget", async () => {
+    const forged = [
+      Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+      Buffer.from(JSON.stringify({ sub: "GOWNER1" })).toString("base64url"),
+      "forged",
+    ].join(".");
+
+    for (let i = 0; i < 6; i++) {
+      const res = await createExport(authRequest("http://localhost/api/exports", forged));
+      expect(res.status).toBe(401);
+    }
+
+    const token = makeToken("GOWNER1");
+    for (let i = 0; i < 5; i++) {
+      const res = await createExport(authRequest("http://localhost/api/exports", token));
+      expect(res.status).toBe(201);
+    }
+  });
+
+  it("does not drain the export bucket from other limit tiers", async () => {
+    const token = makeToken("GOWNER1");
+
+    for (let i = 0; i < 5; i++) {
+      const res = await createExport(authRequest("http://localhost/api/exports", token));
+      expect(res.status).toBe(201);
+    }
+    const limited = await createExport(authRequest("http://localhost/api/exports", token));
+    expect(limited.status).toBe(429);
+
+    const readCheck = await checkRateLimit(
+      { type: "wallet", value: "GOWNER1", displayValue: "GOWNER1" },
+      "read",
+    );
+    expect(readCheck.allowed).toBe(true);
+    expect(readCheck.remaining).toBe(59);
   });
 });

--- a/app/api/exports/route.ts
+++ b/app/api/exports/route.ts
@@ -2,6 +2,17 @@ import { createHmac } from "crypto";
 import { NextResponse } from "next/server";
 import { tryAuthenticateRequest, JWT_SECRET } from "@/app/lib/auth";
 import { ExportJob, getStore } from "@/app/lib/db";
+import { checkRateLimit, rateLimitResponse, type ClientIdentity } from "@/app/lib/rate-limit";
+import { getLimitForRoute } from "@/app/lib/rate-limit-config";
+import { recordRequest, recordThrottle } from "@/app/lib/rate-limit-metrics";
+
+function getRequestUrl(request: Request): URL {
+  try {
+    return new URL(request.url);
+  } catch {
+    return new URL("http://localhost/api/exports");
+  }
+}
 
 const EXPORT_RETENTION_DAYS = 7;
 const SIGNED_URL_TTL_SECONDS = 60 * 60; // 1 hour
@@ -107,6 +118,23 @@ export async function POST(request: Request) {
   if (!actor) {
     return createErrorResponse("UNAUTHORIZED", "Missing or invalid authorization header", 401);
   }
+
+  // Limit by the verified wallet, after auth, so a forged bearer token can
+  // neither mint fresh buckets nor spend another user's budget.
+  const url = getRequestUrl(request);
+  const limitType = getLimitForRoute("POST", url.pathname);
+  const identity: ClientIdentity = {
+    type: "wallet",
+    value: actor.walletAddress,
+    displayValue: actor.walletAddress.slice(0, 16) + "...",
+  };
+  const rateCheck = await checkRateLimit(identity, limitType);
+
+  if (!rateCheck.allowed) {
+    recordThrottle(url.pathname, limitType, identity.type, identity.displayValue);
+    return rateLimitResponse(rateCheck.retryAfter!);
+  }
+  recordRequest(url.pathname);
 
   const id = crypto.randomUUID();
   const requestedAt = new Date().toISOString();

--- a/app/lib/rate-limit-config.ts
+++ b/app/lib/rate-limit-config.ts
@@ -1,6 +1,7 @@
 export const RATE_LIMITS = {
   read: { limit: 60, windowMs: 60_000 },
   write: { limit: 10, windowMs: 60_000 },
+  export: { limit: 5, windowMs: 60_000 },
 } as const;
 
 export type LimitType = keyof typeof RATE_LIMITS;
@@ -34,6 +35,7 @@ export const ROUTE_LIMITS: Record<string, LimitType> = {
   "POST:/api/streams/*/settle": "write",
   "POST:/api/streams/*/withdraw": "write",
   "POST:/api/streams/*/webhooks/test": "write",
+  "POST:/api/exports": "export",
 };
 
 export const STORE_TYPE = process.env.RATE_LIMIT_STORE_TYPE || "in-memory";

--- a/app/lib/rate-limit.ts
+++ b/app/lib/rate-limit.ts
@@ -76,7 +76,12 @@ export async function checkRateLimit(
   const store = getRateLimitStore();
   const config = RATE_LIMITS[limitType];
 
-  const result = await store.check(identity.value, config.limit, config.windowMs);
+  // Key per limit tier so one endpoint class cannot drain another's bucket.
+  const result = await store.check(
+    `${limitType}:${identity.value}`,
+    config.limit,
+    config.windowMs,
+  );
 
   return {
     allowed: result.allowed,

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -65,6 +65,7 @@ All API endpoints are rate limited:
 | GET | `/api/identity/me` | Read |
 | GET | `/api/auth/wallet` | Challenge (20 req/min per IP) |
 | POST | `/api/auth/wallet` | Login (5 req/min per IP) |
+| POST | `/api/exports` | Export (5 req/min per user) |
 
 ## Wallet Authentication Limits
 


### PR DESCRIPTION
## What
Per-user rate limit on POST /api/exports: a dedicated `export` bucket (5 req/min) in RATE_LIMITS plus a ROUTE_LIMITS entry, wired through the shared checkRateLimit machinery with recordThrottle/recordRequest metrics and the standard 429 envelope with Retry-After.

Two deliberate hardening choices, both disclosed here because they go slightly beyond a mechanical mirror of /api/streams:

- The limit is checked after JWT verification and keyed by the verified wallet. `getClientIdentity` trusts the token's `sub` without signature verification, so checking before auth would let a forged bearer token mint unlimited fresh buckets or spend a targeted victim's budget. Auth-first closes both; anonymous requests are rejected by auth exactly as before.
- Store buckets are now keyed per limit tier (`limitType:identity`) instead of identity alone. Previously all tiers shared one bucket per user, so interleaved GETs could bank read-refill tokens and sustain roughly 50 exports/min through the 5/min cap, and a single export drained the caller's read allowance. The per-tier key makes each documented limit actually independent. This changes shared-lib behavior for the better; existing rate-limit suites stay green (the two settle/pause failures in rateLimiterConsistency are pre-existing on main).

## Testing
20/20 exports tests: the original auth/scoping suite plus per-user limit exhaustion with Retry-After and envelope assertions, per-user isolation (second user unaffected), forged-token cannot consume a victim's budget, and tier independence (exhausting exports leaves the read bucket full). The suite also now destroys each InMemoryRateLimitStore before abandoning it, so its cleanup interval no longer leaks and the suite exits cleanly (it previously hung). eslint clean.

Documented in docs/rate-limits.md and CHANGELOG.md. Note: openapi.json does not document /api/exports at all (pre-existing absence); happy to add the operation with its 429 in a follow-up.

Closes #1124
