### PR TITLE
Add v7 empty-state illustration to RecentRecipients on the create-str…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3899,6 +3899,34 @@ a:hover {
   }
 }
 
+/*
+ * Compact override for the generic-variant EmptyState rendered inline above
+ * the recipient address field when there are no recent recipients yet.
+ * Scoped to this class only so the shared .empty-state styles used by the
+ * streams list, contacts, and templates pages are unaffected.
+ */
+.recent-recipients-empty.empty-state {
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  gap: 0.5rem;
+}
+
+.recent-recipients-empty .empty-state__content {
+  gap: 0.35rem;
+}
+
+.recent-recipients-empty .empty-state__eyebrow {
+  font-size: 0.6875rem;
+}
+
+.recent-recipients-empty .empty-state__title {
+  font-size: 1rem;
+}
+
+.recent-recipients-empty .empty-state__description {
+  font-size: 0.8125rem;
+}
+
 /* =========================================================
    Help & FAQ page
    ========================================================= */

--- a/app/streams/new/components/RecentRecipients.test.tsx
+++ b/app/streams/new/components/RecentRecipients.test.tsx
@@ -88,11 +88,65 @@ describe("recentRecipients state module", () => {
 });
 
 describe("RecentRecipients component", () => {
-  it("renders nothing when there are no recent recipients", () => {
-    const { container } = render(
-      <RecentRecipients onSelect={jest.fn()} />
-    );
-    expect(container.firstChild).toBeNull();
+  describe("empty state (no recent recipients)", () => {
+    it("renders a themed empty state instead of nothing", () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+
+      expect(screen.getByText("Recent recipients")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "No recent recipients yet" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Addresses you send streams to will appear here for quick reuse next time."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("uses the generic EmptyState variant (no illustration) in this compact context", () => {
+      const { container } = render(<RecentRecipients onSelect={jest.fn()} />);
+
+      expect(container.querySelector(".empty-state__illustration")).toBeNull();
+      expect(container.querySelector("svg")).toBeNull();
+    });
+
+    it("applies the compact recent-recipients-empty class alongside any forwarded className", () => {
+      const { container } = render(
+        <RecentRecipients onSelect={jest.fn()} className="my-extra-class" />
+      );
+
+      const section = container.querySelector("section.empty-state")!;
+      expect(section).toHaveClass("recent-recipients-empty");
+      expect(section).toHaveClass("my-extra-class");
+    });
+
+    it("focuses the recipient address input when the CTA is activated", () => {
+      render(
+        <div>
+          <RecentRecipients onSelect={jest.fn()} />
+          <input id="recipient" />
+        </div>
+      );
+
+      const input = document.getElementById("recipient") as HTMLInputElement;
+      expect(input).not.toHaveFocus();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Enter an address" })
+      );
+
+      expect(input).toHaveFocus();
+    });
+
+    it("does not throw when the recipient input is not present in the DOM", () => {
+      render(<RecentRecipients onSelect={jest.fn()} />);
+
+      expect(() =>
+        fireEvent.click(
+          screen.getByRole("button", { name: "Enter an address" })
+        )
+      ).not.toThrow();
+    });
   });
 
   it("renders a pill for each recent recipient", async () => {

--- a/app/streams/new/components/RecentRecipients.tsx
+++ b/app/streams/new/components/RecentRecipients.tsx
@@ -5,6 +5,7 @@ import {
   getRecentRecipients,
   RecentRecipient,
 } from "../../../state/recentRecipients";
+import { EmptyState } from "../../../components/EmptyState";
 
 export interface RecentRecipientsProps {
   /** Called with the full address when the user clicks a recent-recipient pill. */
@@ -21,8 +22,9 @@ function truncateAddress(address: string, chars = 6): string {
 
 /**
  * RecentRecipients — quick-pick rail showing the last 6 addresses used in the
- * create-stream form.  Reads from localStorage on mount and renders nothing
- * when the list is empty (e.g. first-time users).
+ * create-stream form.  Reads from localStorage on mount and renders a themed
+ * empty state (v7 `EmptyState`, generic variant) for first-time users who
+ * have no recent addresses yet, with a CTA that focuses the address input.
  *
  * Accessibility
  * - Landmark-free; the outer `<div>` has an `aria-label` describing the region.
@@ -44,7 +46,21 @@ export function RecentRecipients({
     setRecipients(getRecentRecipients());
   }, []);
 
-  if (recipients.length === 0) return null;
+  if (recipients.length === 0) {
+    return (
+      <EmptyState
+        variant="generic"
+        eyebrow="Recent recipients"
+        title="No recent recipients yet"
+        description="Addresses you send streams to will appear here for quick reuse next time."
+        actionLabel="Enter an address"
+        onAction={() => {
+          document.getElementById("recipient")?.focus();
+        }}
+        className={`recent-recipients-empty${className ? ` ${className}` : ""}`}
+      />
+    );
+  }
 
   return (
     <div


### PR DESCRIPTION
Add empty-state illustration for CreateStreamForm (v7)

Implement a themed empty state on the CreateStreamForm component with a helpful call-to-action.

## Description

The issue's suggested file paths (`app/CreateStreamForm.tsx`, `src/components/EmptyState.tsx`) don't exist in this repo — the actual create-stream form is `app/streams/new/page.tsx`, and a fully-built v7 `EmptyState` system (with `EmptyIllustration`, generic/streams variants, guidance steps) already exists at `app/components/EmptyState.tsx`, used by the streams list, contacts, and templates pages.

The only genuinely empty-able piece of the create-stream form is `RecentRecipients` — it silently rendered `null` for first-time users with no recent addresses. This wires it up to the existing `EmptyState` system instead.

Closes #1045

## Changes

- **`app/streams/new/components/RecentRecipients.tsx`**: renders `EmptyState` (`variant="generic"`, no illustration — this is a compact inline rail, not a full list view) instead of `null` when there are no recent recipients. The CTA ("Enter an address") focuses the `#recipient` input on the same form.
- **`app/globals.css`**: added a `.recent-recipients-empty` override scoped to just this usage (reduced padding/font sizes to fit inline above a form field) so the shared `.empty-state` styles used elsewhere are unaffected.
- **`app/streams/new/components/RecentRecipients.test.tsx`**: replaced the now-obsolete "renders nothing" test with coverage for the empty-state content, the generic variant (no illustration/SVG), class forwarding, the focus-the-input CTA behavior, and that it doesn't throw when the input isn't present.

## Verification

`node node_modules/jest/bin/jest.js app/streams/new/components/RecentRecipients.test.tsx app/components/EmptyState.test.tsx app/streams/new/page.test.tsx` — 42 of 42 pass.

`tsc --noEmit` shows no errors in either touched file.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)