### PR TITLE
fix: StreamRow focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
 - The streams list now surfaces a distinct filtered-results empty state when the
   current view has no matches, with clearer guidance to clear filters and return
   to the broader streams list.
+- `StreamRow` now uses the shared keyboard focus-visible layer for its action
+  button, so the focus outline only appears for keyboard-style navigation and
+  stays consistent across themes.
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/components/StreamRow.test.tsx
+++ b/app/components/StreamRow.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StreamRow, type StreamRowData } from "./StreamRow";
 import type { StreamStatus } from "@/app/types/openapi";
@@ -47,33 +47,16 @@ describe("StreamRow", () => {
     expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
   });
 
-  it("applies a consistent visible focus ring style when the action button is focused", () => {
+  it("lets the action button receive focus without inline focus styling", () => {
     render(<StreamRow stream={baseStream} />);
     const actionButton = screen.getByRole("button", { name: "Pause" });
 
-    // Initial state: not focused, should not have the custom outline styles
-    expect(actionButton).not.toHaveStyle({ outline: "2px solid var(--accent)" });
+    expect(actionButton).not.toHaveAttribute("style");
 
-    // Focus the button
-    act(() => {
-      actionButton.focus();
-      fireEvent.focus(actionButton);
-    });
+    actionButton.focus();
+
     expect(actionButton).toHaveFocus();
-
-    // Verify it applies the correct design-token outline style for visual consistency
-    expect(actionButton).toHaveStyle({
-      outline: "2px solid var(--accent)",
-      outlineOffset: "2px",
-    });
-
-    // Blur the button
-    act(() => {
-      actionButton.blur();
-      fireEvent.blur(actionButton);
-    });
-    expect(actionButton).not.toHaveFocus();
-    expect(actionButton).not.toHaveStyle({ outline: "2px solid var(--accent)" });
+    expect(actionButton).not.toHaveAttribute("style");
   });
 
   describe("color-blind safe pattern overlay (v7)", () => {

--- a/app/components/StreamRow.tsx
+++ b/app/components/StreamRow.tsx
@@ -44,7 +44,6 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
   const [errorMsg, setErrorMsg] = useState("");
   // Local notification state for polite screen reader announcements (#219)
   const [srAnnouncement, setSrAnnouncement] = useState("");
-  const [isFocused, setIsFocused] = useState(false);
 
   // Ref hook to preserve active keyboard focus target parameters across button re-renders
   const actionButtonRef = useRef<HTMLButtonElement>(null);
@@ -198,13 +197,6 @@ export function StreamRow({ stream, density = "cozy" }: StreamRowProps) {
           className={`button button--secondary stream-row__action ${isProcessing ? "button--busy" : ""}`}
           type="button"
           onClick={handleAction}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          style={
-            isFocused
-              ? { outline: "2px solid var(--accent)", outlineOffset: "2px" }
-              : undefined
-          }
           disabled={isProcessing || isIncidentMode}
           aria-busy={isProcessing}
           aria-live="assertive"

--- a/app/styles/focus.css
+++ b/app/styles/focus.css
@@ -11,6 +11,7 @@
     [role="button"],
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
+    .stream-row__action,
     .stream-progress__track
   ):focus-visible {
     outline: 2px solid var(--accent);
@@ -29,6 +30,7 @@
     [role="button"],
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
+    .stream-row__action,
     .stream-progress__track
   ):focus:not(:focus-visible) {
     outline: none;

--- a/app/styles/focus.css.test.tsx
+++ b/app/styles/focus.css.test.tsx
@@ -22,9 +22,14 @@ describe("shared focus-visible layer", () => {
     expect(styleText).toContain(".stream-progress__track");
   });
 
+  it("includes the StreamRow action button in the keyboard-visible focus layer", () => {
+    expect(styleText).toContain(".stream-row__action");
+  });
+
   it("hides the outline again for mouse/touch focus on the StreamProgress track", () => {
     const suppressionRule = styleText.split(":focus-visible {")[1] ?? "";
     expect(suppressionRule).toContain(".stream-progress__track");
+    expect(suppressionRule).toContain(".stream-row__action");
     expect(styleText).toContain(":focus:not(:focus-visible)");
   });
 });


### PR DESCRIPTION
# Title: fix: StreamRow focus

## Summary
Adds a shared keyboard-only focus-visible outline to StreamRow’s action button so the visible ring is consistent across themes and only appears for keyboard navigation.

## Changes
- Removed the StreamRow-specific inline focus ring state from [app/components/StreamRow.tsx](app/components/StreamRow.tsx)
- Added `.stream-row__action` to the shared focus-visible layer in [app/styles/focus.css](app/styles/focus.css)
- Updated focused coverage in [app/components/StreamRow.test.tsx](app/components/StreamRow.test.tsx) and [app/styles/focus.css.test.tsx](app/styles/focus.css.test.tsx)
- Documented the visible behavior change in [CHANGELOG.md](CHANGELOG.md)

## Verification
- `npm test -- --runInBand app/components/StreamRow.test.tsx app/styles/focus.css.test.tsx`
- `npx eslint app/components/StreamRow.tsx app/components/StreamRow.test.tsx app/styles/focus.css.test.tsx`

Closes: #1036