### PR TITLE
fix: add reduced-motion fallback for CreateStreamForm BottomSheet

### DIFF
--- a/app/components/BottomSheet.tsx
+++ b/app/components/BottomSheet.tsx
@@ -14,12 +14,14 @@ interface BottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
+  reducedMotion?: boolean;
 }
 
 export const BottomSheet: React.FC<PropsWithChildren<BottomSheetProps>> = ({
   isOpen,
   onClose,
   title,
+  reducedMotion = false,
   children,
 }) => {
   const [shouldRender, setShouldRender] = useState(isOpen);
@@ -149,7 +151,9 @@ export const BottomSheet: React.FC<PropsWithChildren<BottomSheetProps>> = ({
         alignItems: "flex-end",
         justifyContent: "center",
         zIndex: 1000,
-        animation: `${isOpen ? "sheetFadeIn" : "sheetFadeOut"} var(--motion-duration-medium, 200ms) var(--motion-easing, cubic-bezier(0.16, 1, 0.3, 1)) forwards`,
+        ...(reducedMotion
+          ? { opacity: isOpen ? 1 : 0 }
+          : { animation: `${isOpen ? "sheetFadeIn" : "sheetFadeOut"} var(--motion-duration-medium, 200ms) var(--motion-easing, cubic-bezier(0.16, 1, 0.3, 1)) forwards` }),
       }}
     >
       <div
@@ -169,7 +173,9 @@ export const BottomSheet: React.FC<PropsWithChildren<BottomSheetProps>> = ({
           padding: "1.5rem 1.5rem calc(2rem + env(safe-area-inset-bottom)) 1.5rem",
           boxShadow: "0 -10px 25px rgba(0, 0, 0, 0.4)",
           overflowY: "auto",
-          animation: `${isOpen ? "sheetSlideUp" : "sheetSlideDown"} var(--motion-duration-medium, 200ms) var(--motion-easing, cubic-bezier(0.16, 1, 0.3, 1)) forwards`,
+          ...(reducedMotion
+            ? { transform: isOpen ? "translateY(0)" : "translateY(100%)" }
+            : { animation: `${isOpen ? "sheetSlideUp" : "sheetSlideDown"} var(--motion-duration-medium, 200ms) var(--motion-easing, cubic-bezier(0.16, 1, 0.3, 1)) forwards` }),
         }}
       >
         {/* Grab Handle */}

--- a/app/hooks/usePrefersReducedMotion.ts
+++ b/app/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks the user's `prefers-reduced-motion` setting.
+ *
+ * Returns `true` when the user has requested reduced motion. SSR-safe: defaults
+ * to `false` on the server (and before hydration) and updates live if the
+ * preference changes.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(query.matches);
+
+    const onChange = (event: MediaQueryListEvent) => setPrefersReduced(event.matches);
+
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", onChange);
+      return () => query.removeEventListener("change", onChange);
+    }
+
+    query.addListener(onChange);
+    return () => query.removeListener(onChange);
+  }, []);
+
+  return prefersReduced;
+}

--- a/app/streams/new/page.test.tsx
+++ b/app/streams/new/page.test.tsx
@@ -22,6 +22,20 @@ const createMockMedia = (matches: boolean) => {
   });
 };
 
+/**
+ * Creates a matchMedia mock that returns `mobile` for the viewport query
+ * and `prefersReduced` for the prefers-reduced-motion query.
+ */
+const createMockMediaMulti = (mobile: boolean, prefersReduced: boolean) => {
+  return (query: string) => ({
+    matches: query.includes("prefers-reduced-motion")
+      ? prefersReduced
+      : mobile,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+};
+
 describe("NewStreamPage - Mobile Bottom Sheet Summary", () => {
   let originalMatchMedia: typeof window.matchMedia;
 
@@ -153,5 +167,72 @@ describe("NewStreamPage - Mobile Bottom Sheet Summary", () => {
 
     // Should still be on the edit form
     expect(screen.getByRole("heading", { name: /create stream/i })).toBeInTheDocument();
+  });
+});
+
+describe("NewStreamPage - Reduced Motion Fallback", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeAll(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterAll(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error reset between tests
+    delete window.matchMedia;
+  });
+
+  it("does not use CSS animation when reduced motion is preferred", async () => {
+    window.matchMedia = createMockMediaMulti(true, true) as any;
+    render(<NewStreamPage />);
+
+    const recipientInput = screen.getByLabelText(/recipient address/i);
+    const amountInput = screen.getByLabelText(/amount/i);
+    const submitButton = screen.getByRole("button", { name: /create stream/i });
+
+    fireEvent.change(recipientInput, { target: { value: "GD72X2Y3B6V7XW5P4D8Q2Z9K0F1E3R5T7Y9U0I2O4P6A8S0D2F4G6H8J" } });
+    fireEvent.change(amountInput, { target: { value: "150" } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-overlay")).toBeInTheDocument();
+    });
+
+    const overlay = screen.getByTestId("bottom-sheet-overlay");
+    expect(overlay.style.animation).toBe("");
+    expect(overlay.style.opacity).toBe("1");
+
+    const panel = overlay.querySelector("[role='dialog']") as HTMLElement;
+    expect(panel.style.animation).toBe("");
+    expect(panel.style.transform).toBe("translateY(0)");
+  });
+
+  it("uses CSS animation when reduced motion is not preferred", async () => {
+    window.matchMedia = createMockMediaMulti(true, false) as any;
+    render(<NewStreamPage />);
+
+    const recipientInput = screen.getByLabelText(/recipient address/i);
+    const amountInput = screen.getByLabelText(/amount/i);
+    const submitButton = screen.getByRole("button", { name: /create stream/i });
+
+    fireEvent.change(recipientInput, { target: { value: "GD72X2Y3B6V7XW5P4D8Q2Z9K0F1E3R5T7Y9U0I2O4P6A8S0D2F4G6H8J" } });
+    fireEvent.change(amountInput, { target: { value: "150" } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-overlay")).toBeInTheDocument();
+    });
+
+    const overlay = screen.getByTestId("bottom-sheet-overlay");
+    expect(overlay.style.animation).toContain("sheetFadeIn");
+
+    const panel = overlay.querySelector("[role='dialog']") as HTMLElement;
+    expect(panel.style.animation).toContain("sheetSlideUp");
   });
 });

--- a/app/streams/new/page.tsx
+++ b/app/streams/new/page.tsx
@@ -6,6 +6,7 @@ import { GasOnRecipientToggle } from '../../components/GasOnRecipientToggle';
 import { RecentRecipients } from './components/RecentRecipients';
 import { addRecentRecipient } from '../../state/recentRecipients';
 import { BottomSheet } from '../../components/BottomSheet';
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion';
 
 function shortenAddress(address: string): string {
   const trimmed = address.trim();
@@ -34,6 +35,8 @@ export default function NewStreamPage() {
 
   const [isMobile, setIsMobile] = useState(false);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // Detect mobile viewport using matchMedia
   useEffect(() => {
@@ -238,6 +241,7 @@ export default function NewStreamPage() {
         isOpen={isBottomSheetOpen}
         onClose={() => setIsBottomSheetOpen(false)}
         title="Review Stream Details"
+        reducedMotion={prefersReducedMotion}
       >
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
           <p style={{ color: 'var(--muted-light)', fontSize: 'var(--text-sm, 0.875rem)', margin: 0 }}>


### PR DESCRIPTION
Adds a \`prefers-reduced-motion\` fallback for the BottomSheet used by the CreateStreamForm (NewStreamPage). When the user has \`prefers-reduced-motion: reduce\` enabled, the BottomSheet overlay and panel render without CSS animations, using instant opacity and transform instead.

This is a UI/UX issue for the GrantFox campaign (Stellar Wave) â Closes #1048.

## Changes

| File | Description |
|------|-------------|
| \`app/hooks/usePrefersReducedMotion.ts\` | New shared hook that tracks \`prefers-reduced-motion\` via \`matchMedia\`. SSR-safe, defaults to \`false\`, live-updates on preference change. |
| \`app/components/BottomSheet.tsx\` | Accepts optional \`reducedMotion\` prop. When \`true\`, replaces CSS \`animation\` with static \`opacity\` (overlay) and \`transform\` (panel). |
| \`app/streams/new/page.tsx\` | Imports the hook and passes the reduced-motion state to \`BottomSheet\`. |
| \`app/streams/new/page.test.tsx\` | Adds 2 focused tests: verifies no animation when reduced motion is preferred, and verifies animation is present otherwise. |

## Technical Details

### How it works

1. \`usePrefersReducedMotion\` listens to the \`(prefers-reduced-motion: reduce)\` media query via \`matchMedia\` and returns a boolean.
2. \`NewStreamPage\` calls the hook and passes the result as \`reducedMotion\` to \`BottomSheet\`.
3. In \`BottomSheet\`, when \`reducedMotion\` is \`true\`:
   - **Overlay**: Uses \`opacity: 1\` (open) or \`opacity: 0\` (closed) instead of \`sheetFadeIn\`/\`sheetFadeOut\` animations.
   - **Panel**: Uses \`transform: translateY(0)\` (open) or \`transform: translateY(100%)\` (closed) instead of \`sheetSlideUp\`/\`sheetSlideDown\` animations.
4. When \`reducedMotion\` is \`false\`, existing CSS animations are preserved as-is.

### Accessibility (WCAG 2.1 AA)

- The \`BottomSheet\` component already has proper ARIA attributes (\`role=\"dialog\"\`, \`aria-modal=\"true\"\`, \`aria-labelledby\`).
- Keyboard focus trapping and Escape-to-close are unaffected by the reduced-motion change.
- The static fallback still provides full visual and functional parity â only the motion is removed.

### Design-token consistency

- Uses the same design tokens (\`--motion-duration-medium\`, \`--motion-easing\`) for the animated path.
- Static path uses no tokens, matching the pattern established by \`StreamProgress\`.

## Tests

\`\`\`
PASS app/streams/new/page.test.tsx
  NewStreamPage - Mobile Bottom Sheet Summary
    â renders the stream creation form successfully
    â submits the form directly on desktop
    â opens the BottomSheet on mobile instead of submitting immediately
    â submits and creates stream when Confirm & Create is clicked in BottomSheet
    â closes the BottomSheet when Cancel is clicked
  NewStreamPage - Reduced Motion Fallback
    â does not use CSS animation when reduced motion is preferred
    â uses CSS animation when reduced motion is not preferred

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
\`\`\`

\`\`\`
PASS app/components/StreamProgress.test.tsx
  StreamProgress reduced-motion fallback
    â animates the fill when reduced motion is not requested
    â renders a static fill when reduced motion is requested
    â preserves the accessible progress value regardless of motion preference
  ... (27 tests total â all passing)
\`\`\`

Lint: Clean (no warnings or errors).

## Checklist

- [x] Implementation matches the description
- [x] Tests added and passing (7/7 in page.test.tsx, 27/27 in StreamProgress.test.tsx)
- [x] Code review ready
- [x] No docs file changes needed (inline JSDoc on hook)
- [x] Responsive across all breakpoints (no layout changes)
- [x] WCAG 2.1 AA accessibility
- [x] Design-token + dark-mode consistency
- [x] Clean lint output
" 2>&1