### PR TITLE
feat: metrics on /api/reconciliation

### DIFF
--- a/app/api/reconciliation/route.test.ts
+++ b/app/api/reconciliation/route.test.ts
@@ -20,6 +20,7 @@ import {
   type RateLimitStore,
   type RateLimitResult,
 } from '@/app/lib/rate-limit-store';
+import { reconciliationCounter, reconciliationDuration } from '@/src/metrics/registry';
 
 // ── Logger mock ──────────────────────────────────────────────────────────────
 
@@ -32,6 +33,23 @@ jest.mock('@/app/lib/logger', () => ({
   },
   getCorrelationContext: jest.fn(),
 }));
+
+jest.mock('@/src/metrics/registry', () => {
+  const mockInc = jest.fn();
+  const mockLabels = jest.fn(() => ({ inc: mockInc }));
+  const mockEndTimer = jest.fn();
+  const mockStartTimer = jest.fn(() => mockEndTimer);
+
+  return {
+    reconciliationCounter: {
+      labels: mockLabels,
+      inc: mockInc, // Just in case it's called directly
+    },
+    reconciliationDuration: {
+      startTimer: mockStartTimer,
+    },
+  };
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -138,6 +156,42 @@ describe('GET /api/reconciliation – existing behaviour', () => {
   });
 });
 
+// ── Metrics tests ────────────────────────────────────────────────────────────
+
+describe('GET /api/reconciliation – metrics', () => {
+  it('records 200 status for successful requests', async () => {
+    await GET(makeRequest());
+    
+    expect(reconciliationDuration.startTimer).toHaveBeenCalled();
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('200');
+    // Start timer returns end timer function
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '200' });
+  });
+
+  it('records 400 status for invalid input', async () => {
+    await GET(makeRequest({ search: '?limit=invalid' }));
+    
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('400');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '400' });
+  });
+
+  it('records 500 status on unexpected errors', async () => {
+    // Force an error by mocking URL to throw
+    const originalURL = global.URL;
+    global.URL = jest.fn().mockImplementation(() => { throw new Error('Boom'); }) as any;
+    
+    await GET(makeRequest());
+    
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('500');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '500' });
+    
+    global.URL = originalURL;
+  });
+});
+
 // ── Rate-limit tests ─────────────────────────────────────────────────────────
 
 describe('GET /api/reconciliation – rate limiting', () => {
@@ -148,6 +202,9 @@ describe('GET /api/reconciliation – rate limiting', () => {
     const res = await GET(makeRequest());
 
     expect(res.status).toBe(429);
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('429');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '429' });
   });
 
   it('429 response has Retry-After header', async () => {

--- a/app/api/reconciliation/route.ts
+++ b/app/api/reconciliation/route.ts
@@ -3,6 +3,8 @@ import crypto from 'crypto';
 import { getCorrelationContext, logger } from '@/app/lib/logger';
 import { withStrongEtag } from '@/src/middleware/etag';
 import { applyRateLimit } from '@/src/middleware/rateLimit';
+import { reconciliationCounter, reconciliationDuration } from '@/src/metrics/registry';
+
 
 function errorResponse(code: string, message: string, status: number) {
   const requestId = getCorrelationContext()?.request_id ?? `req-${crypto.randomUUID()}`;
@@ -10,11 +12,17 @@ function errorResponse(code: string, message: string, status: number) {
 }
 
 export async function GET(request: Request) {
+  const endTimer = reconciliationDuration.startTimer();
+
   // ── Per-user rate limit ─────────────────────────────────────────────────
   // Identity resolution priority: API key > JWT wallet sub > IP address.
   // Returns 429 with Retry-After when the caller's bucket is exhausted.
   const rateLimited = await applyRateLimit(request, 'reconciliation');
-  if (rateLimited) return rateLimited;
+  if (rateLimited) {
+    reconciliationCounter.labels('429').inc();
+    endTimer({ status: '429' });
+    return rateLimited;
+  }
 
   // ── Request handling ────────────────────────────────────────────────────
   try {
@@ -26,6 +34,8 @@ export async function GET(request: Request) {
       limit = parseInt(limitParam, 10);
       if (Number.isNaN(limit) || limit < 1 || limit > 1000) {
         logger.warn('Invalid limit parameter provided', { limit: limitParam });
+        reconciliationCounter.labels('400').inc();
+        endTimer({ status: '400' });
         return errorResponse('INVALID_INPUT', 'Limit must be an integer between 1 and 1000', 400);
       }
     }
@@ -45,9 +55,13 @@ export async function GET(request: Request) {
       },
     };
 
+    reconciliationCounter.labels('200').inc();
+    endTimer({ status: '200' });
     return withStrongEtag(request, responsePayload);
   } catch (error: any) {
     logger.error('Unexpected error in reconciliation route', { error: error.message });
+    reconciliationCounter.labels('500').inc();
+    endTimer({ status: '500' });
     return errorResponse('INTERNAL_SERVER_ERROR', 'An unexpected error occurred', 500);
   }
 }

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -19,3 +19,18 @@ export const webhookDuration = new Histogram({
   buckets: [0.1, 0.5, 1, 2, 5],
   registers: [registry],
 });
+
+export const reconciliationCounter = new Counter({
+  name: 'api_reconciliation_requests_total',
+  help: 'Total number of /api/reconciliation requests received',
+  labelNames: ['status'],
+  registers: [registry],
+});
+
+export const reconciliationDuration = new Histogram({
+  name: 'api_reconciliation_request_duration_seconds',
+  help: 'Histogram of /api/reconciliation request processing duration in seconds',
+  labelNames: ['status'],
+  buckets: [0.1, 0.5, 1, 2, 5],
+  registers: [registry],
+});


### PR DESCRIPTION
Closes #1137 

Title: feat: add metrics on /api/reconciliation (v7)

Description:

This PR implements backend metrics for the GrantFox FWC26 campaign (Stellar Wave) as requested.

Changes made:

Added reconciliationCounter (Counter) and reconciliationDuration (Histogram) to the prometheus registry in src/metrics/registry.ts.
Instrumented the /api/reconciliation endpoint in app/api/reconciliation/route.ts to capture durations and increments based on response statuses (200, 400, 429, and 500).
Added focused unit tests in app/api/reconciliation/route.test.ts to mock and verify that the metrics are properly captured across all expected scenarios (success, bad request, rate limit, and internal error).
