### PR TITLE
fix(#1132): add structured access logs to reconciliation route

### DIFF
--- a/app/api/reconciliation/route.ts
+++ b/app/api/reconciliation/route.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { getCorrelationContext, logger } from '@/app/lib/logger';
 import { withStrongEtag } from '@/src/middleware/etag';
 import { applyRateLimit } from '@/src/middleware/rateLimit';
+import { logAccessEvent } from '@/src/middleware/accessLog';
 
 function errorResponse(code: string, message: string, status: number) {
   const requestId = getCorrelationContext()?.request_id ?? `req-${crypto.randomUUID()}`;
@@ -45,8 +46,29 @@ export async function GET(request: Request) {
       },
     };
 
-    return withStrongEtag(request, responsePayload);
+    const startTime = Date.now();
+    const response = withStrongEtag(request, responsePayload);
+
+    // Structured access log for observability
+    logAccessEvent({
+      method: 'GET',
+      path: '/api/reconciliation',
+      status: 200,
+      durationMs: Date.now() - startTime,
+      limit,
+    });
+
+    return response;
   } catch (error: any) {
+    const statusCode = error.message?.includes('INVALID') ? 400 : 500;
+    logAccessEvent({
+      method: 'GET',
+      path: '/api/reconciliation',
+      status: statusCode,
+      errorCode: statusCode === 400 ? 'INVALID_INPUT' : 'INTERNAL_SERVER_ERROR',
+      errorMessage: error.message,
+    });
+
     logger.error('Unexpected error in reconciliation route', { error: error.message });
     return errorResponse('INTERNAL_SERVER_ERROR', 'An unexpected error occurred', 500);
   }

--- a/src/middleware/accessLog.ts
+++ b/src/middleware/accessLog.ts
@@ -13,7 +13,7 @@ export interface AccessLogContext {
 export function logAccessEvent(context: AccessLogContext): void {
   const correlation = getCorrelationContext();
 
-  logger.info("auth wallet access", {
+  logger.info("api access", {
     ...context,
     request_id: correlation?.request_id,
     correlation_id: correlation?.correlation_id,

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -37,3 +37,25 @@ export async function streamsRateLimit(
   recordRequest(url.pathname);
   return { allowed: true };
 }
+
+/**
+ * Convenience wrapper for per-route rate limiting.
+ *
+ * Applies the rate limit for the given route key and returns the 429 response
+ * if the caller's bucket is exhausted, or `null` if the request is allowed.
+ *
+ * @param request  Incoming request (used for identity resolution).
+ * @param routeKey Route slug used to look up the rate-limit configuration
+ *                 (e.g. `"reconciliation"`, `"webhooks"`).
+ * @returns `null` when allowed, or a `NextResponse` with status 429.
+ */
+export async function applyRateLimit(
+  request: Request,
+  routeKey: string,
+): Promise<NextResponse | null> {
+  const result = await streamsRateLimit(request, "GET", `/api/${routeKey}`);
+  if (!result.allowed) {
+    return result.response;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
Adds structured access log events to the /api/reconciliation route and fixes a missing export in the rateLimit middleware.

### Changes
- Add `logAccessEvent` calls with timing and error details to reconciliation route
- Make `accessLog.ts` generic (log message changed from "auth wallet access" to "api access")
- Add missing `applyRateLimit` export wrapper function in `src/middleware/rateLimit.ts`

### Why
The reconciliation route lacked structured observability. The access log events provide method, path, status, duration, and error details for monitoring and debugging. The rateLimit fix resolves a pre-existing import error.

### Testing
- `app/api/reconciliation/route.test.ts` — all tests pass
- TypeScript typecheck clean on modified files

Closes #1132