### PR TITLE
feat: ETag on /api/streams

### DIFF
--- a/app/api/streams/etag.test.ts
+++ b/app/api/streams/etag.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment node */
+
+import { GET as listStreams } from "@/app/api/streams/route";
+import { resetDb } from "@/app/lib/db";
+import { resetRateLimitStore } from "@/app/lib/rate-limit-store";
+
+describe("GET /api/streams ETag handling", () => {
+  beforeEach(() => {
+    resetDb();
+    resetRateLimitStore();
+  });
+
+  it("returns 200 with an ETag and cache-control headers on the first request", async () => {
+    const req = new Request("http://localhost/api/streams", { method: "GET" });
+
+    const res = await listStreams(req);
+    expect(res.status).toBe(200);
+
+    const etag = res.headers.get("etag");
+    expect(etag).toBeDefined();
+    expect(etag).toMatch(/^"[^"]+"$/);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+  });
+
+  it("returns 304 Not Modified when If-None-Match matches the current ETag", async () => {
+    const initialReq = new Request("http://localhost/api/streams", { method: "GET" });
+    const initialRes = await listStreams(initialReq);
+    const etag = initialRes.headers.get("etag");
+
+    expect(etag).toBeDefined();
+
+    const cachedReq = new Request("http://localhost/api/streams", {
+      method: "GET",
+      headers: { "If-None-Match": etag! },
+    });
+
+    const cachedRes = await listStreams(cachedReq);
+    expect(cachedRes.status).toBe(304);
+    expect(cachedRes.headers.get("etag")).toBe(etag);
+    expect(cachedRes.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    await expect(cachedRes.text()).resolves.toBe("");
+  });
+});

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -18,6 +18,7 @@ import {
   validateListStreamsQuery,
 } from "@/app/lib/stream-validation";
 import type { Stream } from "@/app/types/openapi";
+import { createCacheHeaders, createStrongEtag, isIfNoneMatchMatch } from "@/src/middleware/etag";
 
 function errorResponse(code: string, message: string, status: number) {
   return createErrorResponse(code, message, status);
@@ -111,16 +112,30 @@ export async function GET(request: Request) {
       ? encodeCursor(paginatedStreams[paginatedStreams.length - 1].id)
       : null;
 
+  const payload = {
+    data: paginatedStreams,
+    links: { self: `/api/v1/streams?limit=${limit}` },
+    meta: { hasNext, nextCursor, total: streams.length },
+  };
+  const etag = createStrongEtag(payload);
+
+  if (isIfNoneMatchMatch(etag, getHeader(request, "if-none-match"))) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: createCacheHeaders(etag),
+    });
+  }
+
   logger.info("Streams listed successfully", {
     count: paginatedStreams.length,
     total: streamRepository.streams.size,
   });
 
-  return NextResponse.json({
-    data: paginatedStreams,
-    links: { self: `/api/v1/streams?limit=${limit}` },
-    meta: { hasNext, nextCursor, total: streams.length },
-  });
+  const response = NextResponse.json(payload);
+  for (const [name, value] of Object.entries(createCacheHeaders(etag))) {
+    response.headers.set(name, value);
+  }
+  return response;
 }
 
 export async function POST(request: Request) {

--- a/docs/api-client-usage.md
+++ b/docs/api-client-usage.md
@@ -7,6 +7,8 @@ directly from React components.
 
 ## Basic GET
 
+`GET /api/streams` now returns an `ETag` header and supports `If-None-Match` revalidation. A matching request returns `304 Not Modified` without re-sending the full payload.
+
 ```ts
 import { get } from '@/lib/apiClient';
 

--- a/src/middleware/etag.ts
+++ b/src/middleware/etag.ts
@@ -1,0 +1,53 @@
+import { createHash } from "crypto";
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort((left, right) => left.localeCompare(right))
+      .reduce<Record<string, unknown>>((accumulator, key) => {
+        accumulator[key] = sortKeys((value as Record<string, unknown>)[key]);
+        return accumulator;
+      }, {});
+  }
+
+  return value;
+}
+
+export function createStrongEtag(value: unknown): string {
+  const canonical = JSON.stringify(sortKeys(value));
+  const hash = createHash("sha256").update(canonical).digest("hex");
+  return `"${hash}"`;
+}
+
+function normaliseEtagToken(token: string): string {
+  return token.trim().replace(/^W\//i, "");
+}
+
+export function isIfNoneMatchMatch(etag: string, ifNoneMatchHeader: string | null): boolean {
+  if (!ifNoneMatchHeader) {
+    return false;
+  }
+
+  const normalisedEtag = normaliseEtagToken(etag);
+  return ifNoneMatchHeader
+    .split(",")
+    .map((token) => token.trim())
+    .some((token) => {
+      if (token === "*") {
+        return true;
+      }
+
+      return normaliseEtagToken(token) === normalisedEtag;
+    });
+}
+
+export function createCacheHeaders(etag: string): Record<string, string> {
+  return {
+    etag,
+    "cache-control": "public, max-age=0, must-revalidate",
+  };
+}


### PR DESCRIPTION
# feat: ETag on /api/streams

Adds ETag support for GET /api/streams so clients can perform conditional requests with If-None-Match and receive 304 Not Modified responses when the list payload is unchanged.

## What changed

- Implemented ETag generation for the streams listing payload
- Added conditional revalidation support via If-None-Match
- Returned cache headers for clients to reuse cached responses safely
- Added focused regression tests covering 200 and 304 behavior
- Documented the new API behavior for consumers

## Verification

- Added and ran targeted tests for the new ETag behavior
- Verified existing stream-listing query validation tests still pass

Closes: #1090