### PR TITLE
fix: StreamTypeChip tabular-nums

### DIFF
--- a/app/StreamTypeChip.test.tsx
+++ b/app/StreamTypeChip.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StreamTypeChip from './StreamTypeChip';
+import '@testing-library/jest-dom';
+
+describe('StreamTypeChip', () => {
+  it('renders the type and amount correctly', () => {
+    render(<StreamTypeChip type="Video" amount={12345} />);
+    
+    expect(screen.getByText('Video')).toBeInTheDocument();
+    expect(screen.getByText('12345')).toBeInTheDocument();
+  });
+
+  it('applies the tabular-nums class for tabular numerals', () => {
+    render(<StreamTypeChip type="Audio" amount={67890} />);
+    
+    const amountElement = screen.getByText('67890');
+    expect(amountElement).toHaveClass('tabular-nums');
+  });
+});

--- a/app/StreamTypeChip.tsx
+++ b/app/StreamTypeChip.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import '../src/styles/typography.css'; // Adjust path if needed
+
+/**
+ * StreamTypeChip component.
+ * Displays a stream type and an amount using tabular figures for better alignment.
+ * 
+ * @param {string} type - The type of stream.
+ * @param {number} amount - The amount associated with the stream.
+ */
+export interface StreamTypeChipProps {
+  type: string;
+  amount: number;
+}
+
+export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) => {
+  return (
+    <div className="stream-type-chip" style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+      <span className="type" style={{ fontWeight: 'bold' }}>{type}</span>
+      <span className="amount tabular-nums" style={{ fontVariantNumeric: 'tabular-nums' }}>
+        {amount}
+      </span>
+    </div>
+  );
+};
+
+export default StreamTypeChip;

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,6 @@
+/* Typography Styles */
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+  font-family: monospace; /* For fallback */
+}


### PR DESCRIPTION
Closes #1087 

Description
This PR addresses the issue with StreamTypeChip where amounts were not aligned properly due to proportional numerals. It introduces tabular numeral styling to the stream amounts for better readability and consistent alignment.

Changes Made
Created app/StreamTypeChip.tsx component which displays a stream's type and amount side-by-side.
Added src/styles/typography.css with a .tabular-nums utility class that enforces font-variant-numeric: tabular-nums.
Created focused tests in app/StreamTypeChip.test.tsx ensuring that the component mounts correctly and the .tabular-nums class is accurately applied.