### PR TITLE
fix(#1119): add graceful timeout to all webhook routes

### DIFF
--- a/app/api/webhooks/deliveries/route.ts
+++ b/app/api/webhooks/deliveries/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { errorResponse, ErrorCode } from "@/app/lib/errors/server";
 import { webhookDeliveryStore } from "@/app/lib/webhook-delivery-store";
 import { getOutboxStore } from "@/lib/outbox";
+import { withTimeout, WEBHOOK_TIMEOUT_MS } from "@/src/middleware/timeout";
 
 /**
  * GET /api/webhooks/deliveries
@@ -14,6 +15,7 @@ import { getOutboxStore } from "@/lib/outbox";
  *   - cursor (opaque pagination cursor)
  */
 export async function GET(req: NextRequest) {
+  return withTimeout(WEBHOOK_TIMEOUT_MS, req, async () => {
   try {
     const { searchParams } = req.nextUrl;
     const rawLimit = searchParams.get("limit");
@@ -51,4 +53,5 @@ export async function GET(req: NextRequest) {
       500,
     );
   }
+  });
 }

--- a/app/api/webhooks/dlq/[dlqId]/replay/route.ts
+++ b/app/api/webhooks/dlq/[dlqId]/replay/route.ts
@@ -27,6 +27,7 @@ import { tryAuthenticateRequest } from "@/app/lib/auth";
 import { webhookDeliveryWorker } from "@/app/lib/webhook-delivery-worker";
 import { webhookDeliveryStore } from "@/app/lib/webhook-delivery-store";
 import { logger, withCorrelationContext, getCorrelationContext } from "@/app/lib/logger";
+import { withTimeout, WEBHOOK_TIMEOUT_MS } from "@/src/middleware/timeout";
 
 function errorResponse(code: string, message: string, status: number) {
   const ctx = getCorrelationContext();
@@ -68,6 +69,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ dlqId: string }> },
 ) {
+  return withTimeout(WEBHOOK_TIMEOUT_MS, request, async () => {
   const { dlqId } = await params;
 
   const correlation_id =
@@ -149,5 +151,6 @@ export async function POST(
         delivery: `/api/webhooks/deliveries?endpoint_id=${dlqEntry.endpointId}`,
       },
     });
+  });
   });
 }

--- a/app/api/webhooks/health/route.test.ts
+++ b/app/api/webhooks/health/route.test.ts
@@ -20,6 +20,13 @@ jest.mock("next/headers", () => ({
   headers: () => ({ get: () => null }),
 }));
 
+// Mock request for withTimeout — must provide method, url, and headers.
+const mockRequest = {
+  method: "GET",
+  url: "http://localhost/api/webhooks/health",
+  headers: new Headers(),
+} as unknown as Request;
+
 const emptyStats: WebhookDeliveryStats = {
   total: 0,
   delivered: 0,
@@ -31,7 +38,7 @@ const emptyStats: WebhookDeliveryStats = {
 
 describe("GET /api/webhooks/health", () => {
   it("returns 200 with expected shape", async () => {
-    const res = await GET();
+    const res = await GET(mockRequest);
     expect(res.status).toBe(200);
 
     const body = (res as unknown as { body: Record<string, unknown> }).body;
@@ -42,13 +49,13 @@ describe("GET /api/webhooks/health", () => {
   });
 
   it("returns status 'ok' when all subscriptions are healthy", async () => {
-    const res = await GET();
+    const res = await GET(mockRequest);
     const body = (res as unknown as { body: { status: string } }).body;
     expect(body.status).toBe("ok");
   });
 
   it("includes all subscription fields", async () => {
-    const res = await GET();
+    const res = await GET(mockRequest);
     const body = (
       res as unknown as {
         body: { subscriptions: Record<string, unknown> };
@@ -61,7 +68,7 @@ describe("GET /api/webhooks/health", () => {
   });
 
   it("includes all delivery_stats fields", async () => {
-    const res = await GET();
+    const res = await GET(mockRequest);
     const body = (
       res as unknown as {
         body: { delivery_stats: Record<string, unknown> };
@@ -76,7 +83,7 @@ describe("GET /api/webhooks/health", () => {
   });
 
   it("checked_at is a valid ISO-8601 timestamp", async () => {
-    const res = await GET();
+    const res = await GET(mockRequest);
     const body = (res as unknown as { body: { checked_at: string } }).body;
     expect(new Date(body.checked_at).toISOString()).toBe(body.checked_at);
   });

--- a/app/api/webhooks/health/route.ts
+++ b/app/api/webhooks/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { errorResponse, ErrorCode } from "@/app/lib/errors/server";
+import { withTimeout, WEBHOOK_TIMEOUT_MS } from "@/src/middleware/timeout";
 import {
   deriveHealthStatus,
   type WebhookDeliveryStats,
@@ -14,7 +15,8 @@ import {
  * per-subscription delivery statistics.
  */
 
-export async function GET() {
+export async function GET(request: Request) {
+  return withTimeout(WEBHOOK_TIMEOUT_MS, request, async () => {
   try {
     // TODO: replace stubs with real data-layer queries once persistence is wired up.
     const subscriptions: WebhookSubscriptionStats = {
@@ -51,4 +53,5 @@ export async function GET() {
       500,
     );
   }
+  });
 }

--- a/app/api/webhooks/rotate/route.ts
+++ b/app/api/webhooks/rotate/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server';
 import { tryAuthenticateRequest } from '@/app/lib/auth';
 import { webhookSecretStore, MIN_SECRET_LENGTH } from '@/app/lib/webhook-secrets';
+import { withTimeout, WEBHOOK_TIMEOUT_MS } from '@/src/middleware/timeout';
 
 function err(code: string, message: string, status: number) {
   return NextResponse.json({ error: { code, message } }, { status });
 }
 
 export async function POST(request: Request) {
+  return withTimeout(WEBHOOK_TIMEOUT_MS, request, async () => {
   const auth = tryAuthenticateRequest(request);
   if (!auth || auth.role !== 'admin') {
     return err('UNAUTHORIZED', 'Admin authentication required', 403);
@@ -49,4 +51,5 @@ export async function POST(request: Request) {
     }
     throw error;
   }
+  });
 }

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -57,6 +57,13 @@ export const WALLET_CHALLENGE_TIMEOUT_MS =
 export const WALLET_VERIFY_TIMEOUT_MS =
   Number(process.env.AUTH_WALLET_VERIFY_TIMEOUT_MS) || 5_000;
 
+/**
+ * Default wall-clock budget for webhook routes.
+ * Override via the `WEBHOOK_TIMEOUT_MS` environment variable.
+ */
+export const WEBHOOK_TIMEOUT_MS =
+  Number(process.env.WEBHOOK_TIMEOUT_MS) || 30_000;
+
 // ── Core helper ───────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
Adds a 30-second graceful timeout wrapper to all webhook route handlers.

### Changes
- Add `WEBHOOK_TIMEOUT_MS` (30s default) constant to `src/middleware/timeout.ts`
- Wrap `deliveries`, `health`, `rotate`, and `dlq/[dlqId]/replay` route handlers with `withTimeout`
- Update health route signature to accept `request` param for timeout support
- Update health route tests to pass mock request

### Why
Unbounded webhook route handlers could cause hanging connections. Wrapping them with `withTimeout` ensures requests are aborted with a 504 Gateway Timeout after the deadline, preventing resource exhaustion.

### Testing
- `app/api/webhooks/health/route.test.ts` — all 5 tests pass
- `src/middleware/timeout.test.ts` — all tests pass
- TypeScript typecheck clean on modified files

Closes #1119