### PR TITLE
feat: WalletBadge aria-live #1071

### DIFF
--- a/app/WalletBadge.test.tsx
+++ b/app/WalletBadge.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WalletBadge } from "./WalletBadge";
+
+describe("WalletBadge", () => {
+  it("renders disconnected state by default with connect label and SR announcement", () => {
+    render(<WalletBadge providerName="Freighter" />);
+    const badge = screen.getByTestId("wallet-badge");
+    expect(badge).toBeInTheDocument();
+    expect(screen.getByText("Connect Wallet")).toBeInTheDocument();
+    const liveRegion = screen.getByTestId("live-region");
+    expect(liveRegion).toHaveTextContent("Freighter disconnected.");
+  });
+
+  it("announces connecting state via live region", () => {
+    render(<WalletBadge state="connecting" providerName="Freighter" />);
+    expect(screen.getByText("Connecting Freighter...")).toBeInTheDocument();
+    const liveRegion = screen.getByTestId("live-region");
+    expect(liveRegion).toHaveTextContent("Connecting to Freighter...");
+  });
+
+  it("announces connected state with formatted address, network, and balance", () => {
+    render(
+      <WalletBadge
+        state="connected"
+        address="GABCD1234567890XYZ"
+        providerName="Freighter"
+        network="Testnet"
+        balance="150.00 XLM"
+      />
+    );
+    expect(screen.getByText("GABC...0XYZ")).toBeInTheDocument();
+    expect(screen.getByText("Testnet")).toBeInTheDocument();
+    expect(screen.getByText("150.00 XLM")).toBeInTheDocument();
+
+    const liveRegion = screen.getByTestId("live-region");
+    expect(liveRegion).toHaveTextContent(
+      "Freighter connected. Address: GABC...0XYZ. Network: Testnet. Balance: 150.00 XLM."
+    );
+  });
+
+  it("announces error state with errorMessage", () => {
+    render(
+      <WalletBadge
+        state="error"
+        errorMessage="User rejected connection"
+        providerName="Albedo"
+      />
+    );
+    expect(screen.getByText("User rejected connection")).toBeInTheDocument();
+    const liveRegion = screen.getByTestId("live-region");
+    expect(liveRegion).toHaveTextContent("Wallet connection error: User rejected connection");
+  });
+
+  it("invokes onConnect when clicked in disconnected state", () => {
+    const handleConnect = jest.fn();
+    render(<WalletBadge state="disconnected" onConnect={handleConnect} />);
+    fireEvent.click(screen.getByTestId("wallet-badge"));
+    expect(handleConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onDisconnect when disconnect button is clicked in connected state", () => {
+    const handleDisconnect = jest.fn();
+    render(
+      <WalletBadge
+        state="connected"
+        address="GABCD1234567890XYZ"
+        onDisconnect={handleDisconnect}
+      />
+    );
+    const disconnectBtn = screen.getByRole("button", { name: "Disconnect wallet" });
+    fireEvent.click(disconnectBtn);
+    expect(handleDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom announcement override", () => {
+    render(
+      <WalletBadge
+        state="connected"
+        address="GABCD1234567890XYZ"
+        announcement="Custom screen reader message"
+      />
+    );
+    const liveRegion = screen.getByTestId("live-region");
+    expect(liveRegion).toHaveTextContent("Custom screen reader message");
+  });
+});

--- a/app/WalletBadge.tsx
+++ b/app/WalletBadge.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { LiveRegion } from "../src/components/LiveRegion";
+
+export type WalletState = "disconnected" | "connecting" | "connected" | "error" | "disconnecting";
+
+export interface WalletBadgeProps {
+  /** Connection state of the wallet */
+  state?: WalletState;
+  /** Stellar wallet public key / address */
+  address?: string | null;
+  /** Name of the connected wallet provider (e.g. Freighter, Albedo) */
+  providerName?: string;
+  /** Connected network name (e.g. Mainnet, Testnet) */
+  network?: string;
+  /** Formatted balance string (e.g. "100.00 XLM") */
+  balance?: string;
+  /** Error details if state === "error" */
+  errorMessage?: string;
+  /** Callback triggered when user clicks connect */
+  onConnect?: () => void;
+  /** Callback triggered when user clicks disconnect */
+  onDisconnect?: () => void;
+  /** Callback triggered when user clicks the badge container */
+  onClick?: () => void;
+  /** Screen reader announcement politeness level */
+  politeness?: "polite" | "assertive";
+  /** Manual announcement message override */
+  announcement?: string;
+  /** Additional CSS class names */
+  className?: string;
+}
+
+/**
+ * WalletBadge displays current wallet status and announces state changes via an ARIA live region.
+ */
+export function WalletBadge({
+  state = "disconnected",
+  address = null,
+  providerName,
+  network,
+  balance,
+  errorMessage,
+  onConnect,
+  onDisconnect,
+  onClick,
+  politeness = "polite",
+  announcement,
+  className = "",
+}: WalletBadgeProps) {
+  const [srMessage, setSrMessage] = useState<string>("");
+
+  const formattedAddress = useMemo(() => {
+    if (!address) return "";
+    if (address.length <= 10) return address;
+    return `${address.slice(0, 4)}...${address.slice(-4)}`;
+  }, [address]);
+
+  // Generate SR-announce text on state/prop changes
+  useEffect(() => {
+    if (announcement !== undefined) {
+      setSrMessage(announcement);
+      return;
+    }
+
+    const provider = providerName ? providerName : "Wallet";
+
+    switch (state) {
+      case "connecting":
+        setSrMessage(`Connecting to ${provider}...`);
+        break;
+      case "connected": {
+        const parts = [`${provider} connected.`];
+        if (formattedAddress) parts.push(`Address: ${formattedAddress}.`);
+        if (network) parts.push(`Network: ${network}.`);
+        if (balance) parts.push(`Balance: ${balance}.`);
+        setSrMessage(parts.join(" "));
+        break;
+      }
+      case "disconnecting":
+        setSrMessage(`Disconnecting from ${provider}...`);
+        break;
+      case "disconnected":
+        setSrMessage(`${provider} disconnected.`);
+        break;
+      case "error":
+        setSrMessage(`Wallet connection error: ${errorMessage || "Failed to connect"}`);
+        break;
+      default:
+        setSrMessage("");
+    }
+  }, [state, address, formattedAddress, providerName, network, balance, errorMessage, announcement]);
+
+  const handleAction = (e: React.MouseEvent) => {
+    if (onClick) onClick();
+    if (state === "disconnected" && onConnect) {
+      onConnect();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (onClick) onClick();
+      if (state === "disconnected" && onConnect) {
+        onConnect();
+      }
+    }
+  };
+
+  const getStatusColor = () => {
+    switch (state) {
+      case "connected":
+        return "#10B981"; // green
+      case "connecting":
+      case "disconnecting":
+        return "#F59E0B"; // amber / yellow
+      case "error":
+        return "#EF4444"; // red
+      case "disconnected":
+      default:
+        return "#9CA3AF"; // gray
+    }
+  };
+
+  const isInteractive = Boolean(onClick || (state === "disconnected" && onConnect));
+
+  return (
+    <div
+      className={`wallet-badge wallet-badge--${state} ${className}`.trim()}
+      onClick={handleAction}
+      onKeyDown={isInteractive ? handleKeyDown : undefined}
+      role={isInteractive ? "button" : "region"}
+      tabIndex={isInteractive ? 0 : undefined}
+      aria-label={`Wallet status: ${state}`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        padding: "0.4rem 0.8rem",
+        borderRadius: "9999px",
+        border: "1px solid var(--border, #374151)",
+        backgroundColor: "var(--panel, #1F2937)",
+        color: "var(--foreground, #F9FAFB)",
+        fontSize: "0.875rem",
+        fontWeight: 500,
+        cursor: isInteractive ? "pointer" : "default",
+        userSelect: "none",
+        position: "relative",
+      }}
+      data-testid="wallet-badge"
+    >
+      {/* Status Dot */}
+      <span
+        className="wallet-badge__dot"
+        style={{
+          width: "8px",
+          height: "8px",
+          borderRadius: "50%",
+          backgroundColor: getStatusColor(),
+          display: "inline-block",
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Main Content */}
+      <span className="wallet-badge__label">
+        {state === "connecting" && (providerName ? `Connecting ${providerName}...` : "Connecting...")}
+        {state === "disconnecting" && "Disconnecting..."}
+        {state === "error" && (errorMessage || "Connection Error")}
+        {state === "disconnected" && "Connect Wallet"}
+        {state === "connected" && (
+          <>
+            {providerName && <span style={{ opacity: 0.8, marginRight: "0.25rem" }}>{providerName}:</span>}
+            <span>{formattedAddress || "Connected"}</span>
+          </>
+        )}
+      </span>
+
+      {/* Optional Network tag */}
+      {state === "connected" && network && (
+        <span
+          className="wallet-badge__network"
+          style={{
+            fontSize: "0.75rem",
+            padding: "0.1rem 0.4rem",
+            borderRadius: "4px",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            color: "var(--muted-light, #9CA3AF)",
+          }}
+        >
+          {network}
+        </span>
+      )}
+
+      {/* Optional Balance tag */}
+      {state === "connected" && balance && (
+        <span className="wallet-badge__balance" style={{ fontWeight: 600 }}>
+          {balance}
+        </span>
+      )}
+
+      {/* Disconnect Action Button */}
+      {state === "connected" && onDisconnect && (
+        <button
+          type="button"
+          className="wallet-badge__disconnect"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDisconnect();
+          }}
+          aria-label="Disconnect wallet"
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--muted-light, #9CA3AF)",
+            cursor: "pointer",
+            fontSize: "0.75rem",
+            padding: "0 0.2rem",
+            marginLeft: "0.25rem",
+          }}
+        >
+          ✕
+        </button>
+      )}
+
+      {/* ARIA Live Region Announcement */}
+      <LiveRegion message={srMessage} politeness={politeness} />
+    </div>
+  );
+}
+
+export default WalletBadge;

--- a/app/components/LiveRegion.tsx
+++ b/app/components/LiveRegion.tsx
@@ -1,0 +1,2 @@
+export { LiveRegion, default } from "../../src/components/LiveRegion";
+export type { LiveRegionProps } from "../../src/components/LiveRegion";

--- a/app/components/WalletBadge.tsx
+++ b/app/components/WalletBadge.tsx
@@ -1,0 +1,2 @@
+export { WalletBadge, default } from "../WalletBadge";
+export type { WalletBadgeProps, WalletState } from "../WalletBadge";

--- a/src/components/LiveRegion.test.tsx
+++ b/src/components/LiveRegion.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LiveRegion } from "./LiveRegion";
+
+describe("LiveRegion", () => {
+  it("renders with default polite aria-live attributes", () => {
+    render(<LiveRegion message="Status update" />);
+    const region = screen.getByTestId("live-region");
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+    expect(region).toHaveAttribute("role", "status");
+    expect(region).toHaveTextContent("Status update");
+  });
+
+  it("renders with assertive politeness and alert role", () => {
+    render(<LiveRegion message="Urgent alert" politeness="assertive" />);
+    const region = screen.getByTestId("live-region");
+    expect(region).toHaveAttribute("aria-live", "assertive");
+    expect(region).toHaveAttribute("role", "alert");
+  });
+
+  it("supports custom role override", () => {
+    render(<LiveRegion message="Log entry" role="log" />);
+    const region = screen.getByTestId("live-region");
+    expect(region).toHaveAttribute("role", "log");
+  });
+
+  it("renders children when message prop is not supplied", () => {
+    render(
+      <LiveRegion>
+        <span>Child content</span>
+      </LiveRegion>
+    );
+    expect(screen.getByTestId("live-region")).toHaveTextContent("Child content");
+  });
+
+  it("applies sr-only class name for screen reader visibility", () => {
+    render(<LiveRegion message="Hidden text" className="custom-live" />);
+    const region = screen.getByTestId("live-region");
+    expect(region.className).toContain("sr-only");
+    expect(region.className).toContain("custom-live");
+  });
+});

--- a/src/components/LiveRegion.tsx
+++ b/src/components/LiveRegion.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+
+export interface LiveRegionProps {
+  /** Text message to announce to screen readers */
+  message?: string;
+  /** Politeness level for aria-live announcements ("polite", "assertive", "off"). Defaults to "polite". */
+  politeness?: "polite" | "assertive" | "off";
+  /** Directly sets aria-live attribute (takes precedence over politeness) */
+  "aria-live"?: "polite" | "assertive" | "off";
+  /** Whether screen reader should announce the entire region on change. Defaults to true. */
+  atomic?: boolean;
+  /** Directly sets aria-atomic attribute */
+  "aria-atomic"?: boolean;
+  /** ARIA role for the live region ("status", "alert", "log", etc.) */
+  role?: "status" | "alert" | "log" | string;
+  /** Types of changes to announce ("additions text", "all", etc.) */
+  "aria-relevant"?: "additions" | "removals" | "text" | "all" | "additions text";
+  /** Additional CSS class names */
+  className?: string;
+  /** Additional inline styles */
+  style?: React.CSSProperties;
+  /** Children elements if message is not supplied */
+  children?: React.ReactNode;
+}
+
+/**
+ * LiveRegion provides an accessible ARIA live region for screen reader announcements.
+ * Dynamic content rendered inside is announced when updated without interrupting visual flow.
+ */
+export function LiveRegion({
+  message,
+  politeness = "polite",
+  "aria-live": ariaLive,
+  atomic = true,
+  "aria-atomic": ariaAtomic,
+  role,
+  "aria-relevant": ariaRelevant,
+  className = "",
+  style,
+  children,
+}: LiveRegionProps) {
+  const live = ariaLive ?? politeness;
+  const isAtomic = ariaAtomic ?? atomic;
+  const computedRole = role ?? (live === "assertive" ? "alert" : "status");
+
+  // Visually hidden style to guarantee SR accessibility regardless of external CSS loading
+  const srOnlyStyle: React.CSSProperties = {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: "0",
+    margin: "-1px",
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    border: "0",
+    ...style,
+  };
+
+  return (
+    <div
+      aria-live={live}
+      aria-atomic={isAtomic}
+      aria-relevant={ariaRelevant}
+      role={computedRole}
+      className={`sr-only ${className}`.trim()}
+      style={srOnlyStyle}
+      data-testid="live-region"
+    >
+      {message ?? children}
+    </div>
+  );
+}
+
+export default LiveRegion;


### PR DESCRIPTION
## Overview
This PR adds SR-announce state changes on `WalletBadge` via an `aria-live` region (`LiveRegion` component) for WCAG 2.1 AA accessibility.

## Related Issue
Closes #1071

## Changes
- [ADD] `src/components/LiveRegion.tsx` — Accessible ARIA live region component (`polite`/`assertive`, `sr-only`).
- [ADD] `app/WalletBadge.tsx` — Wallet badge status component announcing state transitions to screen readers.
- [ADD] `src/components/LiveRegion.test.tsx` & `app/WalletBadge.test.tsx` — Comprehensive unit test coverage for ARIA attributes, politeness levels, state transitions, and user interactions.
- [ADD] Re-exports in `app/components/LiveRegion.tsx` and `app/components/WalletBadge.tsx` for flexible import resolution.

## Verification
```bash
npm test -- src/components/LiveRegion.test.tsx app/WalletBadge.test.tsx
```
✅ 12/12 passed  
Live acceptance check:  
✅ Default polite `aria-live` status updates  
✅ State transition announcements (connecting, connected with address/network/balance, disconnecting, error)  
✅ Keyboard accessibility (Enter/Space triggers connect)  
✅ ESLint: 0 errors
