### PR TITLE
fix: StreamProgress tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ API versioning follows the policy in [README.md#api-versioning](README.md#api-ve
   to the broader streams list.
 - `StreamProgress` now emits shared color-blind pattern classes on its fill so
   stream state remains distinguishable beyond color alone.
+- `StreamProgress` spacing and typography are now pinned to design tokens
+  (`--space-*` / `--text-*` / `--font-*` in `app/globals.css`) instead of
+  hardcoded rem values. These tokens were referenced elsewhere in the
+  codebase but never actually defined; they're now added to `:root`,
+  fixing the underlying gap app-wide. The percentage label's font-size
+  normalizes from `0.8125rem` to the nearest scale step, `--text-sm`
+  (`0.875rem`).
 
 ### Fixed
 - `GET /api/orgs/:orgId/members` and `POST /api/orgs/:orgId/members` now return

--- a/app/components/StreamProgress.test.tsx
+++ b/app/components/StreamProgress.test.tsx
@@ -1,4 +1,6 @@
 /** @jest-environment jsdom */
+import fs from "fs";
+import path from "path";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
@@ -148,6 +150,58 @@ describe("StreamProgress progressbar semantics", () => {
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "100");
     expect(bar).toHaveAttribute("aria-valuetext", "Completed");
+  });
+});
+
+// ── Spacing/typography design tokens (FWC26 Stellar Wave) ───────────────────
+
+describe("StreamProgress spacing/typography design tokens", () => {
+  const css = fs.readFileSync(path.join(__dirname, "..", "globals.css"), "utf8");
+
+  /** Returns the declaration block body for a top-level CSS selector. */
+  function ruleBody(selector: string): string {
+    const start = css.indexOf(`${selector} {`);
+    expect(start).toBeGreaterThan(-1);
+    return css.slice(start, css.indexOf("}", start));
+  }
+
+  it("defines the spacing scale tokens referenced across the app", () => {
+    for (const token of ["--space-1", "--space-2", "--space-3", "--space-4", "--space-5", "--space-6", "--space-8"]) {
+      expect(css).toContain(`${token}:`);
+    }
+  });
+
+  it("defines the typography scale tokens referenced across the app", () => {
+    for (const token of ["--text-xs", "--text-sm", "--text-base", "--text-lg", "--text-xl", "--text-2xl", "--text-4xl"]) {
+      expect(css).toContain(`${token}:`);
+    }
+  });
+
+  it("defines the font-weight tokens referenced across the app", () => {
+    for (const token of ["--font-medium", "--font-semibold", "--font-bold"]) {
+      expect(css).toContain(`${token}:`);
+    }
+  });
+
+  it("pins the track/label gap to a spacing token instead of a hardcoded rem value", () => {
+    const rule = ruleBody(".stream-progress");
+    expect(rule).toContain("gap: var(--space-2)");
+  });
+
+  it("pins the meta row gap to a spacing token", () => {
+    const rule = ruleBody(".stream-progress__meta");
+    expect(rule).toContain("gap: var(--space-4)");
+  });
+
+  it("pins the percentage label's typography to design tokens", () => {
+    const rule = ruleBody(".stream-progress__label");
+    expect(rule).toContain("font-size: var(--text-sm)");
+    expect(rule).toContain("font-weight: var(--font-semibold)");
+  });
+
+  it("pins the remaining-balance font-size to a typography token", () => {
+    const rule = ruleBody(".stream-progress__remaining");
+    expect(rule).toContain("font-size: var(--text-xs)");
   });
 });
 

--- a/app/components/StreamProgress.tsx
+++ b/app/components/StreamProgress.tsx
@@ -26,6 +26,12 @@
  * ## Amounts
  * Accepts raw i128-compatible bigint or number values. No decimal conversion
  * is performed here; callers supply pre-scaled display values if needed.
+ *
+ * ## Styling
+ * Track/meta spacing and label typography (`app/globals.css`, the
+ * `.stream-progress*` rules) are pinned to the shared `--space-*` / `--text-*`
+ * / `--font-*` design tokens rather than hardcoded rem values, so the
+ * component stays in step with any future scale adjustments.
  */
 
 "use client";

--- a/app/globals.css
+++ b/app/globals.css
@@ -95,6 +95,28 @@
   --badge-cancelled-bg: var(--stream-status-cancelled-bg);
   --badge-cancelled-border: var(--stream-status-cancelled-border);
   --badge-cancelled-text: var(--stream-status-cancelled-text);
+
+  /* ── Spacing Scale ── */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* ── Typography Scale ── */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-4xl: 2.25rem;
+
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
 }
 
 /* ── Light Theme ── */
@@ -495,7 +517,7 @@ a:hover {
 
 .stream-progress {
   display: grid;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .stream-progress__track {
@@ -555,19 +577,19 @@ a:hover {
 .stream-progress__meta {
   align-items: baseline;
   display: flex;
-  gap: 1rem;
+  gap: var(--space-4);
   justify-content: space-between;
 }
 
 .stream-progress__label {
   color: var(--foreground);
-  font-size: 0.8125rem;
-  font-weight: 600;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
 }
 
 .stream-progress__remaining {
   color: var(--muted-light);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
 }
 
 /* Reduced motion: disable any width transitions (component also handles this


### PR DESCRIPTION
## Summary
- Pins StreamProgress's spacing (`.stream-progress` / `.stream-progress__meta` gaps) and typography (`.stream-progress__label` font-size/weight, `.stream-progress__remaining` font-size) to design tokens instead of hardcoded rem values.
- The `--space-*` / `--text-*` / `--font-*` custom properties were already referenced throughout `app/globals.css` (compare-streams modal, streams/new pages, etc.) but were never actually defined in `:root` — they silently resolved to nothing wherever used. This adds the missing scale definitions (matching the values already implied by the existing naming convention), fixing that gap app-wide, not just for this component.
- Visible change: the percentage label's font-size normalizes from `0.8125rem` (an off-scale value) to the nearest defined step, `--text-sm` (`0.875rem`).

Closes #1050

## Test plan
- [x] `npm test -- app/components/StreamProgress.test.tsx` — 31/31 passing, including 7 new focused tests asserting the token definitions exist and that the `.stream-progress*` rules reference them instead of hardcoded values
- [x] `npm run lint` — no new errors introduced (2 pre-existing parse errors in unrelated files, confirmed present on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)