### PR TITLE
feat: structured logs /api/streams

### DIFF
--- a/app/api/streams/route.test.ts
+++ b/app/api/streams/route.test.ts
@@ -4,7 +4,12 @@ import { GET, POST } from "./route";
 import { resetDb, getStore } from "@/app/lib/db";
 import { resetRateLimitStore, setRateLimitStore } from "@/app/lib/rate-limit-store";
 import { _resetAllowlistForTesting, addAllowedToken } from "@/app/lib/token-allowlist";
+import { logAccessEvent } from "@/src/middleware/accessLog";
 import type { Stream } from "@/app/types/openapi";
+
+jest.mock("@/src/middleware/accessLog", () => ({
+  logAccessEvent: jest.fn(),
+}));
 
 const VALID_RECIPIENT = "GDSBCG3OKHCMMWS5EBH2X7XOYTJRWXN2YYQPCNS5OFBU4IDO4X7OFSQA";
 
@@ -44,6 +49,7 @@ beforeEach(() => {
   resetRateLimitStore();
   _resetAllowlistForTesting();
   addAllowedToken("XLM");
+  (logAccessEvent as jest.Mock).mockClear();
 });
 
 afterEach(() => {
@@ -212,6 +218,60 @@ describe("GET /api/streams", () => {
       expect(body.error.request_id).toBe("test-req-456");
     });
   });
+
+  describe("structured access logs", () => {
+    it("logs a 200 access event with method, path, status and duration on success", async () => {
+      seedStream(2);
+      const res = await GET(getRequest());
+      expect(res.status).toBe(200);
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/api/streams",
+          status: 200,
+          durationMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it("logs a 429 access event with an error code when rate limited", async () => {
+      setRateLimitStore({
+        check: async () => ({ allowed: false, remaining: 0, resetAt: 123456, retryAfter: 60 }),
+      });
+
+      await GET(getRequest());
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/api/streams",
+          status: 429,
+          errorCode: "rate_limit_exceeded",
+        }),
+      );
+    });
+
+    it("logs a 422 access event for invalid query params", async () => {
+      await GET(getRequest("?limit=abc"));
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "GET", status: 422, errorCode: "VALIDATION_ERROR" }),
+      );
+    });
+
+    it("logs a 304 access event on a matching If-None-Match", async () => {
+      const initialRes = await GET(getRequest());
+      const etag = initialRes.headers.get("etag")!;
+      (logAccessEvent as jest.Mock).mockClear();
+
+      await GET(new Request("http://localhost/api/streams", { headers: { "if-none-match": etag } }));
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "GET", status: 304 }),
+      );
+    });
+  });
 });
 
 describe("POST /api/streams", () => {
@@ -361,6 +421,43 @@ describe("POST /api/streams", () => {
 
       const body = await res2.json();
       expect(body.error.code).toBe("IDEMPOTENCY_CONFLICT");
+    });
+  });
+
+  describe("structured access logs", () => {
+    it("logs a 201 access event on successful creation", async () => {
+      const res = await POST(postRequest({ recipient: VALID_RECIPIENT, rate: "50", schedule: "month" }));
+      expect(res.status).toBe(201);
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          path: "/api/streams",
+          status: 201,
+          durationMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it("logs a 400 access event for a non-JSON body", async () => {
+      const req = new Request("http://localhost/api/streams", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+      await POST(req);
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "POST", status: 400, errorCode: "INVALID_REQUEST" }),
+      );
+    });
+
+    it("logs a 422 access event for validation failures", async () => {
+      await POST(postRequest({}));
+
+      expect(logAccessEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "POST", status: 422, errorCode: "VALIDATION_ERROR" }),
+      );
     });
   });
 });

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -9,6 +9,7 @@ import {
   setIdempotency,
 } from "@/app/lib/db";
 import { getCorrelationContext, logger } from "@/app/lib/logger";
+import { logAccessEvent } from "@/src/middleware/accessLog";
 import { streamsRateLimit } from "@/src/middleware/rateLimit";
 import { checkTokenAllowed, normaliseToken } from "@/app/lib/token-allowlist";
 import {
@@ -40,13 +41,19 @@ function getHeader(request: Request, name: string): string | null {
 }
 
 export async function GET(request: Request) {
+  const startedAt = Date.now();
   const { streamRepository } = getStore();
+  const url = getRequestUrl(request, "/api/streams");
+  const path = url.pathname;
+  const logAccess = (status: number, extra?: Record<string, unknown>) =>
+    logAccessEvent({ method: "GET", path, status, durationMs: Date.now() - startedAt, ...extra });
+
   const rateLimitResult = await streamsRateLimit(request, "GET", "/api/streams");
   if (!rateLimitResult.allowed) {
+    logAccess(429, { errorCode: "rate_limit_exceeded" });
     return rateLimitResult.response;
   }
 
-  const url = getRequestUrl(request, "/api/streams");
   const { searchParams } = url;
   const rawQuery: Record<string, string> = {};
   for (const key of ["limit", "status", "cursor"] as const) {
@@ -59,6 +66,7 @@ export async function GET(request: Request) {
   const { errors: queryErrors, values: query } = validateListStreamsQuery(rawQuery);
   if (queryErrors.length > 0) {
     logger.warn("Stream list validation failed", { errors: queryErrors });
+    logAccess(422, { errorCode: "VALIDATION_ERROR" });
     return NextResponse.json(
       {
         error: {
@@ -90,6 +98,7 @@ export async function GET(request: Request) {
     try {
       cursorId = decodeCursor(cursor);
     } catch {
+      logAccess(422, { errorCode: "INVALID_CURSOR" });
       return errorResponse("INVALID_CURSOR", "Malformed cursor", 422);
     }
     const cursorIndex = streams.findIndex((stream) => stream.id === cursorId);
@@ -113,6 +122,7 @@ export async function GET(request: Request) {
   const etag = createStrongEtag(payload);
 
   if (isIfNoneMatchMatch(etag, getHeader(request, "if-none-match"))) {
+    logAccess(304);
     return new NextResponse(null, {
       status: 304,
       headers: createCacheHeaders(etag),
@@ -123,6 +133,7 @@ export async function GET(request: Request) {
     count: paginatedStreams.length,
     total: streamRepository.streams.size,
   });
+  logAccess(200, { count: paginatedStreams.length, total: streamRepository.streams.size });
 
   const response = NextResponse.json(payload);
   for (const [name, value] of Object.entries(createCacheHeaders(etag))) {
@@ -132,9 +143,15 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const startedAt = Date.now();
   const { idempotencyStore, streamRepository } = getStore();
+  const path = getRequestUrl(request, "/api/streams").pathname;
+  const logAccess = (status: number, extra?: Record<string, unknown>) =>
+    logAccessEvent({ method: "POST", path, status, durationMs: Date.now() - startedAt, ...extra });
+
   const rateLimitResult = await streamsRateLimit(request, "POST", "/api/streams");
   if (!rateLimitResult.allowed) {
+    logAccess(429, { errorCode: "rate_limit_exceeded" });
     return rateLimitResult.response;
   }
 
@@ -146,6 +163,7 @@ export async function POST(request: Request) {
   try {
     body = await request.json();
   } catch {
+    logAccess(400, { errorCode: "INVALID_REQUEST" });
     return errorResponse("INVALID_REQUEST", "Request body must be valid JSON", 400);
   }
 
@@ -155,11 +173,13 @@ export async function POST(request: Request) {
     const cached = checkIdempotency(idempotencyStore, token, fingerprint);
     if (cached) {
       if (!cached.ok) {
+        logAccess(409, { errorCode: "IDEMPOTENCY_CONFLICT" });
         return NextResponse.json(
           { error: { code: "IDEMPOTENCY_CONFLICT", message: "Idempotency key has been used with a different request." } },
           { status: 409 },
         );
       }
+      logAccess(cached.status, { idempotent: true });
       return NextResponse.json(cached.body, { status: cached.status });
     }
   }
@@ -170,6 +190,7 @@ export async function POST(request: Request) {
     logger.warn("Stream creation validation failed", {
       errors: validationErrors,
     });
+    logAccess(422, { errorCode: "VALIDATION_ERROR" });
     return NextResponse.json(
       {
         error: {
@@ -199,12 +220,14 @@ export async function POST(request: Request) {
     normalisedToken = normaliseToken(tokenStr);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
+    logAccess(422, { errorCode: "INVALID_TOKEN" });
     return createErrorResponse("INVALID_TOKEN", `Invalid token format: ${msg}`, 422);
   }
 
   const allowlistResult = await checkTokenAllowed(normalisedToken);
   if (!allowlistResult.accepted) {
     logger.warn("Stream creation rejected: token not in allowlist", { token: normalisedToken });
+    logAccess(422, { errorCode: "TOKEN_NOT_ALLOWED" });
     return createErrorResponse("TOKEN_NOT_ALLOWED", allowlistResult.reason, 422);
   }
 
@@ -229,5 +252,6 @@ export async function POST(request: Request) {
     setIdempotency(idempotencyStore, token, fingerprint, 201, payload);
   }
 
+  logAccess(201, { streamId: id });
   return NextResponse.json(payload, { status: 201 });
 }

--- a/src/middleware/accessLog.test.ts
+++ b/src/middleware/accessLog.test.ts
@@ -1,0 +1,68 @@
+import { logAccessEvent } from "./accessLog";
+import { getCorrelationContext, logger } from "@/app/lib/logger";
+
+jest.mock("@/app/lib/logger", () => ({
+  getCorrelationContext: jest.fn(),
+  logger: { info: jest.fn() },
+}));
+
+describe("logAccessEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("logs a generic access message with the caller's context", () => {
+    (getCorrelationContext as jest.Mock).mockReturnValue(undefined);
+
+    logAccessEvent({ method: "GET", path: "/api/streams", status: 200, durationMs: 12 });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "http access",
+      expect.objectContaining({ method: "GET", path: "/api/streams", status: 200, durationMs: 12 }),
+    );
+  });
+
+  it("does not hardcode a route-specific message", () => {
+    (getCorrelationContext as jest.Mock).mockReturnValue(undefined);
+
+    logAccessEvent({ method: "POST", path: "/api/streams", status: 201 });
+
+    const [message] = (logger.info as jest.Mock).mock.calls[0];
+    expect(message).not.toMatch(/wallet/i);
+  });
+
+  it("attaches correlation, request and trace identifiers when present", () => {
+    (getCorrelationContext as jest.Mock).mockReturnValue({
+      request_id: "req-1",
+      correlation_id: "corr-1",
+      traceparent: "00-trace-1",
+    });
+
+    logAccessEvent({ method: "GET", path: "/api/streams", status: 200 });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "http access",
+      expect.objectContaining({
+        request_id: "req-1",
+        correlation_id: "corr-1",
+        traceparent: "00-trace-1",
+      }),
+    );
+  });
+
+  it("passes through arbitrary extra fields (e.g. errorCode)", () => {
+    (getCorrelationContext as jest.Mock).mockReturnValue(undefined);
+
+    logAccessEvent({
+      method: "GET",
+      path: "/api/streams",
+      status: 429,
+      errorCode: "rate_limit_exceeded",
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "http access",
+      expect.objectContaining({ errorCode: "rate_limit_exceeded" }),
+    );
+  });
+});

--- a/src/middleware/accessLog.ts
+++ b/src/middleware/accessLog.ts
@@ -13,7 +13,7 @@ export interface AccessLogContext {
 export function logAccessEvent(context: AccessLogContext): void {
   const correlation = getCorrelationContext();
 
-  logger.info("auth wallet access", {
+  logger.info("http access", {
     ...context,
     request_id: correlation?.request_id,
     correlation_id: correlation?.correlation_id,


### PR DESCRIPTION
## Summary
Closes #1092

Adds structured access logging with correlation IDs to `GET`/`POST /api/streams`, using the existing `logAccessEvent` helper in `src/middleware/accessLog.ts` (previously wired up only for `/api/auth/wallet`).

## Changes
- `src/middleware/accessLog.ts`: the shared helper hardcoded the log message `"auth wallet access"` — a leftover from being written specifically for the wallet route, even though it's a generic, reusable helper (it already accepts an arbitrary `AccessLogContext`). Renamed the message to the generic `"http access"` so it accurately describes what it logs regardless of caller. This is the one behavior change outside of the streams route; `logAccessEvent` is mocked in `app/api/auth/wallet/route.test.ts`, so this doesn't affect any wallet-route assertions.
- `app/api/streams/route.ts`: both `GET` and `POST` now call `logAccessEvent` at every response path (success, validation errors, rate limiting, idempotency, ETag 304, etc.) with `method`, `path`, `status`, `durationMs`, and an `errorCode` where applicable. `logAccessEvent` itself attaches `request_id` / `correlation_id` / `traceparent` from `getCorrelationContext()`.
- `app/api/streams/route.test.ts`: added a `structured access logs` describe block per verb asserting `logAccessEvent` is called with the right method/path/status/errorCode for the key response paths (200, 429, 422, 304 on GET; 201, 400, 422 on POST).
- `src/middleware/accessLog.test.ts` (new): unit tests for the helper itself — logs the generic message (not a route-specific one), attaches correlation/request/trace IDs when present, passes through arbitrary extra fields (e.g. `errorCode`).

## Test plan
- `npm run lint` — no new errors (2 pre-existing `Parsing error` failures in `app/components/DateRangePicker.tsx`/`.test.tsx` are present on `main` before this change too — confirmed via `git stash`).
- `npm test` — targeted comparison against `main` before this change (`git stash` + rerun):
  - `app/api/streams/route.test.ts`: same 5 pre-existing failures on `main` (fixture-data pollution in `getStore()`/`resetDb()`, and a `parseAssetString` bug for `USDC` in `app/lib/assets.ts` — both unrelated to logging), plus all 7 new access-log tests passing (21 → 28 passing).
  - `src/middleware/accessLog.test.ts` + `app/api/auth/wallet/route.test.ts`: 28/28 passing — the wallet route's `logAccessEvent` assertions are unaffected by the message rename since that module is mocked in its tests.
  - Full suite: no new failures introduced (pre-existing unrelated breakage elsewhere in the repo, same as on `main`).
- `npm run build` — fails identically on `main` before this change too (`Module not found: Can't resolve 'pg'` in `app/api/exports/health/route.ts`, an unrelated missing dependency — confirmed via `git stash`).

### Focused test output
```
PASS src/middleware/accessLog.test.ts
PASS app/api/auth/wallet/route.test.ts
Test Suites: 2 passed, 2 total
Tests:       28 passed, 28 total
```