### PR TITLE
Feature/streampay stream cooldown v7 10

### DIFF
--- a/app/api/reconciliation/route.test.ts
+++ b/app/api/reconciliation/route.test.ts
@@ -20,6 +20,7 @@ import {
   type RateLimitStore,
   type RateLimitResult,
 } from '@/app/lib/rate-limit-store';
+import { reconciliationCounter, reconciliationDuration } from '@/src/metrics/registry';
 
 // ── Logger mock ──────────────────────────────────────────────────────────────
 
@@ -32,6 +33,23 @@ jest.mock('@/app/lib/logger', () => ({
   },
   getCorrelationContext: jest.fn(),
 }));
+
+jest.mock('@/src/metrics/registry', () => {
+  const mockInc = jest.fn();
+  const mockLabels = jest.fn(() => ({ inc: mockInc }));
+  const mockEndTimer = jest.fn();
+  const mockStartTimer = jest.fn(() => mockEndTimer);
+
+  return {
+    reconciliationCounter: {
+      labels: mockLabels,
+      inc: mockInc, // Just in case it's called directly
+    },
+    reconciliationDuration: {
+      startTimer: mockStartTimer,
+    },
+  };
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -138,6 +156,42 @@ describe('GET /api/reconciliation – existing behaviour', () => {
   });
 });
 
+// ── Metrics tests ────────────────────────────────────────────────────────────
+
+describe('GET /api/reconciliation – metrics', () => {
+  it('records 200 status for successful requests', async () => {
+    await GET(makeRequest());
+    
+    expect(reconciliationDuration.startTimer).toHaveBeenCalled();
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('200');
+    // Start timer returns end timer function
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '200' });
+  });
+
+  it('records 400 status for invalid input', async () => {
+    await GET(makeRequest({ search: '?limit=invalid' }));
+    
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('400');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '400' });
+  });
+
+  it('records 500 status on unexpected errors', async () => {
+    // Force an error by mocking URL to throw
+    const originalURL = global.URL;
+    global.URL = jest.fn().mockImplementation(() => { throw new Error('Boom'); }) as any;
+    
+    await GET(makeRequest());
+    
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('500');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '500' });
+    
+    global.URL = originalURL;
+  });
+});
+
 // ── Rate-limit tests ─────────────────────────────────────────────────────────
 
 describe('GET /api/reconciliation – rate limiting', () => {
@@ -148,6 +202,9 @@ describe('GET /api/reconciliation – rate limiting', () => {
     const res = await GET(makeRequest());
 
     expect(res.status).toBe(429);
+    expect(reconciliationCounter.labels).toHaveBeenCalledWith('429');
+    const mockEndTimer = (reconciliationDuration.startTimer as jest.Mock).mock.results[0].value;
+    expect(mockEndTimer).toHaveBeenCalledWith({ status: '429' });
   });
 
   it('429 response has Retry-After header', async () => {

--- a/app/api/reconciliation/route.ts
+++ b/app/api/reconciliation/route.ts
@@ -3,6 +3,8 @@ import crypto from 'crypto';
 import { getCorrelationContext, logger } from '@/app/lib/logger';
 import { withStrongEtag } from '@/src/middleware/etag';
 import { applyRateLimit } from '@/src/middleware/rateLimit';
+import { reconciliationCounter, reconciliationDuration } from '@/src/metrics/registry';
+
 
 function errorResponse(code: string, message: string, status: number) {
   const requestId = getCorrelationContext()?.request_id ?? `req-${crypto.randomUUID()}`;
@@ -10,11 +12,17 @@ function errorResponse(code: string, message: string, status: number) {
 }
 
 export async function GET(request: Request) {
+  const endTimer = reconciliationDuration.startTimer();
+
   // ── Per-user rate limit ─────────────────────────────────────────────────
   // Identity resolution priority: API key > JWT wallet sub > IP address.
   // Returns 429 with Retry-After when the caller's bucket is exhausted.
   const rateLimited = await applyRateLimit(request, 'reconciliation');
-  if (rateLimited) return rateLimited;
+  if (rateLimited) {
+    reconciliationCounter.labels('429').inc();
+    endTimer({ status: '429' });
+    return rateLimited;
+  }
 
   // ── Request handling ────────────────────────────────────────────────────
   try {
@@ -26,6 +34,8 @@ export async function GET(request: Request) {
       limit = parseInt(limitParam, 10);
       if (Number.isNaN(limit) || limit < 1 || limit > 1000) {
         logger.warn('Invalid limit parameter provided', { limit: limitParam });
+        reconciliationCounter.labels('400').inc();
+        endTimer({ status: '400' });
         return errorResponse('INVALID_INPUT', 'Limit must be an integer between 1 and 1000', 400);
       }
     }
@@ -45,9 +55,13 @@ export async function GET(request: Request) {
       },
     };
 
+    reconciliationCounter.labels('200').inc();
+    endTimer({ status: '200' });
     return withStrongEtag(request, responsePayload);
   } catch (error: any) {
     logger.error('Unexpected error in reconciliation route', { error: error.message });
+    reconciliationCounter.labels('500').inc();
+    endTimer({ status: '500' });
     return errorResponse('INTERNAL_SERVER_ERROR', 'An unexpected error occurred', 500);
   }
 }

--- a/contracts/contracts/streampay-stream/src/admin.rs
+++ b/contracts/contracts/streampay-stream/src/admin.rs
@@ -57,7 +57,17 @@ use crate::storage as store;
 pub enum AdminKey {
     /// Monotonic counter; value is the **next** nonce the admin must supply.
     AdminNonce,
+    /// Timestamp of the last successful admin action (for cooldown enforcement).
+    LastActionTime,
 }
+
+// ---------------------------------------------------------------------------
+// Cooldown constant
+// ---------------------------------------------------------------------------
+
+/// The minimum time (in seconds) that must elapse between admin actions.
+/// Used to enforce a rate limit on privileged overrides.
+pub const ADMIN_COOLDOWN_SECONDS: u64 = 86_400; // 24 hours
 
 // ---------------------------------------------------------------------------
 // TTL constants (mirrors instance-storage cadence from storage.rs)
@@ -123,6 +133,30 @@ pub fn consume_nonce(env: &Env, provided_nonce: u64) -> Result<(), Error> {
 }
 
 // ---------------------------------------------------------------------------
+// Cooldown validation
+// ---------------------------------------------------------------------------
+
+/// Validates that the cooldown period has elapsed since the last admin action.
+/// If valid, updates the last action time to the current ledger timestamp.
+///
+/// # Errors
+/// - [`Error::AdminCooldown`] if the time since the last action is less than the cooldown period.
+fn enforce_and_update_cooldown(env: &Env) -> Result<(), Error> {
+    let now = env.ledger().timestamp();
+    let last_action_time: Option<u64> = env.storage().instance().get(&AdminKey::LastActionTime);
+    
+    if let Some(last) = last_action_time {
+        if now < last.saturating_add(ADMIN_COOLDOWN_SECONDS) {
+            return Err(Error::AdminCooldown);
+        }
+    }
+    
+    env.storage().instance().set(&AdminKey::LastActionTime, &now);
+    // Instance TTL will be extended by `consume_nonce` immediately after this.
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Public entrypoint
 // ---------------------------------------------------------------------------
 
@@ -150,6 +184,7 @@ pub fn consume_nonce(env: &Env, provided_nonce: u64) -> Result<(), Error> {
 /// - [`Error::NotFound`] if the contract is not initialised or `stream_id`
 ///   does not exist.
 /// - [`Error::Unauthorized`] if `admin` is not the stored admin.
+/// - [`Error::AdminCooldown`] if the time since the last action is less than the cooldown period.
 /// - [`Error::NonceTooLow`] if `nonce` is stale (already consumed).
 /// - [`Error::NonceOutOfOrder`] if `nonce` skips ahead of the current counter.
 /// - [`Error::InvalidTimeRange`] if `new_end_time <= stream.start_time`.
@@ -181,7 +216,10 @@ pub fn admin_override(
         return Err(Error::Unauthorized);
     }
 
-    // (3) Nonce: consume the nonce *before* any state mutation.
+    // (3) Cooldown: enforce rate limiting on admin overrides.
+    enforce_and_update_cooldown(env)?;
+
+    // (4) Nonce: consume the nonce *before* any state mutation.
     //     This ensures that a failed subsequent mutation cannot be retried
     //     with the same nonce — the nonce is spent even on partial failure.
     consume_nonce(env, nonce)?;

--- a/contracts/contracts/streampay-stream/src/admin_nonce_test.rs
+++ b/contracts/contracts/streampay-stream/src/admin_nonce_test.rs
@@ -161,12 +161,63 @@ mod admin_nonce_tests {
 
         ctx.client()
             .admin_override(&ctx.admin, &0, &stream_id, &10_000);
+            
+        ctx.env.ledger().with_mut(|l| {
+            l.timestamp += admin::ADMIN_COOLDOWN_SECONDS;
+        });
+
         ctx.client()
             .admin_override(&ctx.admin, &1, &stream_id, &15_000);
+            
+        ctx.env.ledger().with_mut(|l| {
+            l.timestamp += admin::ADMIN_COOLDOWN_SECONDS;
+        });
+
         ctx.client()
             .admin_override(&ctx.admin, &2, &stream_id, &20_000);
 
         assert_eq!(ctx.client().get_admin_nonce(), 3);
+    }
+
+    #[test]
+    fn admin_override_cooldown_enforced() {
+        let ctx = Ctx::new();
+        let stream_id = ctx.insert_active_stream();
+
+        // First call succeeds
+        ctx.client()
+            .admin_override(&ctx.admin, &0, &stream_id, &10_000);
+
+        // Immediate second call should fail with AdminCooldown
+        let err = ctx
+            .client()
+            .try_admin_override(&ctx.admin, &1, &stream_id, &15_000)
+            .expect_err("cooldown must block rapid admin actions");
+
+        assert_eq!(err, Ok(Error::AdminCooldown));
+
+        // Advance time just before the cooldown expires, should still fail
+        ctx.env.ledger().with_mut(|l| {
+            l.timestamp += admin::ADMIN_COOLDOWN_SECONDS - 1;
+        });
+        
+        let err_almost = ctx
+            .client()
+            .try_admin_override(&ctx.admin, &1, &stream_id, &15_000)
+            .expect_err("cooldown must block until fully elapsed");
+            
+        assert_eq!(err_almost, Ok(Error::AdminCooldown));
+        
+        // Advance time past the cooldown
+        ctx.env.ledger().with_mut(|l| {
+            l.timestamp += 1;
+        });
+        
+        // Should succeed now
+        ctx.client()
+            .admin_override(&ctx.admin, &1, &stream_id, &15_000);
+            
+        assert_eq!(ctx.client().get_admin_nonce(), 2);
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/contracts/contracts/streampay-stream/src/error.rs
+++ b/contracts/contracts/streampay-stream/src/error.rs
@@ -62,4 +62,6 @@ pub enum Error {
     /// 20: Accumulated fee balance for a stream underflows or would produce an
     ///     invalid token transfer amount.  Guards against integer manipulation.
     SweepAmountMismatch = 20,
+    /// 21: Admin action is currently in cooldown.
+    AdminCooldown = 21,
 }

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -19,3 +19,18 @@ export const webhookDuration = new Histogram({
   buckets: [0.1, 0.5, 1, 2, 5],
   registers: [registry],
 });
+
+export const reconciliationCounter = new Counter({
+  name: 'api_reconciliation_requests_total',
+  help: 'Total number of /api/reconciliation requests received',
+  labelNames: ['status'],
+  registers: [registry],
+});
+
+export const reconciliationDuration = new Histogram({
+  name: 'api_reconciliation_request_duration_seconds',
+  help: 'Histogram of /api/reconciliation request processing duration in seconds',
+  labelNames: ['status'],
+  buckets: [0.1, 0.5, 1, 2, 5],
+  registers: [registry],
+});


### PR DESCRIPTION
Closes #1149 

This PR addresses the "GrantFox FWC26 campaign (Stellar Wave)" issue by introducing a mandatory cooldown between critical admin actions on the streampay-stream contract. This provides a cool-off window that prevents rapid sequential admin overrides without an appropriate delay.

Implementation Details
Cooldown Logic: Introduced a new LastActionTime state inside AdminKey in contracts/contracts/streampay-stream/src/admin.rs.
Duration: Defined a new constant ADMIN_COOLDOWN_SECONDS set to 86,400 (24 hours) for the wait period between successful admin actions.
Enforcement: Implemented enforce_and_update_cooldown to validate the required wait duration using env.ledger().timestamp().
Admin Override Protection: Protected the admin_override entrypoint with the cooldown check, enforcing the rate limit strictly before nonce consumption and any state mutations.
Error Types: Added the AdminCooldown = 21 discriminant to the Error enum inside contracts/contracts/streampay-stream/src/error.rs
