### PR TITLE
fix: CreateStreamForm tokens

### DIFF
--- a/app/CreateStreamForm.test.tsx
+++ b/app/CreateStreamForm.test.tsx
@@ -352,3 +352,192 @@ describe("CreateStreamForm — general behaviour", () => {
     expect(screen.getByTestId("create-stream-form-wrapper")).toHaveClass("my-form");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// tokens-v7 — Design-token spacing & typography BEM class hooks
+//
+// jsdom does not load stylesheets, so we cannot assert computed style values.
+// Instead we assert that the DOM carries the BEM class names that the CSS
+// token rules hook into — the same pattern used for StreamRow design-tokens-v7.
+// This proves the CSS selectors will activate when the stylesheet loads in a
+// real browser.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CreateStreamForm — tokens-v7 (design-token BEM class hooks)", () => {
+  // ── Wrapper ─────────────────────────────────────────────────────────────
+
+  it("wrapper carries .create-stream-form scoping class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(screen.getByTestId("create-stream-form-wrapper")).toHaveClass(
+      "create-stream-form"
+    );
+  });
+
+  it("preserves a custom className alongside .create-stream-form", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} className="my-form" />);
+    const wrapper = screen.getByTestId("create-stream-form-wrapper");
+    expect(wrapper).toHaveClass("create-stream-form");
+    expect(wrapper).toHaveClass("my-form");
+  });
+
+  // ── Field chrome (.csf-field) ────────────────────────────────────────────
+
+  it("recipient input carries .csf-field class (tokens: padding, border-radius, font-size)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(screen.getByLabelText(/recipient address/i)).toHaveClass("csf-field");
+  });
+
+  it("amount input carries .csf-field class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(screen.getByLabelText(/amount/i)).toHaveClass("csf-field");
+  });
+
+  it("token select carries .csf-field class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(screen.getByLabelText(/token/i)).toHaveClass("csf-field");
+  });
+
+  it("cancel button carries .csf-field class (focus-ring scoping)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(screen.getByRole("button", { name: /cancel/i })).toHaveClass(
+      "csf-field"
+    );
+  });
+
+  it("submit button carries .csf-field class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    expect(
+      screen.getByRole("button", { name: /create stream/i })
+    ).toHaveClass("csf-field");
+  });
+
+  // ── Labels (.csf-label) ──────────────────────────────────────────────────
+
+  it("recipient label carries .csf-label class (tokens: font-size, color, margin)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const label = document.querySelector('label[for="csf-recipient"]');
+    expect(label).toHaveClass("csf-label");
+  });
+
+  it("amount label carries .csf-label class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const label = document.querySelector('label[for="csf-amount"]');
+    expect(label).toHaveClass("csf-label");
+  });
+
+  it("token label carries .csf-label class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const label = document.querySelector('label[for="csf-token"]');
+    expect(label).toHaveClass("csf-label");
+  });
+
+  // ── Label rows (.csf-label-row) ──────────────────────────────────────────
+
+  it("recipient label+KbdHint row carries .csf-label-row class (token: margin-bottom)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const recipientInput = screen.getByLabelText(/recipient address/i);
+    // The .csf-label-row is the sibling row immediately above the input
+    const labelRow = recipientInput.closest(".csf-field-group")?.querySelector(".csf-label-row");
+    expect(labelRow).not.toBeNull();
+    expect(labelRow).toHaveClass("csf-label-row");
+  });
+
+  it("amount label+KbdHint row carries .csf-label-row class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const amountInput = screen.getByLabelText(/amount/i);
+    const labelRow = amountInput.closest(".csf-field-group")?.querySelector(".csf-label-row");
+    expect(labelRow).not.toBeNull();
+    expect(labelRow).toHaveClass("csf-label-row");
+  });
+
+  // ── Hint text (.csf-hint) ────────────────────────────────────────────────
+
+  it("recipient hint paragraph carries .csf-hint class (tokens: font-size, margin)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const hint = document.querySelector("#csf-recipient-hint");
+    expect(hint).toHaveClass("csf-hint");
+  });
+
+  // ── Amount+Token grid (.csf-grid) ────────────────────────────────────────
+
+  it("amount+token section is wrapped in .csf-grid (token: gap, grid-template-columns)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const amountInput = screen.getByLabelText(/amount/i);
+    // The .csf-grid is the nearest ancestor with that class
+    const grid = amountInput.closest(".csf-grid");
+    expect(grid).not.toBeNull();
+    expect(grid).toHaveClass("csf-grid");
+  });
+
+  it("token select shares the same .csf-grid as amount input", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const amountGrid = screen.getByLabelText(/amount/i).closest(".csf-grid");
+    const tokenGrid = screen.getByLabelText(/token/i).closest(".csf-grid");
+    expect(amountGrid).toBe(tokenGrid);
+  });
+
+  // ── Action row (.csf-actions) ────────────────────────────────────────────
+
+  it("action row carries .csf-actions class (tokens: gap, justify-content)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const cancelBtn = screen.getByRole("button", { name: /cancel/i });
+    const actionsRow = cancelBtn.closest(".csf-actions");
+    expect(actionsRow).not.toBeNull();
+    expect(actionsRow).toHaveClass("csf-actions");
+  });
+
+  it("both cancel and submit buttons are inside the same .csf-actions row", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const cancelRow = screen
+      .getByRole("button", { name: /cancel/i })
+      .closest(".csf-actions");
+    const submitRow = screen
+      .getByRole("button", { name: /create stream/i })
+      .closest(".csf-actions");
+    expect(cancelRow).toBe(submitRow);
+  });
+
+  // ── Skeleton BEM hooks ───────────────────────────────────────────────────
+
+  it("skeleton wrapper carries .csf-skeleton class (token: gap, flex-direction)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} isLoading />);
+    expect(screen.getByTestId("create-stream-skeleton")).toHaveClass(
+      "csf-skeleton"
+    );
+  });
+
+  it("skeleton grid carries .csf-skeleton__grid class (token: gap, grid-template-columns)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} isLoading />);
+    const skeletonGrid = document.querySelector(".csf-skeleton__grid");
+    expect(skeletonGrid).not.toBeNull();
+  });
+
+  it("skeleton action row carries .csf-skeleton__actions class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} isLoading />);
+    const actionsRow = document.querySelector(".csf-skeleton__actions");
+    expect(actionsRow).not.toBeNull();
+  });
+
+  it("skeleton field groups carry .csf-skeleton__field class", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} isLoading />);
+    const fieldGroups = document.querySelectorAll(".csf-skeleton__field");
+    // Recipient + Amount + Token = at least 3 skeleton field groups
+    expect(fieldGroups.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── No raw inline spacing (regression guard) ─────────────────────────────
+
+  it("form element does not carry inline gap style (should use .csf- classes)", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} />);
+    const form = document.querySelector("form[data-form='create-stream']");
+    expect(form).not.toBeNull();
+    // Inline style with a raw gap value would be a regression
+    expect(form?.getAttribute("style") ?? "").not.toMatch(/gap:\s*[0-9]/);
+  });
+
+  it("skeleton wrapper does not carry inline gap style", () => {
+    render(<CreateStreamForm onSubmit={resolvedSubmit()} isLoading />);
+    const skel = screen.getByTestId("create-stream-skeleton");
+    expect(skel.getAttribute("style") ?? "").not.toMatch(/gap:\s*[0-9]/);
+  });
+});

--- a/app/CreateStreamForm.tsx
+++ b/app/CreateStreamForm.tsx
@@ -23,9 +23,17 @@
  *   A `<LiveRegion>` announces status changes (submitting, success, error)
  *   so screen-reader users receive feedback without visual focus shifts.
  *
+ * ### tokens-v7 — Design-token spacing & typography
+ *   All spacing, typography, and border-radius values now reference global
+ *   CSS custom properties (see `app/globals.css`, `.create-stream-form`
+ *   rule block). Inline `React.CSSProperties` objects have been replaced
+ *   with BEM-style class names so updates to the design token scale
+ *   propagate automatically across dark, light, and high-contrast themes.
+ *
  * ## Accessibility (WCAG 2.1 AA)
  * - All form controls have associated `<label>` elements.
- * - Focus-visible ring is inherited from `globals.css` (`@layer focus`).
+ * - Focus-visible ring is provided by `app/styles/focus.css` (`@layer focus`)
+ *   via the `.csf-field` class; inline `border` no longer overrides it.
  * - Keyboard shortcuts do not override browser or OS reserved combos.
  * - Skeleton is marked `aria-hidden` and includes an `aria-busy` attribute
  *   on the parent so ATs know content is loading.
@@ -66,25 +74,6 @@ export interface CreateStreamFormProps {
   className?: string;
 }
 
-// ── Shared styles ─────────────────────────────────────────────────────────────
-
-const fieldStyle: React.CSSProperties = {
-  width: "100%",
-  background: "var(--panel)",
-  border: "1px solid var(--border)",
-  color: "var(--foreground)",
-  padding: "0.75rem",
-  borderRadius: "var(--radius-md, 0.5rem)",
-  fontSize: "var(--text-base, 1rem)",
-};
-
-const labelStyle: React.CSSProperties = {
-  display: "block",
-  fontSize: "var(--text-sm, 0.875rem)",
-  marginBottom: "0.5rem",
-  color: "var(--muted-light, #a1a1aa)",
-};
-
 // ── Skeleton layout ───────────────────────────────────────────────────────────
 
 /**
@@ -92,34 +81,36 @@ const labelStyle: React.CSSProperties = {
  * from loading→loaded is as jump-free as possible.
  *
  * All skeleton elements are `aria-hidden`; the parent carries `aria-busy`.
+ * Spacing uses `.csf-skeleton` and `.csf-skeleton__*` classes that reference
+ * `--space-*` tokens (see `app/globals.css`).
  */
 function FormSkeleton() {
   return (
     <div
       aria-hidden="true"
-      style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
+      className="csf-skeleton"
       data-testid="create-stream-skeleton"
     >
       {/* Recipient field skeleton */}
-      <div>
-        <Skeleton variant="label" style={{ marginBottom: "0.5rem" } as React.CSSProperties} />
+      <div className="csf-skeleton__field">
+        <Skeleton variant="label" className="skeleton--label" />
         <Skeleton variant="text" width="100%" height="2.75rem" />
       </div>
 
       {/* Amount + Token grid skeleton */}
-      <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: "1rem" }}>
-        <div>
-          <Skeleton variant="label" style={{ marginBottom: "0.5rem" } as React.CSSProperties} />
+      <div className="csf-skeleton__grid">
+        <div className="csf-skeleton__field">
+          <Skeleton variant="label" className="skeleton--label" />
           <Skeleton variant="text" width="100%" height="2.75rem" />
         </div>
-        <div>
-          <Skeleton variant="label" style={{ marginBottom: "0.5rem" } as React.CSSProperties} />
+        <div className="csf-skeleton__field">
+          <Skeleton variant="label" className="skeleton--label" />
           <Skeleton variant="badge" width="100%" height="2.75rem" />
         </div>
       </div>
 
       {/* Action buttons skeleton */}
-      <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem" }}>
+      <div className="csf-skeleton__actions">
         <Skeleton variant="button" />
         <Skeleton variant="button" />
       </div>
@@ -225,7 +216,16 @@ export function CreateStreamForm({
   // ── Render form ────────────────────────────────────────────────────────────
 
   return (
-    <div className={className} data-testid="create-stream-form-wrapper">
+    /*
+     * .create-stream-form — scoping root for all CSS token rules.
+     * Spacing, typography, and border-radius are applied via class names
+     * defined in app/globals.css (.csf-*) rather than inline styles, so
+     * the design token scale propagates automatically to all themes.
+     */
+    <div
+      className={`create-stream-form${className ? ` ${className}` : ""}`}
+      data-testid="create-stream-form-wrapper"
+    >
       {/* Screen reader live region — announces state changes */}
       <LiveRegion
         message={announcement}
@@ -236,13 +236,13 @@ export function CreateStreamForm({
       <form
         data-form="create-stream"
         onSubmit={handleSubmit}
-        style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
         noValidate
       >
         {/* ── Recipient ─────────────────────────────────────────────── */}
-        <div>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
-            <label htmlFor="csf-recipient" style={labelStyle}>
+        <div className="csf-field-group">
+          {/* Label row: label + Alt+R KbdHint side by side */}
+          <div className="csf-label-row">
+            <label htmlFor="csf-recipient" className="csf-label">
               Recipient address
             </label>
             {/* Keyboard shortcut hint: Alt+R focuses this field */}
@@ -262,22 +262,24 @@ export function CreateStreamForm({
             placeholder="GABC…"
             autoComplete="off"
             spellCheck={false}
-            style={fieldStyle}
+            className="csf-field"
             aria-describedby="csf-recipient-hint"
           />
-          <p
-            id="csf-recipient-hint"
-            style={{ margin: "0.25rem 0 0", fontSize: "var(--text-xs, 0.75rem)", color: "var(--muted, #71717a)" }}
-          >
+          <p id="csf-recipient-hint" className="csf-hint">
             Stellar address of the stream recipient.
           </p>
         </div>
 
         {/* ── Amount + Token ─────────────────────────────────────────── */}
-        <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: "1rem" }}>
-          <div>
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
-              <label htmlFor="csf-amount" style={labelStyle}>
+        {/*
+         * .csf-grid → `display: grid; grid-template-columns: 2fr 1fr;
+         *              gap: var(--space-4)`  (see globals.css)
+         */}
+        <div className="csf-grid">
+          <div className="csf-field-group">
+            {/* Label row: label + Alt+A KbdHint side by side */}
+            <div className="csf-label-row">
+              <label htmlFor="csf-amount" className="csf-label">
                 Amount
               </label>
               {/* Keyboard shortcut hint: Alt+A focuses this field */}
@@ -297,18 +299,18 @@ export function CreateStreamForm({
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               placeholder="100"
-              style={fieldStyle}
+              className="csf-field"
             />
           </div>
-          <div>
-            <label htmlFor="csf-token" style={{ ...labelStyle, marginBottom: "0.5rem" }}>
+          <div className="csf-field-group">
+            <label htmlFor="csf-token" className="csf-label">
               Token
             </label>
             <select
               id="csf-token"
               value={token}
               onChange={(e) => setToken(e.target.value as StreamToken)}
-              style={fieldStyle}
+              className="csf-field"
             >
               <option value="XLM">XLM</option>
               <option value="USDC">USDC</option>
@@ -317,11 +319,15 @@ export function CreateStreamForm({
         </div>
 
         {/* ── Actions ────────────────────────────────────────────────── */}
-        <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: "1rem" }}>
+        {/*
+         * .csf-actions → `display: flex; justify-content: flex-end;
+         *                 align-items: center; gap: var(--space-4)`
+         */}
+        <div className="csf-actions">
           {/* Cancel button with Esc hint */}
           <button
             type="button"
-            className="button button--secondary"
+            className="button button--secondary csf-field"
             onClick={handleCancel}
             aria-label="Cancel stream creation"
           >
@@ -337,7 +343,7 @@ export function CreateStreamForm({
           {/* Submit button with Ctrl+Enter hint */}
           <button
             type="submit"
-            className={`button button--primary${isSubmitting ? " button--busy" : ""}`}
+            className={`button button--primary csf-field${isSubmitting ? " button--busy" : ""}`}
             disabled={isSubmitting}
             aria-label={isSubmitting ? "Creating stream, please wait" : "Create stream"}
           >

--- a/app/globals.css
+++ b/app/globals.css
@@ -120,6 +120,12 @@
   --space-6: 1.5rem;    /* 24px */
   --space-8: 2rem;      /* 32px */
 
+  /* ── Border Radius Scale ── */
+  --radius-sm: 4px;       /* small chips, badges */
+  --radius-md: 0.5rem;    /* 8px — form fields, cards (CreateStreamForm) */
+  --radius-full: 9999px;  /* pill buttons, progress bars */
+  --radius-xl: 1.25rem;   /* 20px — large cards (StreamRow) */
+
   /* ── Typography Scale ── */
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
@@ -1034,6 +1040,124 @@ a:hover {
   text-decoration: underline;
   text-underline-offset: 2px;
   text-transform: uppercase;
+}
+
+/* ─── CreateStreamForm — design tokens v7 ────────────────────────────────
+ *
+ * All spacing, typography, and radius values use design tokens from :root.
+ * Inline styles in CreateStreamForm.tsx have been replaced with these classes
+ * so that future token updates propagate automatically across themes (dark,
+ * light, high-contrast) without touching the component source.
+ *
+ * BEM-style naming mirrors the .stream-row pattern:
+ *   .create-stream-form         — wrapper
+ *   .csf-field-group            — a label + input pair
+ *   .csf-label-row              — flex row holding label + KbdHint
+ *   .csf-label                  — <label> element
+ *   .csf-field                  — <input> / <select> element (also in focus.css)
+ *   .csf-hint                   — helper text beneath a field
+ *   .csf-grid                   — 2-col amount/token grid
+ *   .csf-actions                — flex row for Cancel + Submit buttons
+ *   .csf-skeleton               — skeleton wrapper
+ *   .csf-skeleton__field        — individual skeleton field group
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.create-stream-form {
+  /* no extra styles needed on the wrapper; className is used as scoping hook */
+}
+
+/* Top-level form: vertical stack with token gap */
+.create-stream-form form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+/* Label + KbdHint row */
+.csf-label-row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+/* <label> typography */
+.csf-label {
+  color: var(--muted-light, #a1a1aa);
+  display: block;
+  font-size: var(--text-sm);
+  /* margin-bottom is applied by .csf-label-row when used inside the flex row,
+     or directly on the element when used standalone */
+  margin-bottom: var(--space-2);
+}
+
+/* Standalone label (not inside a flex row) — no extra margin needed
+   when the wrapper already provides it */
+.csf-label-row .csf-label {
+  margin-bottom: 0;
+}
+
+/* <input> and <select> — field chrome */
+.csf-field {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--foreground);
+  font-size: var(--text-base);
+  padding: var(--space-3);
+  width: 100%;
+}
+
+/* Helper / hint text beneath a field */
+.csf-hint {
+  color: var(--muted, #71717a);
+  font-size: var(--text-xs);
+  margin: var(--space-1) 0 0;
+}
+
+/* Amount + Token two-column grid */
+.csf-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 2fr 1fr;
+}
+
+/* Action button row */
+.csf-actions {
+  align-items: center;
+  display: flex;
+  gap: var(--space-4);
+  justify-content: flex-end;
+}
+
+/* Skeleton layout — mirrors the real form structure so the
+   loading → loaded transition is jump-free */
+.csf-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.csf-skeleton__field {
+  /* Skelton items within a field group */
+}
+
+.csf-skeleton__field .skeleton--label {
+  margin-bottom: var(--space-2);
+}
+
+/* Skeleton grid (amount + token) */
+.csf-skeleton__grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 2fr 1fr;
+}
+
+/* Skeleton action row */
+.csf-skeleton__actions {
+  display: flex;
+  gap: var(--space-4);
+  justify-content: flex-end;
 }
 
 /* ─── Density Toggle ─────────────────────────────────────────────────────── */


### PR DESCRIPTION
Pin all spacing, typography, and border-radius values to CSS design tokens in CreateStreamForm (issue #1040, GrantFox FWC26 — tokens-v7).

## What changed

### app/globals.css
- Add --radius-sm/md/full/xl border-radius token declarations to :root (--radius-md was previously referenced with a raw fallback but never declared)
- Add .create-stream-form / .csf-* CSS rule block (before Density Toggle) using --space-* and --text-* tokens for all spacing and typography values

### app/CreateStreamForm.tsx
- Remove inline fieldStyle and labelStyle CSSProperties objects
- Replace all inline style props with BEM class names: .create-stream-form  — scoping wrapper
    .csf-field-group     — label + input pair
    .csf-label-row       — flex row (label + KbdHint)
    .csf-label           — <label> typography
    .csf-field           — <input>/<select>/<button> chrome
    .csf-hint            — helper text beneath a field
    .csf-grid            — 2-col amount/token grid
    .csf-actions         — flex row for action buttons
    .csf-skeleton        — skeleton wrapper
    .csf-skeleton__*     — skeleton field/grid/actions groups
- Add tokens-v7 section to JSDoc

### app/CreateStreamForm.test.tsx
- Add describe('tokens-v7') with 23 tests asserting BEM class presence (wrapper, fields, labels, label rows, hint, grid, actions, skeleton, regression guard for no raw inline gap styles)

## Test results
- CreateStreamForm.test.tsx: 53/53 pass (30 existing + 23 new)
- Lint: 0 errors (1 pre-existing warning in unrelated file)
- Broader suite failures (60 suites) are all pre-existing on main

## Security Changes

### Type of Security Change
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update
- [ ] Other: _______________

### Vulnerability Details (if applicable)

**CVE/Advisory ID:** 
- CVE-ID: 
- GHSA-ID: 

**Affected Package:**
- Name: 
- Version: 
- Severity: [ ] Critical [ ] High [ ] Medium [ ] Low

**Fix Applied:**
- [ ] Package version bump
- [ ] Code change to mitigate
- [ ] Configuration update
- [ ] Exemption granted (see below)

### Exemption Request (if applicable)

**Exemption ID:** EXEMPT-___

**Justification:**
<!-- Detailed reason why this vulnerability can be temporarily exempted -->

**Mitigation Applied:**
<!-- What compensating controls or workarounds are in place -->

**Expiry Date:** YYYY-MM-DD (max 90 days from now)

**Review Plan:**
<!-- How and when this will be re-evaluated -->

### Testing

- [ ] Ran `npm audit` locally - output attached or no new vulnerabilities
- [ ] Security workflow passes on this branch
- [ ] Test suite passes: `npm test`
- [ ] Build succeeds: `npm run build`

### Security Impact Analysis

**Affected Components:**
- [ ] Authentication/Authorization
- [ ] Payment processing
- [ ] Data encryption
- [ ] API endpoints
- [ ] Dependencies
- [ ] Container images
- [ ] CI/CD pipeline
- [ ] Other: _______________

**Risk Assessment:**
<!-- Describe any potential security risks introduced or mitigated by this change -->

### Documentation Updates

- [ ] Updated README.md (if workflow changed)
- [ ] Updated SECURITY-CI-SETUP.md (if process changed)
- [ ] Updated security-exemptions.json (if applicable)
- [ ] Added security notes to code comments

### Checklist

- [ ] No secrets or keys committed
- [ ] No PII or sensitive data in logs
- [ ] All security scans pass (or exemptions documented)
- [ ] Branch protection requirements met
- [ ] Code review from security team (for critical changes)

### Additional Notes

<!-- Any additional context, links to advisories, or relevant discussions -->

### Test Output

```
# Paste npm test output here
npm test

# Paste npm audit output here (if relevant)
npm audit
```

### CI Run Link

<!-- Link to passing GitHub Actions run -->
Workflow Run: 

---

**Security Review Required:** @security-team
**Compliance Impact:** [Yes/No - explain if yes]


closes #1040