### PR TITLE
fix: StreamProgress tabular-nums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
   to the broader streams list.
 - `StreamProgress` now emits shared color-blind pattern classes on its fill so
   stream state remains distinguishable beyond color alone.
+- `StreamProgress` now applies `tabular-nums` to its percentage/status label
+  (the remaining-balance amount already had it), so digit widths stay fixed
+  as accrual updates instead of jittering horizontally.
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -151,6 +151,33 @@ describe("StreamProgress progressbar semantics", () => {
   });
 });
 
+// ── Tabular numerals (FWC26 Stellar Wave) ───────────────────────────────────
+
+describe("StreamProgress tabular-nums formatting", () => {
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it("applies tabular-nums to the percentage label so digit widths stay fixed", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" accruedAmount={25} totalAmount={100} />);
+    expect(screen.getByText("25% accrued")).toHaveClass("tabular-nums");
+  });
+
+  it("applies tabular-nums to the label for non-numeric statuses too", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="draft" />);
+    expect(screen.getByText("Not started")).toHaveClass("tabular-nums");
+  });
+
+  it("applies tabular-nums to the remaining-balance amount", () => {
+    mockMatchMedia(false);
+    render(<StreamProgress status="active" accruedAmount={30} totalAmount={100} />);
+    expect(screen.getByText("70 remaining")).toHaveClass("tabular-nums");
+  });
+});
+
 // ── Aria-live announcements ─────────────────────────────────────────────────
 
 describe("StreamProgress aria-live announcements", () => {

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -26,6 +26,10 @@
  * ## Amounts
  * Accepts raw i128-compatible bigint or number values. No decimal conversion
  * is performed here; callers supply pre-scaled display values if needed.
+ * The percentage label and remaining-balance text both render with
+ * `font-variant-numeric: tabular-nums` (the shared `.tabular-nums` utility
+ * in `app/styles/typography.css`) so digit widths stay fixed as the value
+ * changes, preventing the bar's meta row from jittering horizontally.
  */
 
 "use client";
@@ -266,7 +270,7 @@ export function StreamProgress({
 
       {/* Visible label — state is NOT conveyed by color alone */}
       <div className="stream-progress__meta" aria-hidden="true">
-        <span className="stream-progress__label">{label}</span>
+        <span className="stream-progress__label tabular-nums">{label}</span>
         {typeof totalAmount === "number" && typeof accruedAmount === "number" && totalAmount > 0 && (
           <span className="stream-progress__remaining tabular-nums">
             {Math.round(totalAmount - accruedAmount).toLocaleString()} remaining


### PR DESCRIPTION
## Summary
- Applies the shared `.tabular-nums` utility (`app/styles/typography.css`) to StreamProgress's percentage/status label span, so digit widths stay fixed as accrual updates (e.g. `9% accrued` → `10% accrued` no longer shifts the layout).
- The remaining-balance amount already carried `.tabular-nums` from a prior PR; this closes the last gap so every numeric display on the component is covered.
- Documents the behavior in the component's docblock and CHANGELOG.

Closes #1057

## Test plan
- [x] `npm test -- app/components/StreamProgress.test.tsx` — 27/27 passing, including 3 new focused tests covering the label (numeric and non-numeric statuses) and the remaining-balance amount
- [x] `npm run lint` — no new errors introduced (2 pre-existing parse errors in unrelated files, confirmed present on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)