### PR TITLE
test: add stellar CLI smoke harness and CI workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,105 @@
+name: Contract Smoke Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "contracts/**"
+      - "scripts/smoke*.sh"
+      - "scripts/smoke*.ts"
+      - ".github/workflows/smoke.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "contracts/**"
+      - "scripts/smoke*.sh"
+      - "scripts/smoke*.ts"
+      - ".github/workflows/smoke.yml"
+  workflow_dispatch:
+    inputs:
+      contract_id:
+        description: "Existing contract ID (skip deploy, useful for re-testing)"
+        required: false
+        type: string
+
+env:
+  STELLAR_NETWORK: testnet
+  NODE_ENV: test
+  SMOKE_SKIP_BUILD: false
+
+jobs:
+  contract-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Rust stable with wasm32v1-none
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache Cargo registry + build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-smoke-
+            ${{ runner.os }}-cargo-
+
+      - name: Install stellar CLI
+        run: cargo install stellar-cli --locked
+
+      - name: Generate throwaway testnet keypair
+        id: keypair
+        run: |
+          node --input-type=module <<'EOF' > /tmp/keypair.txt
+          import { randomBytes } from 'crypto';
+          const B = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+          function b32(b) { let i=0,v=0,o=''; for(const x of b){v=(v<<8)|x;i+=8;while(i>=5){o+=B[(v>>>(i-5))&31];i-=5;}} if(i) o+=B[(v<<(5-i))&31]; return o; }
+          function c16(b) { let c=0; for(const x of b){c^=x<<8; for(let i=0;i<8;i++) c=(c&0x8000)?((c<<1)^0x1021):(c<<1);} return c&0xFFFF; }
+          function e(v,k) { const p=Buffer.alloc(1+k.length); p[0]=v; k.copy(p,1); const r=c16(p); const f=Buffer.alloc(p.length+2); p.copy(f); f[p.length]=r&0xFF; f[p.length+1]=(r>>8)&0xFF; return b32(f); }
+          const s=randomBytes(32); const secret=e(144,s); const pub=e(48,s);
+          process.stdout.write('secret=' + secret + '\npublic=' + pub + '\n');
+          EOF
+          cat /tmp/keypair.txt >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$(sed -n 's/^secret=//p' /tmp/keypair.txt)"
+
+      - name: Fund throwaway account via Friendbot
+        run: |
+          curl -sS "https://friendbot.stellar.org?addr=${{ steps.keypair.outputs.public }}" || echo "warning: Friendbot funding may have failed"
+
+      - name: Build contract WASM
+        run: bash scripts/build-grantfox-contract.sh
+
+      - name: Deploy contract
+        id: deploy
+        if: ${{ github.event.inputs.contract_id == '' }}
+        run: |
+          CONTRACT_ID=$(STELLAR_SEED_SECRET_KEY=${{ steps.keypair.outputs.secret }} \
+            STELLAR_NETWORK=testnet \
+            bash scripts/deploy-grantfox-contract.sh 2>&1 | grep -oE 'C[A-Z0-9a-z]{55}' | tail -1)
+          echo "contract_id=$CONTRACT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Use pre-existing contract ID
+        id: existing
+        if: ${{ github.event.inputs.contract_id != '' }}
+        run: echo "contract_id=${{ github.event.inputs.contract_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Run contract CLI smoke tests
+        env:
+          CONTRACT_ID: ${{ steps.deploy.outputs.contract_id || steps.existing.outputs.contract_id }}
+          STELLAR_SEED_SECRET_KEY: ${{ steps.keypair.outputs.secret }}
+          SMOKE_SKIP_BUILD: "true"
+        run: bash scripts/smoke.sh --contract

--- a/docs/contract-smoke-tests.md
+++ b/docs/contract-smoke-tests.md
@@ -50,7 +50,8 @@ is exercised with at minimum one happy-path or expected-error invocation:
 ## Files
 
 | File | Purpose |
-|---|---|
+|---|---|---|
+| `scripts/smoke.sh` | Unified entrypoint — API tests + optional contract CLI smoke |
 | `scripts/smoke-contract.test.ts` | Jest suite — machine-readable, integrates with coverage |
 | `scripts/smoke-contract.sh` | Shell harness — standalone runner for local use |
 | `.github/workflows/smoke.yml` | Dedicated CI job: build → fund → deploy → initialise → smoke |
@@ -71,8 +72,11 @@ is exercised with at minimum one happy-path or expected-error invocation:
 # Deploy a fresh contract (only needed once per testnet session)
 STELLAR_SEED_SECRET_KEY=S... bash scripts/deploy-grantfox-contract.sh
 
-# Run Jest smoke suite
-CONTRACT_ID=C... STELLAR_SEED_SECRET_KEY=S... npm run smoke
+# Run unified smoke entrypoint (API + contract CLI)
+CONTRACT_ID=C... STELLAR_SEED_SECRET_KEY=S... bash scripts/smoke.sh
+
+# Run contract CLI smoke only (via npm script)
+CONTRACT_ID=C... STELLAR_SEED_SECRET_KEY=S... npm run smoke:contract
 
 # Run shell harness directly
 CONTRACT_ID=C... STELLAR_SEED_SECRET_KEY=S... npm run smoke:shell
@@ -100,6 +104,8 @@ Both harnesses degrade gracefully when `CONTRACT_ID` or
 
 - The Jest suite skips all network-dependent tests and passes on exit 0.
 - The shell harness exits at the pre-flight check with a clear error.
+- The unified `scripts/smoke.sh` runs the API smoke suite regardless and
+  skips the contract CLI phase with a clear message.
 
 This is how `ci.yml` runs the smoke step — no chain access needed, just
 validating the harness itself loads and that the test pattern resolves.
@@ -115,16 +121,16 @@ syntax errors or broken imports.
 
 ### `smoke.yml` (dedicated smoke job)
 
-Triggered on pushes/PRs that touch `contracts/**` or
-`scripts/smoke-contract.*`. Performs the full on-chain flow:
+Triggered on pushes/PRs that touch `contracts/**`, `scripts/smoke*.sh`,
+`scripts/smoke*.ts`, or the workflow definition itself. Performs the full
+on-chain flow:
 
 1. Builds the contract WASM from source
 2. Generates a throwaway testnet keypair
 3. Funds it via Friendbot
 4. Deploys a fresh contract instance
-5. Initialises the contract (`initialize`)
-6. Runs the Jest suite with full chain access
-7. Runs the shell harness as a second opinion
+5. Runs the unified smoke entrypoint (`scripts/smoke.sh --contract`) which
+   exercises every contract entrypoint via `stellar contract invoke`
 
 The job is isolated from `ci.yml` so documentation-only PRs don't pay the
 20-minute budget. It can also be triggered manually via `workflow_dispatch`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:e2e": "node scripts/run-from-realpath.mjs jest --runInBand --testPathPattern=e2e\\.test\\.ts$",
     "test:e2e:coverage": "node scripts/run-from-realpath.mjs jest --runInBand --testPathPattern=stream-lifecycle.e2e --coverage --collectCoverageFrom='app/api/streams/**/*.ts' --forceExit",
     "smoke": "node scripts/validate-openapi.mjs && node scripts/run-from-realpath.mjs jest lib/rateLimitIp.test.ts app/api/auth/wallet/route.test.ts --forceExit",
+    "smoke:contract": "bash scripts/smoke.sh --contract",
+    "smoke:shell": "bash scripts/smoke-contract.sh",
     "reconcile": "node scripts/run-from-realpath.mjs ts-node scripts/reconcile-streams.ts",
     "recon:cli": "node scripts/run-from-realpath.mjs ts-node scripts/recon-cli.ts"
   },

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,5 +1,97 @@
 #!/usr/bin/env bash
-# Thin wrapper around `npm run smoke` for local/manual use.
+# scripts/smoke.sh — Unified smoke test entrypoint.
+#
+# Always runs the API smoke suite (OpenAPI validation, rateLimitIp, wallet
+# routes).  When a Soroban contract ID and the stellar CLI are available,
+# also runs the contract CLI smoke suite (scripts/smoke-contract.sh).
+#
+# Usage:
+#   bash scripts/smoke.sh                              # API + contract (if env ready)
+#   CONTRACT_ID=C... STELLAR_SEED_SECRET_KEY=S... bash scripts/smoke.sh
+#   bash scripts/smoke.sh --contract                   # force contract tests
 set -euo pipefail
+
 cd "$(dirname "$0")/.."
-npm run smoke
+
+PASSED=0; FAILED=0; SKIPPED=0
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; RESET='\033[0m'; BOLD='\033[1m'
+else
+  GREEN=''; RED=''; YELLOW=''; RESET=''; BOLD=''
+fi
+log()  { echo -e "${BOLD}[smoke]${RESET} $*"; }
+pass() { echo -e "  ${GREEN}✓${RESET} $*"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗${RESET} $*" >&2; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}○${RESET} $*"; SKIPPED=$((SKIPPED + 1)); }
+
+# ── Phase 1 — API smoke tests ──────────────────────────────────────────────────
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log " Phase 1 — API Smoke Tests"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+api_exit=0
+npm run smoke || api_exit=$?
+if [ "$api_exit" -eq 0 ]; then
+  pass "API smoke tests"
+else
+  fail "API smoke tests (exit $api_exit)"
+fi
+
+# ── Detect contract environment ────────────────────────────────────────────────
+FORCE_CONTRACT=false
+if [[ "${1:-}" == "--contract" ]]; then
+  FORCE_CONTRACT=true
+  shift
+fi
+
+CONTRACT_READY=false
+CONTRACT_REASON=""
+if command -v stellar &>/dev/null; then
+  if [ -n "${CONTRACT_ID:-}" ]; then
+    CONTRACT_READY=true
+  elif [ -f "contracts/.contracts/streampay-stream.id" ]; then
+    CONTRACT_READY=true
+  else
+    CONTRACT_REASON="CONTRACT_ID not set and contracts/.contracts/streampay-stream.id not found"
+  fi
+else
+  CONTRACT_REASON="stellar CLI not found (install with: cargo install stellar-cli)"
+fi
+
+# ── Phase 2 — Contract CLI smoke tests ─────────────────────────────────────────
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log " Phase 2 — Contract CLI Smoke Tests"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$FORCE_CONTRACT" = true ] || [ "$CONTRACT_READY" = true ]; then
+  if ! command -v stellar &>/dev/null; then
+    fail "stellar CLI required for contract smoke"
+  elif [ -z "${CONTRACT_ID:-}" ] && [ ! -f "contracts/.contracts/streampay-stream.id" ]; then
+    fail "No contract ID available — set CONTRACT_ID or deploy first"
+  else
+    contract_exit=0
+    bash scripts/smoke-contract.sh "$@" || contract_exit=$?
+    if [ "$contract_exit" -eq 0 ]; then
+      pass "Contract CLI smoke tests"
+    else
+      fail "Contract CLI smoke tests (exit $contract_exit)"
+    fi
+  fi
+else
+  skip "Contract CLI smoke tests — $CONTRACT_REASON"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────────
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log " Results:  ${GREEN}${PASSED} passed${RESET}  |  ${RED}${FAILED} failed${RESET}  |  ${YELLOW}${SKIPPED} skipped${RESET}"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$FAILED" -gt 0 ]; then
+  log "${RED}SMOKE TESTS FAILED${RESET}"
+  exit 1
+fi
+
+log "${GREEN}All smoke tests passed.${RESET}"


### PR DESCRIPTION
Adds CLI smoke tests using stellar contract invoke and wires them into CI.
- Rewrites scripts/smoke.sh as a unified entrypoint that runs API smoke tests (Phase 1) and optionally runs contract CLI smoke tests (Phase 2) via smoke-contract.sh
- Creates .github/workflows/smoke.yml — dedicated CI job: build → fund → deploy → smoke, triggered on contracts/** and smoke script changes, with workflow_dispatch support for re-testing existing deployments
- Adds smoke:contract and smoke:shell npm scripts to package.json
- Updates docs/contract-smoke-tests.md to reflect the new workflow and entrypoint
Closes #939.