### PR TITLE
feat: ETag on /api/webhooks

### DIFF
--- a/app/api/webhooks/route.test.ts
+++ b/app/api/webhooks/route.test.ts
@@ -7,6 +7,10 @@ jest.mock("@/app/lib/logger", () => ({
   },
 }));
 
+jest.mock("@/src/middleware/rateLimit", () => ({
+  applyRateLimit: jest.fn(async () => null),
+}));
+
 function makeRequest(body: unknown, shouldThrow = false) {
   return {
     json: async () => {

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -2,21 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { registry, webhookCounter, webhookDuration } from "@/src/metrics/registry";
 import { logger } from "@/app/lib/logger";
 import { webhookPayloadSchema } from "@/src/validators/webhooks";
+import { applyRateLimit } from "@/src/middleware/rateLimit";
+import { withStrongEtagBody } from "@/src/middleware/etag";
 
 // Prometheus metrics endpoint
 export async function GET(request: Request) {
   // Per-user rate limit — identity: API key > JWT wallet sub > IP.
-  const rateLimited = await applyRateLimit(request, 'webhooks', 'GET');
+  const rateLimited = await applyRateLimit(request, "webhooks", "GET");
   if (rateLimited) return rateLimited;
 
   try {
     const metrics = await registry.metrics();
-    return new NextResponse(metrics, {
-      status: 200,
-      headers: {
-        "Content-Type": registry.contentType,
-      },
-    });
+    // Strong ETag / 304 for conditional scrapes (Issue #1110)
+    return withStrongEtagBody(request, metrics, registry.contentType);
   } catch (error) {
     logger.error("Failed to generate metrics", { error });
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
@@ -27,7 +25,7 @@ export async function GET(request: Request) {
 export async function POST(req: NextRequest) {
   // Per-user rate limit before body parse / processing so exhausted callers
   // cannot spend CPU on validation or metrics work.
-  const rateLimited = await applyRateLimit(req, 'webhooks', 'POST');
+  const rateLimited = await applyRateLimit(req, "webhooks", "POST");
   if (rateLimited) return rateLimited;
 
   const start = process.hrtime();

--- a/app/api/webhooks/webhooks.etag.test.ts
+++ b/app/api/webhooks/webhooks.etag.test.ts
@@ -1,0 +1,129 @@
+/** @jest-environment node */
+
+import { GET } from "@/app/api/webhooks/route";
+import { registry } from "@/src/metrics/registry";
+import { createStrongEtagFromBody } from "@/src/middleware/etag";
+import {
+  setRateLimitStore,
+  resetRateLimitStore,
+  type RateLimitStore,
+  type RateLimitResult,
+} from "@/app/lib/rate-limit-store";
+
+jest.mock("@/app/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  getCorrelationContext: jest.fn(() => ({ request_id: "test-req-id" })),
+}));
+
+function makeAllowAllStore(): RateLimitStore {
+  return {
+    async check(
+      _identifier: string,
+      _limit: number,
+      _windowMs: number,
+    ): Promise<RateLimitResult> {
+      return {
+        allowed: true,
+        remaining: 999,
+        resetAt: Math.floor(Date.now() / 1000) + 60,
+      };
+    },
+  };
+}
+
+function makeGetRequest(extraHeaders: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/webhooks", {
+    method: "GET",
+    headers: new Headers(extraHeaders),
+  });
+}
+
+describe("GET /api/webhooks ETag handling (Issue #1110)", () => {
+  const stableMetrics =
+    '# HELP webhook_requests_total Total webhook requests\n' +
+    '# TYPE webhook_requests_total counter\n' +
+    'webhook_requests_total{status="200",event_type="demo"} 1\n';
+
+  let metricsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setRateLimitStore(makeAllowAllStore());
+    // Default Node collectors (CPU/memory) change between scrapes; pin the
+    // exposition body so ETag assertions are deterministic.
+    metricsSpy = jest.spyOn(registry, "metrics").mockResolvedValue(stableMetrics);
+  });
+
+  afterEach(() => {
+    metricsSpy.mockRestore();
+    resetRateLimitStore();
+  });
+
+  it("returns 200 with a strong ETag and cache-control on the first scrape", async () => {
+    const res = await GET(makeGetRequest());
+
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("etag");
+    expect(etag).toBe(createStrongEtagFromBody(stableMetrics));
+    expect(etag).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+
+    await expect(res.text()).resolves.toBe(stableMetrics);
+  });
+
+  it("returns 304 Not Modified when If-None-Match matches the current ETag", async () => {
+    const initialRes = await GET(makeGetRequest());
+    const etag = initialRes.headers.get("etag")!;
+    expect(etag).toBeTruthy();
+
+    const cachedRes = await GET(makeGetRequest({ "If-None-Match": etag }));
+
+    expect(cachedRes.status).toBe(304);
+    expect(cachedRes.headers.get("etag")).toBe(etag);
+    expect(cachedRes.headers.get("cache-control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    await expect(cachedRes.text()).resolves.toBe("");
+  });
+
+  it("returns 200 with a new ETag when metrics contents change", async () => {
+    const firstRes = await GET(makeGetRequest());
+    const firstEtag = firstRes.headers.get("etag")!;
+
+    const updatedMetrics = stableMetrics + 'webhook_requests_total{status="500",event_type="demo"} 2\n';
+    metricsSpy.mockResolvedValue(updatedMetrics);
+
+    const secondRes = await GET(makeGetRequest({ "If-None-Match": firstEtag }));
+
+    expect(secondRes.status).toBe(200);
+    const secondEtag = secondRes.headers.get("etag");
+    expect(secondEtag).toBe(createStrongEtagFromBody(updatedMetrics));
+    expect(secondEtag).not.toBe(firstEtag);
+    expect(secondRes.headers.get("Content-Type")).toContain("text/plain");
+    await expect(secondRes.text()).resolves.toBe(updatedMetrics);
+  });
+
+  it("returns 304 for wildcard If-None-Match when a representation exists", async () => {
+    const res = await GET(makeGetRequest({ "If-None-Match": "*" }));
+
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe(createStrongEtagFromBody(stableMetrics));
+    await expect(res.text()).resolves.toBe("");
+  });
+
+  it("returns 304 when If-None-Match list contains the matching ETag", async () => {
+    const etag = createStrongEtagFromBody(stableMetrics);
+    const res = await GET(
+      makeGetRequest({ "If-None-Match": `"other-tag", ${etag}` }),
+    );
+
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe(etag);
+  });
+});

--- a/docs/api/webhooks-etag.md
+++ b/docs/api/webhooks-etag.md
@@ -1,0 +1,31 @@
+# GET /api/webhooks — ETag / 304 (v7)
+
+**Issue:** [#1110](https://github.com/Streampay-Org/StreamPay-Frontend/issues/1110) Add ETag/304 on /api/webhooks (v7)  
+**Campaign:** GrantFox FWC26 Campaign (Stellar Wave)  
+
+---
+
+## Overview
+
+`GET /api/webhooks` (Prometheus metrics scrape) now emits a **strong ETag** (SHA-256 of the exact metrics body bytes) and honours conditional requests via `If-None-Match`.
+
+## Behaviour
+
+| Request | Response |
+| ------- | -------- |
+| First `GET` | `200` + Prometheus text body + `ETag: "<64-hex>"` + `Cache-Control: public, max-age=0, must-revalidate` |
+| `If-None-Match` matches current ETag | `304 Not Modified` (empty body, same ETag / Cache-Control) |
+| Metrics contents change | `200` with a new ETag |
+
+Implementation uses `withStrongEtagBody` from `src/middleware/etag.ts` so the Prometheus `Content-Type` is preserved (unlike the JSON-oriented `withStrongEtag` helper).
+
+## Visible / API changes
+
+- Response headers on successful scrape: `etag`, `cache-control`
+- Rate limits, metrics body shape, and `Content-Type` are unchanged
+
+## Verification
+
+```bash
+npx jest app/api/webhooks/webhooks.etag.test.ts app/api/webhooks/route.test.ts src/middleware/etag.test.ts --no-coverage
+```

--- a/src/middleware/etag.test.ts
+++ b/src/middleware/etag.test.ts
@@ -1,4 +1,4 @@
-import { withStrongEtag } from './etag';
+import { withStrongEtag, withStrongEtagBody, createStrongEtagFromBody } from './etag';
 
 describe('withStrongEtag', () => {
   it('generates a strong ETag and returns 200 on initial request', () => {
@@ -38,5 +38,57 @@ describe('withStrongEtag', () => {
     const response = withStrongEtag(request, data);
     expect(response.status).toBe(200);
     expect(response.headers.get('etag')).toMatch(/^"[a-f0-9]{64}"$/);
+  });
+});
+
+describe('withStrongEtagBody', () => {
+  const contentType = 'text/plain; version=0.0.4; charset=utf-8';
+  const body = '# HELP demo Demo metric\ndemo 1\n';
+
+  it('returns 200 with strong ETag, cache-control, and Content-Type', () => {
+    const request = new Request('http://localhost/api/webhooks');
+    const response = withStrongEtagBody(request, body, contentType);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('etag')).toBe(createStrongEtagFromBody(body));
+    expect(response.headers.get('etag')).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=0, must-revalidate');
+    expect(response.headers.get('Content-Type')).toBe(contentType);
+  });
+
+  it('returns 304 when If-None-Match matches the body ETag', async () => {
+    const first = withStrongEtagBody(new Request('http://localhost/api/webhooks'), body, contentType);
+    const etag = first.headers.get('etag')!;
+
+    const cached = withStrongEtagBody(
+      new Request('http://localhost/api/webhooks', {
+        headers: new Headers({ 'If-None-Match': etag }),
+      }),
+      body,
+      contentType,
+    );
+
+    expect(cached.status).toBe(304);
+    expect(cached.headers.get('etag')).toBe(etag);
+    expect(cached.headers.get('cache-control')).toBe('public, max-age=0, must-revalidate');
+    await expect(cached.text()).resolves.toBe('');
+  });
+
+  it('returns 200 with a new ETag when the body changes', () => {
+    const first = withStrongEtagBody(new Request('http://localhost/api/webhooks'), body, contentType);
+    const firstEtag = first.headers.get('etag')!;
+
+    const updatedBody = body + 'demo 2\n';
+    const second = withStrongEtagBody(
+      new Request('http://localhost/api/webhooks', {
+        headers: new Headers({ 'If-None-Match': firstEtag }),
+      }),
+      updatedBody,
+      contentType,
+    );
+
+    expect(second.status).toBe(200);
+    expect(second.headers.get('etag')).not.toBe(firstEtag);
+    expect(second.headers.get('Content-Type')).toBe(contentType);
   });
 });

--- a/src/middleware/etag.ts
+++ b/src/middleware/etag.ts
@@ -24,6 +24,15 @@ export function createStrongEtag(value: unknown): string {
   return `"${hash}"`;
 }
 
+/**
+ * Strong ETag over the exact response body bytes (no JSON canonicalisation).
+ * Use for non-JSON representations such as Prometheus text exposition.
+ */
+export function createStrongEtagFromBody(body: string): string {
+  const hash = createHash("sha256").update(body).digest("hex");
+  return `"${hash}"`;
+}
+
 function normaliseEtagToken(token: string): string {
   return token.trim().replace(/^W\//i, "");
 }
@@ -75,5 +84,36 @@ export function withStrongEtag(request: Request, data: unknown): NextResponse {
   return NextResponse.json(data, {
     status: 200,
     headers: cacheHeaders,
+  });
+}
+
+/**
+ * Strong ETag / 304 helper for raw (non-JSON) response bodies.
+ *
+ * Hashes the exact body bytes so the validator remains strong for text
+ * representations such as Prometheus metrics from `GET /api/webhooks`.
+ */
+export function withStrongEtagBody(
+  request: Request,
+  body: string,
+  contentType: string,
+): NextResponse {
+  const etag = createStrongEtagFromBody(body);
+  const cacheHeaders = createCacheHeaders(etag);
+  const ifNoneMatch = request.headers?.get("if-none-match") ?? null;
+
+  if (isIfNoneMatchMatch(etag, ifNoneMatch)) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: cacheHeaders,
+    });
+  }
+
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      ...cacheHeaders,
+    },
   });
 }


### PR DESCRIPTION
## Overview

This PR adds **strong ETag validators** and `304 Not Modified` support on `GET /api/webhooks` (Prometheus metrics scrape), reusing and extending `src/middleware/etag.ts` with a raw-body helper so the Prometheus `Content-Type` is preserved.

## Related Issue

Closes #1110

## Changes

### ⚡ ETag / 304 on webhooks metrics scrape

* **[MODIFY]** `app/api/webhooks/route.ts`
  * `GET` returns strong ETag + Cache-Control via `withStrongEtagBody`
  * Honours `If-None-Match` → 304
  * Restores missing `applyRateLimit` import (broken on main after an earlier merge)

* **[MODIFY]** `src/middleware/etag.ts`
  * Adds `createStrongEtagFromBody` / `withStrongEtagBody` for non-JSON representations

* **[ADD]** `app/api/webhooks/webhooks.etag.test.ts`
* **[MODIFY]** `app/api/webhooks/route.test.ts` / `src/middleware/etag.test.ts`
* **[ADD]** `docs/api/webhooks-etag.md`

## Verification Results

```
npm run test -- --testPathPattern='webhooks.etag|middleware/etag\.test|webhooks/route\.test|exports.etag' --no-coverage
✅ webhooks.etag / etag middleware / webhooks route / exports.etag — all passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Strong ETag on /api/webhooks | ✅ SHA-256 strong validator over metrics body bytes |
| 304 when If-None-Match matches | ✅ covered by tests (exact tag, list, and `*`) |
| Docs updated | ✅ `docs/api/webhooks-etag.md` |
| Tests added and passing | ✅ focused + regression green |