### PR TITLE
fix: StreamProgress color-blind patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
 - The streams list now surfaces a distinct filtered-results empty state when the
   current view has no matches, with clearer guidance to clear filters and return
   to the broader streams list.
+- `StreamProgress` now emits shared color-blind pattern classes on its fill so
+  stream state remains distinguishable beyond color alone.
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -59,6 +59,31 @@ describe("StreamProgress reduced-motion fallback", () => {
   });
 });
 
+describe("StreamProgress color-blind safe patterns", () => {
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it.each([
+    ["active", "cb-pattern--active"],
+    ["paused", "cb-pattern--paused"],
+    ["draft", "cb-pattern--draft"],
+    ["ended", "cb-pattern--ended"],
+    ["withdrawn", "cb-pattern--ended"],
+    ["cancelled", "cb-pattern--cancelled"],
+  ] as const)("applies the %s fill texture class", (status, patternClass) => {
+    mockMatchMedia(false);
+    const { container } = render(
+      <StreamProgress status={status} accruedAmount={50} totalAmount={100} />
+    );
+
+    const fill = container.querySelector(".stream-progress__fill");
+    expect(fill).toHaveClass("cb-pattern");
+    expect(fill).toHaveClass(patternClass);
+  });
+});
+
 describe("StreamProgress keyboard focus", () => {
   afterEach(() => {
     // @ts-expect-error reset between tests

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -204,7 +204,7 @@ export function StreamProgress({
       >
         {/* Fill — transitions width unless reduced motion is requested. */}
         <div
-          className={`stream-progress__fill stream-progress__fill--${modifier}`}
+          className={`stream-progress__fill stream-progress__fill--${modifier} cb-pattern cb-pattern--${modifier}`}
           style={{
             width: `${percent}%`,
             transition: prefersReducedMotion ? "none" : "width 400ms ease",

--- a/app/styles/patterns.css.test.tsx
+++ b/app/styles/patterns.css.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import fs from "fs";
+import path from "path";
+
+const styleText = fs.readFileSync(path.join(__dirname, "patterns.css"), "utf8");
+
+describe("shared color-blind pattern layer", () => {
+  it("defines texture hooks for the StreamProgress fill", () => {
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern");
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern--active");
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern--paused");
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern--ended");
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern--cancelled");
+    expect(styleText).toContain(".stream-progress__fill.cb-pattern--draft");
+  });
+
+  it("keeps the pattern textures layered under the fill color", () => {
+    expect(styleText).toContain("background-image:\n      var(--cb-pattern-active),");
+    expect(styleText).toContain("background-blend-mode: multiply;");
+  });
+});


### PR DESCRIPTION
# Title: fix: StreamProgress color-blind patterns

Adds shared color-blind-safe pattern fills to `StreamProgress` so status remains distinguishable beyond color alone.

Changes:
- Added pattern classes to the `StreamProgress` fill in StreamProgress.tsx
- Added focused coverage in StreamProgress.test.tsx
- Added a stylesheet-level assertion for the shared pattern layer in patterns.css.test.tsx
- Documented the visible change in CHANGELOG.md

Verification:
- `npx jest --runInBand --runTestsByPath StreamProgress.test.tsx /workspaces/StreamPay-Frontend/app/styles/patterns.css.test.tsx`
- `npx eslint StreamProgress.tsx StreamProgress.test.tsx app/styles/patterns.css.test.tsx`

Closes: #1059