### PR TITLE
feat: Receipt loading skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
 - The streams list now surfaces a distinct filtered-results empty state when the
   current view has no matches, with clearer guidance to clear filters and return
   to the broader streams list.
+- The receipt route loading UI now uses the shared `Skeleton` component for the
+  first paint state, preserving the receipt shell layout while the server data
+  resolves.
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/globals.css
+++ b/app/globals.css
@@ -2084,6 +2084,48 @@ a:hover {
   gap: 0.75rem;
 }
 
+.receipt-loading__doc {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.receipt-loading__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.receipt-loading__brand {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.receipt-loading__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.receipt-loading__identity-row {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.receipt-loading__field-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.receipt-loading__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.receipt-loading__textarea {
+  border-radius: 0.5rem;
+  height: 6rem;
+}
+
 .receipt-share-btn {
   align-items: center;
   background: transparent;

--- a/app/streams/[id]/receipt/loading.test.tsx
+++ b/app/streams/[id]/receipt/loading.test.tsx
@@ -23,6 +23,15 @@ describe("ReceiptLoading", () => {
     expect(buttons.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("uses themed skeleton variants for the receipt header and fields", () => {
+    const { container } = render(<ReceiptLoading />);
+
+    expect(container.querySelector(".skeleton--title")).toBeInTheDocument();
+    expect(container.querySelector(".skeleton--text")).toBeInTheDocument();
+    expect(container.querySelector(".skeleton--badge")).toBeInTheDocument();
+    expect(container.querySelector(".skeleton--value")).toBeInTheDocument();
+  });
+
   it("renders skeleton fields for the receipt document", () => {
     const { container } = render(<ReceiptLoading />);
     const skeletons = container.querySelectorAll(".skeleton");

--- a/app/streams/[id]/receipt/loading.tsx
+++ b/app/streams/[id]/receipt/loading.tsx
@@ -7,11 +7,13 @@
  * shift when the real document swaps in.
  */
 
+import { Skeleton } from "../../../components/Skeleton";
+
 function SkeletonField() {
   return (
-    <div style={{ display: "grid", gap: "0.35rem" }}>
-      <div className="skeleton skeleton--label" />
-      <div className="skeleton skeleton--value" />
+    <div className="receipt-loading__field">
+      <Skeleton variant="label" width="5rem" />
+      <Skeleton variant="value" width="12rem" />
     </div>
   );
 }
@@ -22,55 +24,45 @@ export default function ReceiptLoading() {
       {/* Toolbar skeleton */}
       <div className="receipt-toolbar no-print">
         <div className="receipt-note-builder__actions">
-          <div className="skeleton skeleton--button" />
-          <div
-            className="skeleton skeleton--button"
-            style={{ width: "5rem" }}
-          />
+          <Skeleton variant="button" />
+          <Skeleton variant="button" width="5rem" />
         </div>
       </div>
 
       {/* Note-builder skeleton */}
-      <div className="receipt-note-builder no-print" style={{ display: "grid", gap: "0.5rem" }}>
-        <div className="skeleton skeleton--label" />
-        <div
-          className="skeleton"
-          style={{ borderRadius: "0.5rem", height: "6rem" }}
-        />
+      <div className="receipt-note-builder receipt-loading__note-builder no-print">
+        <Skeleton variant="label" width="6rem" />
+        <Skeleton className="receipt-loading__textarea" height="6rem" />
       </div>
 
       {/* Receipt document skeleton */}
-      <article
-        aria-hidden="true"
-        className="receipt-doc"
-        style={{ display: "grid", gap: "1.5rem" }}
-      >
+      <article aria-hidden="true" className="receipt-doc receipt-loading__doc">
         {/* Header */}
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <div style={{ display: "grid", gap: "0.5rem" }}>
-            <div className="skeleton skeleton--title" style={{ width: "7rem" }} />
-            <div className="skeleton skeleton--text" style={{ width: "12rem" }} />
+        <div className="receipt-loading__header">
+          <div className="receipt-loading__brand">
+            <Skeleton variant="title" width="7rem" />
+            <Skeleton variant="text" width="12rem" />
           </div>
-          <div className="skeleton skeleton--badge" />
+          <Skeleton variant="badge" />
         </div>
 
         <div className="receipt-divider" />
 
         {/* Stream identity */}
-        <div style={{ display: "grid", gap: "0.75rem" }}>
-          <div className="skeleton skeleton--title" style={{ width: "9rem" }} />
-          <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-            <div className="skeleton skeleton--value" style={{ width: "11rem" }} />
-            <div className="skeleton skeleton--badge" style={{ width: "4.5rem" }} />
+        <div className="receipt-loading__section">
+          <Skeleton variant="title" width="9rem" />
+          <div className="receipt-loading__identity-row">
+            <Skeleton variant="value" width="11rem" />
+            <Skeleton variant="badge" width="4.5rem" />
           </div>
         </div>
 
         <div className="receipt-divider" />
 
         {/* Recipient section */}
-        <div style={{ display: "grid", gap: "1rem" }}>
-          <div className="skeleton skeleton--title" style={{ width: "6rem" }} />
-          <div style={{ display: "grid", gap: "0.75rem" }}>
+        <div className="receipt-loading__section">
+          <Skeleton variant="title" width="6rem" />
+          <div className="receipt-loading__field-stack">
             <SkeletonField />
             <SkeletonField />
           </div>
@@ -79,9 +71,9 @@ export default function ReceiptLoading() {
         <div className="receipt-divider" />
 
         {/* Payment details section */}
-        <div style={{ display: "grid", gap: "1rem" }}>
-          <div className="skeleton skeleton--title" style={{ width: "9rem" }} />
-          <div style={{ display: "grid", gap: "0.75rem" }}>
+        <div className="receipt-loading__section">
+          <Skeleton variant="title" width="9rem" />
+          <div className="receipt-loading__field-stack">
             <SkeletonField />
             <SkeletonField />
             <SkeletonField />


### PR DESCRIPTION
# Title: feat: Receipt loading skeleton

Implemented a themed first-paint loading state for the receipt route using the shared Skeleton component, so the receipt shell renders consistently while server data loads.

Changes:
- Replaced the receipt loading placeholders with shared Skeleton variants in loading.tsx
- Added receipt-loading layout styles to keep the skeleton aligned with the real receipt structure in globals.css
- Expanded the loading test to verify the themed skeleton variants and receipt structure in loading.test.tsx
- Documented the visible loading-state change in CHANGELOG.md

Verification:
- npx jest --runInBand --runTestsByPath loading.test.tsx
- npx eslint loading.tsx loading.test.tsx

Closes: #1063