### PR TITLE
fix: StreamTypeChip responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
 - The streams list now surfaces a distinct filtered-results empty state when the
   current view has no matches, with clearer guidance to clear filters and return
   to the broader streams list.
+- `StreamTypeChip` now stacks its label and amount on narrow viewports and
+  switches to a horizontal layout at `30rem` and up, keeping the chip readable
+  without overflow while preserving the wide-screen presentation.
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/StreamTypeChip.module.css
+++ b/app/StreamTypeChip.module.css
@@ -1,0 +1,29 @@
+.streamTypeChip {
+  align-items: flex-start;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  max-width: 100%;
+}
+
+.type {
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.amount {
+  line-height: 1.2;
+}
+
+@media (min-width: 30rem) {
+  .streamTypeChip {
+    align-items: center;
+    flex-direction: row;
+    gap: 0.5rem;
+  }
+
+  .type,
+  .amount {
+    white-space: nowrap;
+  }
+}

--- a/app/StreamTypeChip.test.tsx
+++ b/app/StreamTypeChip.test.tsx
@@ -1,7 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
+import fs from 'fs';
+import path from 'path';
 import { render, screen } from '@testing-library/react';
 import StreamTypeChip from './StreamTypeChip';
 import '@testing-library/jest-dom';
+
+const styleText = fs.readFileSync(
+  path.join(__dirname, 'StreamTypeChip.module.css'),
+  'utf8'
+);
 
 describe('StreamTypeChip', () => {
   it('renders the type and amount correctly', () => {
@@ -9,6 +20,13 @@ describe('StreamTypeChip', () => {
     
     expect(screen.getByText('Video')).toBeInTheDocument();
     expect(screen.getByText('12345')).toBeInTheDocument();
+  });
+
+  it('uses a stacked layout on narrow viewports and a row layout above the breakpoint', () => {
+    expect(styleText).toContain('.streamTypeChip');
+    expect(styleText).toContain('flex-direction: column');
+    expect(styleText).toContain('@media (min-width: 30rem)');
+    expect(styleText).toContain('flex-direction: row');
   });
 
   it('applies the tabular-nums class for tabular numerals', () => {

--- a/app/StreamTypeChip.tsx
+++ b/app/StreamTypeChip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../src/styles/typography.css'; // Adjust path if needed
+import styles from './StreamTypeChip.module.css';
 
 /**
  * StreamTypeChip component.
@@ -15,9 +16,9 @@ export interface StreamTypeChipProps {
 
 export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) => {
   return (
-    <div className="stream-type-chip" style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-      <span className="type" style={{ fontWeight: 'bold' }}>{type}</span>
-      <span className="amount tabular-nums" style={{ fontVariantNumeric: 'tabular-nums' }}>
+    <div className={styles.streamTypeChip}>
+      <span className={styles.type}>{type}</span>
+      <span className={`tabular-nums ${styles.amount}`}>
         {amount}
       </span>
     </div>


### PR DESCRIPTION
# Title: fix: StreamTypeChip responsive

## Summary
Updates `StreamTypeChip` to audit narrow and wide viewport behavior and switch its layout at a responsive breakpoint so the chip stays readable without overflow on small screens.

## Changes
- Moved `StreamTypeChip` layout into a scoped stylesheet in [app/StreamTypeChip.module.css](app/StreamTypeChip.module.css)
- Default layout now stacks label and amount on narrow viewports
- Added a `30rem` breakpoint that switches the chip back to a horizontal layout on wider screens
- Kept tabular numeral formatting for the amount value
- Added focused tests in [app/StreamTypeChip.test.tsx](app/StreamTypeChip.test.tsx)
- Documented the visible layout change in [CHANGELOG.md](CHANGELOG.md)

## Verification
- `npm test -- --runInBand app/StreamTypeChip.test.tsx`
- `npx eslint app/StreamTypeChip.tsx app/StreamTypeChip.test.tsx`

Closes: #1082