### PR TITLE
Task/auth/wallet cursor v7

### DIFF
--- a/app/api/auth/wallet/route.test.ts
+++ b/app/api/auth/wallet/route.test.ts
@@ -1,4 +1,4 @@
-import { GET, POST } from "./route";
+import { GET, POST, resetWalletChallengeStoreForTesting } from "./route";
 import { resetRateLimitStore } from "@/app/lib/rate-limit-store";
 
 jest.mock("next/server", () => ({
@@ -67,6 +67,7 @@ function detailFields(res: unknown): string[] {
 
 beforeEach(() => {
   resetRateLimitStore();
+  resetWalletChallengeStoreForTesting();
 });
 
 describe("GET /api/auth/wallet", () => {
@@ -84,6 +85,46 @@ describe("GET /api/auth/wallet", () => {
     const body = (res as any).body;
     expect(body.error.code).toBe("VALIDATION_ERROR");
     expect(detailFields(res)).toEqual(["address"]);
+  });
+
+  it("returns paginated challenge records ordered by created_at and id", async () => {
+    await GET(makeGetRequest({ address: VALID_ADDRESS }));
+    await GET(makeGetRequest({ address: VALID_ADDRESS }));
+    await GET(makeGetRequest({ address: VALID_ADDRESS }));
+
+    const firstPage = await GET(
+      makeGetRequest({ address: VALID_ADDRESS, limit: "2" }),
+    );
+
+    expect(firstPage.status).toBe(200);
+    const firstBody = (firstPage as any).body;
+    expect(firstBody.data).toHaveLength(2);
+    expect(firstBody.meta.hasNext).toBe(true);
+    expect(firstBody.meta.nextCursor).toBeTruthy();
+    expect(firstBody.data[0].created_at.localeCompare(firstBody.data[1].created_at)).toBeLessThanOrEqual(0);
+
+    const secondPage = await GET(
+      makeGetRequest({
+        address: VALID_ADDRESS,
+        limit: "2",
+        cursor: firstBody.meta.nextCursor,
+      }),
+    );
+
+    expect(secondPage.status).toBe(200);
+    const secondBody = (secondPage as any).body;
+    expect(secondBody.data).toHaveLength(1);
+    expect(secondBody.meta.hasNext).toBe(false);
+    expect(secondBody.meta.nextCursor).toBeNull();
+  });
+
+  it("returns 422 for a malformed cursor", async () => {
+    const res = await GET(
+      makeGetRequest({ address: VALID_ADDRESS, limit: "2", cursor: "not-a-cursor" }),
+    );
+
+    expect(res.status).toBe(422);
+    expect((res as any).body.error.code).toBe("INVALID_CURSOR");
   });
 
   it("returns 422 when address has the right shape but a bad checksum", async () => {

--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { decodeCompositeCursor, encodeCompositeCursor } from "@/app/lib/db";
 import { errorResponse, ErrorCode } from "@/app/lib/errors/server";
 import { validateCsrfToken } from "@/app/lib/auth";
 import { checkIpRateLimit, rateLimitResponse } from "@/lib/rateLimitIp";
@@ -8,6 +9,70 @@ import {
   validateWalletVerifyBody,
 } from "@/app/lib/auth-wallet-validation";
 import type { ValidationError } from "@/app/lib/stream-validation";
+
+interface WalletChallengeRecord {
+  id: string;
+  address: string;
+  challenge: string;
+  created_at: string;
+  expires_at: string;
+}
+
+const walletChallengeStore: WalletChallengeRecord[] = [];
+
+function createWalletChallengeRecord(address: string, challenge: string, expiresAt: string): WalletChallengeRecord {
+  return {
+    id: `wallet-challenge-${walletChallengeStore.length + 1}`,
+    address,
+    challenge,
+    created_at: new Date().toISOString(),
+    expires_at: expiresAt,
+  };
+}
+
+function compareWalletChallengeRecords(left: WalletChallengeRecord, right: WalletChallengeRecord): number {
+  const createdAtCompare = left.created_at.localeCompare(right.created_at);
+  if (createdAtCompare !== 0) return createdAtCompare;
+  return left.id.localeCompare(right.id);
+}
+
+function createCursor(record: WalletChallengeRecord): string {
+  return encodeCompositeCursor(record.created_at, record.id);
+}
+
+function getWalletChallengePage(address: string | null, cursor: string | null, limit: number) {
+  const filtered = walletChallengeStore
+    .filter((record) => !address || record.address === address)
+    .sort(compareWalletChallengeRecords);
+
+  let startIndex = 0;
+  if (cursor) {
+    try {
+      const decoded = decodeCompositeCursor(cursor);
+      startIndex = filtered.findIndex(
+        (record) => record.created_at === decoded.timestamp && record.id === decoded.id,
+      );
+      if (startIndex >= 0) {
+        startIndex += 1;
+      } else {
+        startIndex = filtered.findIndex((record) => record.created_at > decoded.timestamp || (record.created_at === decoded.timestamp && record.id > decoded.id));
+        if (startIndex < 0) startIndex = filtered.length;
+      }
+    } catch {
+      throw new Error("INVALID_CURSOR");
+    }
+  }
+
+  const paginated = filtered.slice(startIndex, startIndex + limit);
+  const hasNext = startIndex + paginated.length < filtered.length;
+  const nextCursor = hasNext && paginated.length > 0 ? createCursor(paginated[paginated.length - 1]) : null;
+
+  return { data: paginated, meta: { hasNext, nextCursor, total: filtered.length } };
+}
+
+export function resetWalletChallengeStoreForTesting(): void {
+  walletChallengeStore.length = 0;
+}
 
 /** 422 envelope with per-field details, matching /api/streams. */
 function validationErrorResponse(logMessage: string, errors: ValidationError[]) {
@@ -38,6 +103,46 @@ export async function GET(req: NextRequest) {
 
   try {
     const address = req.nextUrl.searchParams.get("address");
+    const cursor = req.nextUrl.searchParams.get("cursor");
+    const limitParam = req.nextUrl.searchParams.get("limit");
+
+    if (cursor || limitParam) {
+      let limit = 20;
+      if (limitParam) {
+        const parsed = Number.parseInt(limitParam, 10);
+        if (!Number.isNaN(parsed) && parsed > 0) {
+          limit = Math.min(parsed, 100);
+        }
+      }
+
+      try {
+        const page = getWalletChallengePage(address, cursor, limit);
+        logger.info("Wallet challenges listed successfully", {
+          count: page.data.length,
+          total: page.meta.total,
+          hasNext: page.meta.hasNext,
+        });
+        return NextResponse.json(
+          {
+            data: page.data,
+            meta: page.meta,
+            links: { self: `/api/auth/wallet?limit=${limit}` },
+          },
+          { status: 200 },
+        );
+      } catch {
+        return NextResponse.json(
+          {
+            error: {
+              code: "INVALID_CURSOR",
+              message: "Malformed cursor",
+              request_id: getCorrelationContext()?.request_id,
+            },
+          },
+          { status: 422 },
+        );
+      }
+    }
 
     const validationErrors = validateWalletChallengeQuery({
       address: address ?? undefined,
@@ -51,6 +156,8 @@ export async function GET(req: NextRequest) {
 
     const challenge = `streampay_auth_${Date.now()}_${Math.random().toString(36).slice(2)}`;
     const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    const record = createWalletChallengeRecord(address!, challenge, expiresAt);
+    walletChallengeStore.push(record);
 
     return NextResponse.json({ challenge, expires_at: expiresAt }, { status: 200 });
   } catch {

--- a/docs/api/auth-wallet.md
+++ b/docs/api/auth-wallet.md
@@ -6,11 +6,13 @@ other processing.
 
 ## GET /api/auth/wallet
 
-Issues a one-time challenge for wallet-based authentication.
+Issues a one-time challenge for wallet-based authentication. When `limit` or `cursor` is supplied, the endpoint instead returns a paginated list of previously issued wallet challenges ordered by `(created_at, id)` for stable navigation.
 
 | Query param | Rules |
 | ----------- | ----- |
-| `address`   | Required. Stellar public key, checksum-validated (strkey), not just shape. |
+| `address`   | Required for challenge issuance. Stellar public key, checksum-validated (strkey), not just shape. |
+| `limit`     | Optional for pagination. Defaults to `20`, capped at `100`. |
+| `cursor`    | Optional for pagination. Must be a valid composite cursor encoding `(created_at,id)`. |
 
 ## POST /api/auth/wallet
 

--- a/tests/integration/streams.test.ts
+++ b/tests/integration/streams.test.ts
@@ -1,0 +1,142 @@
+// Integration coverage for the public stream creation/listing route using the
+// real route handlers and the in-memory persistence layer used in tests.
+import { NextRequest } from "next/server";
+import { GET as getStreams, POST as createStream } from "@/app/api/streams/route";
+import { resetDb } from "@/app/lib/db";
+import {
+  InMemoryRateLimitStore,
+  resetRateLimitStore,
+  setRateLimitStore,
+} from "@/app/lib/rate-limit-store";
+import { _resetAllowlistForTesting } from "@/app/lib/token-allowlist";
+
+const VALID_STELLAR_KEY =
+  "GDSBCG3OKHCMMWS5EBH2X7XOYTJRWXN2YYQPCNS5OFBU4IDO4X7OFSQA";
+
+function makeRequest(path: string, init?: RequestInit): NextRequest {
+  return new NextRequest(`http://localhost${path}`, init);
+}
+
+describe("streams API integration", () => {
+  let rateLimitStore: InMemoryRateLimitStore;
+
+  beforeEach(() => {
+    resetDb();
+    _resetAllowlistForTesting();
+    rateLimitStore = new InMemoryRateLimitStore(10_000);
+    setRateLimitStore(rateLimitStore);
+  });
+
+  afterEach(() => {
+    rateLimitStore.destroy();
+    resetRateLimitStore();
+  });
+
+  it("lists streams and then exposes a newly created stream", async () => {
+    const initialResponse = await getStreams(makeRequest("/api/streams"));
+
+    expect(initialResponse.status).toBe(200);
+    const initialBody = await initialResponse.json();
+    expect(initialBody).toEqual(
+      expect.objectContaining({
+        links: { self: "/api/v1/streams?limit=20" },
+      }),
+    );
+    expect(Array.isArray(initialBody.data)).toBe(true);
+    expect(initialBody.meta).toEqual(
+      expect.objectContaining({
+        hasNext: false,
+        nextCursor: null,
+      }),
+    );
+
+    const createResponse = await createStream(
+      makeRequest("/api/streams", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          rate: "50",
+          recipient: VALID_STELLAR_KEY,
+          schedule: "month",
+        }),
+      }),
+    );
+
+    expect(createResponse.status).toBe(201);
+    const createBody = await createResponse.json();
+    expect(createBody).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: expect.stringMatching(/^stream-/),
+          recipient: VALID_STELLAR_KEY,
+          status: "draft",
+          token: "XLM",
+        }),
+        links: { self: expect.stringContaining("/api/v1/streams/") },
+      }),
+    );
+
+    const listResponse = await getStreams(makeRequest("/api/streams"));
+    expect(listResponse.status).toBe(200);
+    const listBody = await listResponse.json();
+    expect(listBody.meta.total).toBeGreaterThan(0);
+    expect(listBody.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: createBody.data.id,
+          recipient: VALID_STELLAR_KEY,
+          status: "draft",
+        }),
+      ]),
+    );
+  });
+
+  it("returns the canonical validation error envelope for invalid stream payloads", async () => {
+    const response = await createStream(
+      makeRequest("/api/streams", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ recipient: "not-a-stellar-key", rate: "0", schedule: "invalid" }),
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: "VALIDATION_ERROR",
+          message: "One or more fields are invalid.",
+        }),
+      }),
+    );
+    expect(Array.isArray(body.error.details)).toBe(true);
+    expect(body.error.details.length).toBeGreaterThan(0);
+    expect(body.error.details[0]).toEqual(
+      expect.objectContaining({
+        field: expect.any(String),
+        code: expect.any(String),
+        message: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns a 400 error envelope when the request body is not valid JSON", async () => {
+    const response = await createStream(
+      makeRequest("/api/streams", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Request body must be valid JSON",
+      },
+    });
+  });
+});


### PR DESCRIPTION
# feat: cursor pagination /api/auth/wallet

## Summary
- Added cursor-based pagination for GET /api/auth/wallet using a composite cursor over $(created\_at, id)$ for stable ordering
- Preserved the existing challenge issuance behavior while supporting paginated challenge history retrieval
- Added focused route tests for pagination, malformed cursor handling, and existing validation behavior
- Documented the new query parameters and pagination semantics in the wallet auth API docs

## Testing
- npm test -- --runInBand route.test.ts
- npx eslint route.ts route.test.ts
Closes: #1101 