### PR TITLE
Task/streamtypechip reduced v7

### DIFF
--- a/app/StreamTypeChip.module.css
+++ b/app/StreamTypeChip.module.css
@@ -4,6 +4,17 @@
   flex-direction: column;
   gap: 0.125rem;
   max-width: 100%;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease;
+}
+
+.streamTypeChip:hover {
+  transform: translateY(-1px);
+  opacity: 0.9;
+}
+
+.streamTypeChip:active {
+  transform: translateY(0);
 }
 
 .type {
@@ -27,3 +38,10 @@
     white-space: nowrap;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .streamTypeChip {
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/app/StreamTypeChip.test.tsx
+++ b/app/StreamTypeChip.test.tsx
@@ -35,4 +35,19 @@ describe('StreamTypeChip', () => {
     const amountElement = screen.getByText('67890');
     expect(amountElement).toHaveClass('tabular-nums');
   });
+
+  it('is reachable via keyboard tab order', () => {
+    const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+    const chip = container.querySelector('.stream-type-chip');
+    expect(chip).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('receives real DOM focus and carries the shared focus-visible class hook', () => {
+    const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+    const chip = container.querySelector('.stream-type-chip') as HTMLElement;
+    expect(chip).not.toBeNull();
+    chip.focus();
+    expect(chip).toHaveFocus();
+    expect(chip).toHaveClass('stream-type-chip');
+  });
 });

--- a/app/StreamTypeChip.test.tsx
+++ b/app/StreamTypeChip.test.tsx
@@ -50,4 +50,51 @@ describe('StreamTypeChip', () => {
     expect(chip).toHaveFocus();
     expect(chip).toHaveClass('stream-type-chip');
   });
+
+  describe('reduced-motion', () => {
+    afterEach(() => {
+      // @ts-expect-error reset between tests
+      delete window.matchMedia;
+    });
+
+    it('applies standard transition style and attribute when reduced motion is not requested', () => {
+      window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+
+      const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+      const chip = container.querySelector('.stream-type-chip') as HTMLElement;
+      
+      expect(chip).toHaveAttribute('data-reduced-motion', 'false');
+      expect(chip.style.transition).toContain('transform');
+    });
+
+    it('renders static fallback (transition/transform none) when reduced motion is requested', () => {
+      window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+
+      const { container } = render(<StreamTypeChip type="Video" amount={12345} />);
+      const chip = container.querySelector('.stream-type-chip') as HTMLElement;
+      
+      expect(chip).toHaveAttribute('data-reduced-motion', 'true');
+      expect(chip.style.transition).toBe('none');
+      expect(chip.style.transform).toBe('none');
+    });
+  });
 });
+

--- a/app/StreamTypeChip.tsx
+++ b/app/StreamTypeChip.tsx
@@ -16,7 +16,10 @@ export interface StreamTypeChipProps {
 
 export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) => {
   return (
-    <div className={styles.streamTypeChip}>
+    <div
+      className={`${styles.streamTypeChip} stream-type-chip`}
+      tabIndex={0}
+    >
       <span className={styles.type}>{type}</span>
       <span className={`tabular-nums ${styles.amount}`}>
         {amount}

--- a/app/StreamTypeChip.tsx
+++ b/app/StreamTypeChip.tsx
@@ -1,6 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../src/styles/typography.css'; // Adjust path if needed
 import styles from './StreamTypeChip.module.css';
+
+/**
+ * Tracks the user's `prefers-reduced-motion` setting.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReduced(query.matches);
+
+    const onChange = (event: MediaQueryListEvent) => setPrefersReduced(event.matches);
+
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', onChange);
+      return () => query.removeEventListener('change', onChange);
+    }
+
+    query.addListener(onChange);
+    return () => query.removeListener(onChange);
+  }, []);
+
+  return prefersReduced;
+}
 
 /**
  * StreamTypeChip component.
@@ -15,10 +43,17 @@ export interface StreamTypeChipProps {
 }
 
 export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   return (
     <div
       className={`${styles.streamTypeChip} stream-type-chip`}
       tabIndex={0}
+      data-reduced-motion={prefersReducedMotion}
+      style={{
+        transition: prefersReducedMotion ? 'none' : 'transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease',
+        transform: prefersReducedMotion ? 'none' : undefined,
+      }}
     >
       <span className={styles.type}>{type}</span>
       <span className={`tabular-nums ${styles.amount}`}>
@@ -29,3 +64,4 @@ export const StreamTypeChip: React.FC<StreamTypeChipProps> = ({ type, amount }) 
 };
 
 export default StreamTypeChip;
+

--- a/app/styles/focus.css
+++ b/app/styles/focus.css
@@ -12,7 +12,8 @@
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
     .stream-row__action,
-    .stream-progress__track
+    .stream-progress__track,
+    .stream-type-chip
   ):focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
@@ -31,9 +32,11 @@
     [tabindex]:not([tabindex="-1"]),
     .card--clickable,
     .stream-row__action,
-    .stream-progress__track
+    .stream-progress__track,
+    .stream-type-chip
   ):focus:not(:focus-visible) {
     outline: none;
     box-shadow: none;
   }
 }
+

--- a/app/styles/focus.css.test.tsx
+++ b/app/styles/focus.css.test.tsx
@@ -26,10 +26,15 @@ describe("shared focus-visible layer", () => {
     expect(styleText).toContain(".stream-row__action");
   });
 
+  it("includes the StreamTypeChip in the keyboard-visible focus layer", () => {
+    expect(styleText).toContain(".stream-type-chip");
+  });
+
   it("hides the outline again for mouse/touch focus on the StreamProgress track", () => {
     const suppressionRule = styleText.split(":focus-visible {")[1] ?? "";
     expect(suppressionRule).toContain(".stream-progress__track");
     expect(suppressionRule).toContain(".stream-row__action");
+    expect(suppressionRule).toContain(".stream-type-chip");
     expect(styleText).toContain(":focus:not(:focus-visible)");
   });
 });

--- a/docs/streamtypechip-focus-accessibility.md
+++ b/docs/streamtypechip-focus-accessibility.md
@@ -1,0 +1,23 @@
+# StreamTypeChip — Keyboard Focus Accessibility
+
+## Overview
+`StreamTypeChip` (`app/StreamTypeChip.tsx`) displays the type and total amount for a payment stream. Previously, the chip was static and did not accept focus, so keyboard-only users could not reach it, and it did not have a visible focus indicator.
+
+## Change
+- The component now sets `tabIndex={0}` and adds a global `.stream-type-chip` class.
+- `app/styles/focus.css` — the shared `focus-visible` layer — now includes `.stream-type-chip` in its selector list. This ensures the chip gets the standard 2px accent-colored outline with a background-safe `box-shadow` offset when focused via keyboard navigation, while suppressing the outline for mouse/touch interactions (`:focus:not(:focus-visible)`).
+
+## Accessibility (WCAG 2.1 AA)
+- **2.4.7 Focus Visible**: The chip displays a visible focus indicator when reached via keyboard.
+- **2.1.1 Keyboard**: The chip is reachable in the natural keyboard tab order using `Tab`/`Shift+Tab`.
+- **Screen Reader Support**: When focused, screen readers read the combined type and amount values (e.g., "Video 12345").
+
+## Testing
+- `app/StreamTypeChip.test.tsx` — asserts that the chip has `tabIndex="0"` and successfully receives DOM focus.
+- `app/styles/focus.css.test.tsx` — asserts that `.stream-type-chip` is registered in both the keyboard-visible and suppression selector lists.
+
+## Manual verification
+1. Tab through a page containing `StreamTypeChip` using the keyboard.
+2. Confirm that the chip receives the accent-colored outline when focused via `Tab`.
+3. Confirm that clicking the chip with a mouse does not display the outline.
+4. Verify the visibility of the outline in both light and dark themes.


### PR DESCRIPTION
Closes #1088 This pull request implements a static fallback for StreamTypeChip when the user has set the prefers-reduced-motion accessibility preference. It ensures compliance with WCAG 2.1 AA accessibility guidelines by preventing transitions or transforms from firing when reduced motion is requested.

Changes
StreamTypeChip.tsx: Added client-side detection of prefers-reduced-motion via window.matchMedia and conditionally disabled transitions/transforms on the wrapper container.
StreamTypeChip.module.css: Implemented premium micro-interaction transitions for hover and active states, alongside a @media (prefers-reduced-motion: reduce) block to force static styling.
StreamTypeChip.test.tsx: Added comprehensive tests that mock window.matchMedia to verify behavior under both motion preferences.
Testing & Quality Checklist
 Verified via Jest that all StreamTypeChip tests pass:
bash


npx jest StreamTypeChip
 Linting rules enforced and verified via ESLint.