### PR TITLE
fix: StreamTypeChip focus-visible outline for keyboard navigation

### DIFF
--- a/app/StreamTypeChip.test.tsx
+++ b/app/StreamTypeChip.test.tsx
@@ -35,4 +35,19 @@ describe('StreamTypeChip', () => {
     const amountElement = screen.getByText('67890');
     expect(amountElement).toHaveClass('tabular-nums');
   });
+
+  it('is reachable via keyboard tab order', () => {
+    const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+    const chip = container.querySelector('.stream-type-chip');
+    expect(chip).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('receives real DOM focus and carries the shared focus-visible class hook', () => {
+    const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+    const chip = container.querySelector('.stream-type-chip') as HTMLElement;
+    expect(chip).not.toBeNull();
+    chip.focus();
+    expect(chip).toHaveFocus();
+    expect(chip).toHaveClass('stream-type-chip');
+  });
 });

--- a/app/StreamTypeChip.tsx
+++ b/app/StreamTypeChip.tsx
@@ -16,7 +16,10 @@ export interface StreamTypeChipProps {
 
 export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) => {
   return (
-    <div className={styles.streamTypeChip}>
+    <div
+      className={`${styles.streamTypeChip} stream-type-chip`}
+      tabIndex={0}
+    >
       <span className={styles.type}>{type}</span>
       <span className={`tabular-nums ${styles.amount}`}>
         {amount}

--- a/app/styles/focus.css
+++ b/app/styles/focus.css
@@ -12,7 +12,8 @@
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
     .stream-row__action,
-    .stream-progress__track
+    .stream-progress__track,
+    .stream-type-chip
   ):focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
@@ -31,9 +32,11 @@
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
     .stream-row__action,
-    .stream-progress__track
+    .stream-progress__track,
+    .stream-type-chip
   ):focus:not(:focus-visible) {
     outline: none;
     box-shadow: none;
   }
 }
+

--- a/app/styles/focus.css.test.tsx
+++ b/app/styles/focus.css.test.tsx
@@ -26,10 +26,15 @@ describe("shared focus-visible layer", () => {
     expect(styleText).toContain(".stream-row__action");
   });
 
+  it("includes the StreamTypeChip in the keyboard-visible focus layer", () => {
+    expect(styleText).toContain(".stream-type-chip");
+  });
+
   it("hides the outline again for mouse/touch focus on the StreamProgress track", () => {
     const suppressionRule = styleText.split(":focus-visible {")[1] ?? "";
     expect(suppressionRule).toContain(".stream-progress__track");
     expect(suppressionRule).toContain(".stream-row__action");
+    expect(suppressionRule).toContain(".stream-type-chip");
     expect(styleText).toContain(":focus:not(:focus-visible)");
   });
 });

--- a/docs/streamtypechip-focus-accessibility.md
+++ b/docs/streamtypechip-focus-accessibility.md
@@ -1,0 +1,23 @@
+# StreamTypeChip — Keyboard Focus Accessibility
+
+## Overview
+`StreamTypeChip` (`app/StreamTypeChip.tsx`) displays the type and total amount for a payment stream. Previously, the chip was static and did not accept focus, so keyboard-only users could not reach it, and it did not have a visible focus indicator.
+
+## Change
+- The component now sets `tabIndex={0}` and adds a global `.stream-type-chip` class.
+- `app/styles/focus.css` — the shared `focus-visible` layer — now includes `.stream-type-chip` in its selector list. This ensures the chip gets the standard 2px accent-colored outline with a background-safe `box-shadow` offset when focused via keyboard navigation, while suppressing the outline for mouse/touch interactions (`:focus:not(:focus-visible)`).
+
+## Accessibility (WCAG 2.1 AA)
+- **2.4.7 Focus Visible**: The chip displays a visible focus indicator when reached via keyboard.
+- **2.1.1 Keyboard**: The chip is reachable in the natural keyboard tab order using `Tab`/`Shift+Tab`.
+- **Screen Reader Support**: When focused, screen readers read the combined type and amount values (e.g., "Video 12345").
+
+## Testing
+- `app/StreamTypeChip.test.tsx` — asserts that the chip has `tabIndex="0"` and successfully receives DOM focus.
+- `app/styles/focus.css.test.tsx` — asserts that `.stream-type-chip` is registered in both the keyboard-visible and suppression selector lists.
+
+## Manual verification
+1. Tab through a page containing `StreamTypeChip` using the keyboard.
+2. Confirm that the chip receives the accent-colored outline when focused via `Tab`.
+3. Confirm that clicking the chip with a mouse does not display the outline.
+4. Verify the visibility of the outline in both light and dark themes.


### PR DESCRIPTION
Closes #1086 
This PR resolves the UI/UX accessibility issue for the GrantFox FWC26 campaign (Stellar Wave) by implementing a visible focus outline on keyboard-only navigation for the StreamTypeChip component.

Previously, StreamTypeChip was a static container that did not receive focus, making it inaccessible to keyboard-only and assistive technology users. We have updated it to support natural keyboard tab order and styled its outline to use the repository's shared focus-visible design token layer.

Key Changes
app/StreamTypeChip.tsx:

Added tabIndex={0} to the outer container element to include the component in the natural keyboard navigation tab order.
Appended the global .stream-type-chip CSS class to the container.
app/styles/focus.css:

Registered .stream-type-chip in the :focus-visible outline rules to display the high-contrast 2px accent-colored outline with a background-safe box-shadow offset when focused via keyboard.
Registered .stream-type-chip in the :focus:not(:focus-visible) rules to suppress the focus indicator for mouse and touch interactions, preserving native styling.
Accessibility Documentation (docs/streamtypechip-focus-accessibility.md):

Created a documentation page detailing the change, WCAG 2.1 AA compliance aspects (specifically 2.4.7 Focus Visible and 2.1.1 Keyboard), and verification steps.
Tests (app/StreamTypeChip.test.tsx and app/styles/focus.css.test.tsx):

Added unit tests to assert tabIndex={0} and verify that the chip can receive actual DOM focus.
Added unit tests to assert that .stream-type-chip is registered in both the keyboard-visible and mouse-suppression selector lists within focus.css.
WCAG 2.1 AA Compliance
2.4.7 Focus Visible: Shows a high-contrast focus indicator when navigated to with a keyboard.
2.1.1 Keyboard: Fully reachable via standard Tab/Shift+Tab keys.
Verification
The Jest unit tests run and pass successfully:

bash


PASS app/StreamTypeChip.test.tsx
PASS app/styles/focus.css.test.tsx
Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total