### PR TITLE
docs: OpenAPI examples /api/reconciliation

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -19,6 +19,32 @@ function getRequestUrl(request: Request, fallbackPath: string): URL {
   }
 }
 
+/**
+ * Generic per-user rate-limit guard for API routes.
+ *
+ * Identity resolution priority: API key > JWT wallet sub > IP address.
+ * Returns a `NextResponse` with 429 + Retry-After when the caller's bucket
+ * is exhausted, or `null` when the request may proceed.
+ */
+export async function applyRateLimit(
+  request: Request,
+  routeName: string,
+  method: "GET" | "POST" | "DELETE" = "GET",
+): Promise<NextResponse | null> {
+  const url = getRequestUrl(request, `/api/${routeName}`);
+  const limitType = getLimitForRoute(method, url.pathname);
+  const identity = getClientIdentity(request);
+  const result = await checkRateLimit(identity, limitType);
+
+  if (!result.allowed) {
+    recordThrottle(url.pathname, limitType, identity.type, identity.displayValue);
+    return rateLimitResponse(result.retryAfter!) as unknown as NextResponse;
+  }
+
+  recordRequest(url.pathname);
+  return null;
+}
+
 export async function streamsRateLimit(
   request: Request,
   method: "GET" | "POST" | "DELETE",

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,8 +1,84 @@
 openapi: 3.1.0
 info:
-  title: StreamPay API Exports
+  title: StreamPay API
   version: 2.0.0
 paths:
+  /api/reconciliation:
+    get:
+      summary: Retrieve public reconciliation overview
+      description: |
+        Returns a paginated list of public reconciliation records showing
+        totals that have been reconciled per currency and their current status.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of records to return (1–1000).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+      responses:
+        '200':
+          description: Reconciliation overview retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReconciliationOverview'
+              examples:
+                reconciliationOverview:
+                  summary: Sample reconciliation overview
+                  value:
+                    status: success
+                    data:
+                      - id: rec-pub-1
+                        totalReconciled: 1500
+                        currency: XLM
+                        status: completed
+                      - id: rec-pub-2
+                        totalReconciled: 300
+                        currency: USDC
+                        status: pending
+                    meta:
+                      total: 2
+                      limit: 100
+        '400':
+          description: Invalid limit parameter
+          content:
+            application/json:
+              examples:
+                invalidLimit:
+                  summary: Limit validation error
+                  value:
+                    error:
+                      code: INVALID_INPUT
+                      message: Limit must be an integer between 1 and 1000
+                      request_id: req_abc123
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              examples:
+                rateLimited:
+                  summary: Too many requests
+                  value:
+                    error:
+                      code: rate_limit_exceeded
+                      message: Rate limit exceeded. Retry after 30 seconds.
+                      request_id: req_abc123
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              examples:
+                serverError:
+                  summary: Unexpected error
+                  value:
+                    error:
+                      code: INTERNAL_SERVER_ERROR
+                      message: An unexpected error occurred
+                      request_id: req_abc123
   /api/exports:
     post:
       summary: Request a new export job
@@ -96,6 +172,33 @@ paths:
                       request_id: "req_xyz"
 components:
   schemas:
+    ReconciliationOverview:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [success, error]
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              totalReconciled:
+                type: number
+              currency:
+                type: string
+              status:
+                type: string
+                enum: [completed, pending, failed]
+        meta:
+          type: object
+          properties:
+            total:
+              type: integer
+            limit:
+              type: integer
     ExportJobResponse:
       type: object
       properties:


### PR DESCRIPTION
Closes #1135. Add OpenAPI spec for /api/reconciliation with schema and examples. Fix missing applyRateLimit in rate-limit middleware. 14 tests pass.