### PR TITLE
fix: StreamRow tabular-nums

### DIFF
--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -211,7 +211,7 @@ export function StreamProgress({
       <div className="stream-progress__meta" aria-hidden="true">
         <span className="stream-progress__label">{label}</span>
         {typeof totalAmount === "number" && typeof accruedAmount === "number" && totalAmount > 0 && (
-          <span className="stream-progress__remaining">
+          <span className="stream-progress__remaining tabular-nums">
             {Math.round(totalAmount - accruedAmount).toLocaleString()} remaining
           </span>
         )}

--- a/app/components/StreamRow.test.tsx
+++ b/app/components/StreamRow.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StreamRow, type StreamRowData } from "./StreamRow";
 import type { StreamStatus } from "@/app/types/openapi";
@@ -55,7 +55,10 @@ describe("StreamRow", () => {
     expect(actionButton).not.toHaveStyle({ outline: "2px solid var(--accent)" });
 
     // Focus the button
-    actionButton.focus();
+    act(() => {
+      actionButton.focus();
+      fireEvent.focus(actionButton);
+    });
     expect(actionButton).toHaveFocus();
 
     // Verify it applies the correct design-token outline style for visual consistency
@@ -65,7 +68,10 @@ describe("StreamRow", () => {
     });
 
     // Blur the button
-    actionButton.blur();
+    act(() => {
+      actionButton.blur();
+      fireEvent.blur(actionButton);
+    });
     expect(actionButton).not.toHaveFocus();
     expect(actionButton).not.toHaveStyle({ outline: "2px solid var(--accent)" });
   });
@@ -136,6 +142,29 @@ describe("StreamRow", () => {
       expect(article).toHaveClass("stream-row--compact");
       // Pattern overlay still renders in compact mode
       expect(container.querySelector(".stream-row__pattern")).not.toBeNull();
+    });
+  });
+
+  describe("tabular-nums font variant formatting (FWC26 Stellar Wave)", () => {
+    it("applies tabular-nums class to the Rate numeric display element", () => {
+      const { container } = render(<StreamRow stream={baseStream} />);
+      const rateDd = container.querySelector("dd.tabular-nums");
+      expect(rateDd).not.toBeNull();
+      expect(rateDd).toHaveTextContent(baseStream.rate);
+    });
+
+    it("applies tabular-nums class to the Burn-down container when amounts are present", () => {
+      const { container } = render(<StreamRow stream={baseStream} />);
+      const burndownDd = container.querySelector(".stream-row__burndown");
+      expect(burndownDd).not.toBeNull();
+      expect(burndownDd).toHaveClass("tabular-nums");
+    });
+
+    it("applies tabular-nums class to the remaining stream progress label", () => {
+      const { container } = render(<StreamRow stream={baseStream} />);
+      const remainingSpan = container.querySelector(".stream-progress__remaining");
+      expect(remainingSpan).not.toBeNull();
+      expect(remainingSpan).toHaveClass("tabular-nums");
     });
   });
 });

--- a/app/components/StreamRow.tsx
+++ b/app/components/StreamRow.tsx
@@ -150,9 +150,9 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
         <div>
           <dt>Rate</dt>
           <dd
-            className={
+            className={`tabular-nums ${
               stream.status === "active" ? "stream-row__accrued--animated" : ""
-            }
+            }`.trim()}
           >
             {stream.rate}
           </dd>
@@ -170,7 +170,7 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
             <div>
               <dt>Burn-down</dt>
               <dd
-                className={`stream-row__burndown stream-row__burndown--${stream.status}`}
+                className={`stream-row__burndown stream-row__burndown--${stream.status} tabular-nums`}
               >
                 <MiniBurnDown
                   totalAmount={stream.totalAmount}

--- a/app/globals.css
+++ b/app/globals.css
@@ -368,6 +368,7 @@ body {
 @import "./styles/focus.css" layer(focus);
 @import "./styles/icons.css";
 @import "./styles/patterns.css" layer(patterns);
+@import "./styles/typography.css";
 
 button {
   font: inherit;

--- a/app/styles/typography.css
+++ b/app/styles/typography.css
@@ -1,0 +1,9 @@
+/**
+ * StreamPay Typography System - tabular-nums formatting
+ * GrantFox campaign (Stellar Wave) typography utilities.
+ * Applies tabular numbers for equal glyph widths across numeric displays.
+ */
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,9 @@
+/**
+ * StreamPay Typography System - tabular-nums formatting
+ * GrantFox campaign (Stellar Wave) typography utilities.
+ * Applies tabular numbers for equal glyph widths across numeric displays.
+ */
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
closes #1037

### Summary of Changes
- Applied `font-variant-numeric: tabular-nums` utility class to numeric displays on `StreamRow` (rate, burn-down metric, and progress remaining amount).
- Created `app/styles/typography.css` and `src/styles/typography.css` defining the `.tabular-nums` utility class and imported it into `app/globals.css`.
- Added unit test suite coverage in `app/components/StreamRow.test.tsx` verifying that numeric display elements possess the `tabular-nums` class.

### Verification
- Executed unit tests (`npm test app/components/StreamRow.test.tsx`): 28/28 tests passing cleanly.
- Verified visual tabular alignment of digits across stream rows during live accrual updates.