### PR TITLE
feat: StreamProgress empty state

### DIFF
--- a/app/components/EmptyState.test.tsx
+++ b/app/components/EmptyState.test.tsx
@@ -97,6 +97,17 @@ describe("EmptyState", () => {
       expect(container.querySelector("section.empty-state")).toHaveClass("empty-state--streams");
     });
 
+    it("stream-progress variant renders the StreamProgressEmptyIllustration inside .empty-state__illustration", () => {
+      const { container } = render(<EmptyState {...DEFAULT_PROPS} variant="stream-progress" />);
+      const wrap = container.querySelector(".empty-state__illustration");
+      expect(wrap).not.toBeNull();
+      expect(wrap).toHaveAttribute("aria-hidden", "true");
+      const svg = wrap!.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg!.innerHTML).toContain("var(--accent)");
+      expect(container.querySelector("section.empty-state")).toHaveClass("empty-state--stream-progress");
+    });
+
     it("generic variant omits the illustration entirely", () => {
       const { container } = render(<EmptyState {...DEFAULT_PROPS} variant="generic" />);
       expect(container.querySelector(".empty-state__illustration")).toBeNull();

--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
 import { EmptyIllustration } from "./EmptyIllustration";
+import { StreamProgressEmptyIllustration } from "./StreamProgressEmptyIllustration";
 
-export type EmptyStateVariant = "streams" | "generic";
+export type EmptyStateVariant = "streams" | "generic" | "stream-progress";
 
 type EmptyStateProps = {
   eyebrow: string;
@@ -19,8 +20,8 @@ type EmptyStateProps = {
   guidanceSteps?: readonly string[];
   /**
    * Visual variant. `"streams"` (default) renders the v7 StreamRow ghost-row
-   * SVG illustration; `"generic"` omits the illustration for narrower or
-   * non-list contexts.
+   * SVG illustration; `"stream-progress"` renders the themed StreamProgress empty SVG;
+   * `"generic"` omits the illustration for narrower or non-list contexts.
    */
   variant?: EmptyStateVariant;
   /** Arbitrary supporting content rendered between copy and the CTA. */
@@ -59,7 +60,7 @@ export function EmptyState({
   const hasSupporting = Boolean(children) || hasGuidance;
   const outerClass = [
     "empty-state",
-    variant === "streams" ? "empty-state--streams" : "",
+    variant === "streams" ? "empty-state--streams" : variant === "stream-progress" ? "empty-state--stream-progress" : "",
     className,
   ]
     .filter(Boolean)
@@ -70,6 +71,13 @@ export function EmptyState({
       {variant === "streams" ? (
         <div className="empty-state__illustration" aria-hidden="true">
           <EmptyIllustration
+            className="empty-state__illustration-svg"
+            decorative
+          />
+        </div>
+      ) : variant === "stream-progress" ? (
+        <div className="empty-state__illustration" aria-hidden="true">
+          <StreamProgressEmptyIllustration
             className="empty-state__illustration-svg"
             decorative
           />

--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StreamProgress } from "./StreamProgress";
 
@@ -255,5 +255,60 @@ describe("StreamProgress aria-live announcements", () => {
     const region = screen.getByTestId("stream-progress-live");
     expect(region).toHaveAttribute("aria-live", "polite");
     expect(region).toHaveAttribute("role", "status");
+  });
+});
+
+// ── Empty state tests ───────────────────────────────────────────────────────
+
+describe("StreamProgress empty state", () => {
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it("renders empty state when status is empty", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="empty" />);
+
+    expect(screen.getByText("Stream Progress")).toBeInTheDocument();
+    expect(screen.getByText("No active stream found")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "There is no stream progress to track. Start a stream to see live accumulation."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start a stream" })).toBeInTheDocument();
+  });
+
+  it("renders empty state when isEmpty prop is true", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" isEmpty={true} />);
+
+    expect(screen.getByText("Stream Progress")).toBeInTheDocument();
+    expect(screen.getByText("No active stream found")).toBeInTheDocument();
+  });
+
+  it("renders empty state with custom copy and handles action click", () => {
+    mockMatchMedia(false);
+    const onAction = jest.fn();
+    render(
+      <StreamProgress
+        status="empty"
+        emptyEyebrow="My Custom Eyebrow"
+        emptyTitle="My Custom Title"
+        emptyDescription="My Custom Description"
+        emptyActionLabel="My Custom Action"
+        onEmptyAction={onAction}
+      />
+    );
+
+    expect(screen.getByText("My Custom Eyebrow")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "My Custom Title" })).toBeInTheDocument();
+    expect(screen.getByText("My Custom Description")).toBeInTheDocument();
+
+    const button = screen.getByRole("button", { name: "My Custom Action" });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -33,6 +33,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { StreamStatus } from "@/app/types/openapi";
 import { LiveRegion } from "./LiveRegion";
+import { EmptyState } from "./EmptyState";
 
 // ── Reduced-motion ─────────────────────────────────────────────────────────────
 
@@ -74,7 +75,7 @@ function usePrefersReducedMotion(): boolean {
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface StreamProgressProps {
-  status: StreamStatus;
+  status: StreamStatus | "empty";
   /**
    * Amount already accrued / vested (raw units or display units — must be
    * consistent with `totalAmount`).
@@ -97,6 +98,18 @@ export interface StreamProgressProps {
   endsAt?: string;
   /** Optional CSS class forwarded to the wrapper element. */
   className?: string;
+  /** Optional flag to force the empty state visual. */
+  isEmpty?: boolean;
+  /** Optional custom copy eyebrow for the empty state */
+  emptyEyebrow?: string;
+  /** Optional custom copy title for the empty state */
+  emptyTitle?: string;
+  /** Optional custom copy description for the empty state */
+  emptyDescription?: string;
+  /** Optional custom copy action label for the empty state */
+  emptyActionLabel?: string;
+  /** Optional handler invoked when the empty state CTA button is pressed */
+  onEmptyAction?: () => void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -154,11 +167,12 @@ function derivePercent(props: StreamProgressProps): number {
 /**
  * Human-readable label for aria-valuetext and the visible percentage.
  */
-function deriveLabel(status: StreamStatus, percent: number): string {
+function deriveLabel(status: StreamStatus | "empty", percent: number): string {
   if (status === "draft")      return "Not started";
   if (status === "ended")      return "Completed";
   if (status === "withdrawn")  return "Withdrawn";
   if (status === "cancelled")  return "Cancelled";
+  if (status === "empty")      return "No stream";
   return `${Math.round(percent)}% accrued`;
 }
 
@@ -171,6 +185,12 @@ export function StreamProgress({
   startedAt,
   endsAt,
   className = "",
+  isEmpty = false,
+  emptyEyebrow,
+  emptyTitle,
+  emptyDescription,
+  emptyActionLabel,
+  onEmptyAction,
 }: StreamProgressProps) {
   const percent = derivePercent({ status, accruedAmount, totalAmount, startedAt, endsAt });
   const label   = deriveLabel(status, percent);
@@ -234,6 +254,24 @@ export function StreamProgress({
   // positioned instantly with no width transition. This is also exposed as a
   // modifier class so external CSS can opt out of any keyframe animations.
   const motionModifier = prefersReducedMotion ? "static" : "animated";
+
+  // Return empty state if status is "empty" or isEmpty is explicitly true
+  if (status === "empty" || isEmpty) {
+    return (
+      <EmptyState
+        eyebrow={emptyEyebrow ?? "Stream Progress"}
+        title={emptyTitle ?? "No active stream found"}
+        description={
+          emptyDescription ??
+          "There is no stream progress to track. Start a stream to see live accumulation."
+        }
+        actionLabel={emptyActionLabel ?? "Start a stream"}
+        onAction={onEmptyAction}
+        variant="stream-progress"
+        className={className}
+      />
+    );
+  }
 
   return (
     <div

--- a/app/components/StreamProgressEmptyIllustration.tsx
+++ b/app/components/StreamProgressEmptyIllustration.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useId } from "react";
+
+export interface StreamProgressEmptyIllustrationProps {
+  /** Optional width / height in CSS units. Default: fills container, max 220px. */
+  size?: number | string;
+  /** Tint the graphic — defaults to --muted. */
+  color?: string;
+  /** When true, marks the graphic aria-hidden. Default: true. */
+  decorative?: boolean;
+  /** Accessible label (only used when decorative=false). */
+  label?: string;
+  /** Additional class forwarded to the wrapper. */
+  className?: string;
+}
+
+export function StreamProgressEmptyIllustration({
+  size,
+  color,
+  decorative = true,
+  label = "Empty stream progress illustration",
+  className = "",
+}: StreamProgressEmptyIllustrationProps) {
+  const idPrefix = useId();
+  const glowId = `${idPrefix}-glow`;
+  const patternId = `${idPrefix}-stripes`;
+
+  const wrapperStyle: React.CSSProperties = {
+    display: "block",
+    maxWidth: "100%",
+    width: size ?? "100%",
+    maxHeight: size ? undefined : "160px",
+    aspectRatio: "16 / 9",
+    color: color ?? "var(--muted)",
+  };
+
+  const commonProps = decorative
+    ? { "aria-hidden": true as const, focusable: false as const }
+    : { role: "img" as const, "aria-label": label };
+
+  return (
+    <svg
+      className={className}
+      style={wrapperStyle}
+      viewBox="0 0 400 180"
+      preserveAspectRatio="xMidYMid meet"
+      {...commonProps}
+    >
+      <defs>
+        {/* Soft accent glow under the central clock badge */}
+        <radialGradient id={glowId} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+        </radialGradient>
+
+        {/* Diagonal stripe pattern for a ghost fill chunk at the start */}
+        <pattern
+          id={patternId}
+          width="12"
+          height="12"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="12"
+            stroke="currentColor"
+            strokeOpacity="0.2"
+            strokeWidth="2"
+          />
+        </pattern>
+      </defs>
+
+      {/* ── Outer Group ─────────────────────────────────────────────────── */}
+      <g opacity="0.9">
+        {/* Main progress bar track (dashed/ghost outline) */}
+        <rect
+          x="30"
+          y="70"
+          width="340"
+          height="40"
+          rx="20"
+          ry="20"
+          fill="var(--panel)"
+          stroke="currentColor"
+          strokeOpacity="0.2"
+          strokeWidth="1.5"
+          strokeDasharray="6 4"
+        />
+
+        {/* Muted ghost fill pattern at the beginning (0-15% area) */}
+        <rect
+          x="34"
+          y="74"
+          width="50"
+          height="32"
+          rx="16"
+          ry="16"
+          fill={`url(#${patternId})`}
+          opacity="0.8"
+        />
+      </g>
+
+      {/* ── Central Badge (Time / Clock Theme) ────────────────────────── */}
+
+      {/* Glow halo */}
+      <circle cx="200" cy="90" r="48" fill={`url(#${glowId})`} />
+
+      {/* Badge container */}
+      <g transform="translate(200 90)">
+        {/* Outer ring */}
+        <circle
+          cx="0"
+          cy="0"
+          r="26"
+          fill="var(--panel-elevated)"
+          stroke="var(--accent)"
+          strokeWidth="2.5"
+        />
+
+        {/* Clock outline */}
+        <circle
+          cx="0"
+          cy="0"
+          r="12"
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="2"
+        />
+
+        {/* Clock hands */}
+        <line
+          x1="0"
+          y1="0"
+          x2="0"
+          y2="-7"
+          stroke="var(--accent)"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="0"
+          y1="0"
+          x2="5"
+          y2="0"
+          stroke="var(--accent)"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </g>
+    </svg>
+  );
+}
+
+export default StreamProgressEmptyIllustration;


### PR DESCRIPTION
Closes #1055 
## Description
This PR resolves the UI/UX issue for the GrantFox FWC26 campaign (Stellar Wave) by implementing a themed empty state and illustration on the `StreamProgress` component when there is no active stream or when forced via props.

## Changes
### Components & Styling
- **`app/components/StreamProgressEmptyIllustration.tsx`**: Added a new SVG illustration featuring a dashed ghost progress track and a central clock badge styled with v7 design tokens (`var(--accent)`, `var(--panel)`, etc.).
- **`app/components/EmptyState.tsx`**: Added the `"stream-progress"` variant to dynamically switch and render the new empty-state illustration.
- **`app/components/StreamProgress.tsx`**: Integrated `EmptyState` to handle the empty state display. Added `isEmpty` flag, support for `status="empty"`, and configuration props for custom copy and CTA handler mapping (`emptyTitle`, `emptyDescription`, `emptyActionLabel`, `onEmptyAction`).

### Testing & Verification
- **`app/components/StreamProgress.test.tsx`**: Added unit tests to assert correct rendering of default empty state layout, customization copy mapping, and CTA click action triggers.
- **`app/components/EmptyState.test.tsx`**: Added validation tests to verify that the `"stream-progress"` variant correctly renders the new SVG illustration with the expected CSS classes and design tokens.
- Ran ESLint on all modified/added files (all clean with 0 warnings/errors).
- Ran standard Jest unit tests on the components (all passing).